### PR TITLE
[MRG] Adding compact kwarg to connectivity for backwards compatibility

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,6 +19,12 @@ Here we list a changelog of MNE-connectivity.
 Current
 -------
 
+In this version, we return the relevant Connectivity class from each of the
+connectivity estimation functions. These internally use ``xarray`` to represent
+the connectivity data. One can easily get the v0.1 numpy array by doing
+``conn.get_data()``, which will get exactly the same output as one got in v0.1
+running any of the connectivity functions.
+
 Changelog
 ~~~~~~~~~
 

--- a/mne_connectivity/base.py
+++ b/mne_connectivity/base.py
@@ -504,7 +504,7 @@ class _Connectivity(DynamicMixin):
         size += object_size(self.attrs)
         return size
 
-    def get_data(self, output='raveled'):
+    def get_data(self, output='compact'):
         """Get connectivity data as a numpy array.
 
         Parameters
@@ -513,16 +513,22 @@ class _Connectivity(DynamicMixin):
             How to format the output, by default 'raveled', which
             will represent each connectivity matrix as a
             ``(n_nodes_in * n_nodes_out,)`` list. If 'dense', then
-            will return each connectivity matrix as a 2D array.
-        squeeze : bool, optional
-            Whether to squeeze the array or not, by default True.
+            will return each connectivity matrix as a 2D array. If 'compact'
+            (default) then will return 'raveled' if ``indices`` were defined as
+            a list of tuples, or ``dense`` if indices is 'all'.
 
         Returns
         -------
         data : np.ndarray
             The output connectivity data.
         """
-        _check_option('output', output, ['raveled', 'dense'])
+        _check_option('output', output, ['raveled', 'dense', 'compact'])
+
+        if output == 'compact':
+            if self.indices in ['all', 'symmetric']:
+                output = 'dense'
+            else:
+                output = 'raveled'
 
         if output == 'raveled':
             data = self._data

--- a/mne_connectivity/tests/test_connectivity.py
+++ b/mne_connectivity/tests/test_connectivity.py
@@ -100,7 +100,7 @@ def test_connectivity_containers(conn_cls):
         conn.get_data(output='blah')
 
     assert conn.shape == tuple(correct_numpy_shape)
-    assert conn.get_data().shape == tuple(correct_numpy_shape)
+    assert conn.get_data(output='raveled').shape == tuple(correct_numpy_shape)
     assert conn.get_data(output='dense').ndim == len(correct_numpy_shape) + 1
 
     # test renaming nodes error checks
@@ -158,7 +158,8 @@ def test_connectivity_containers(conn_cls):
     assert symm_conn.n_nodes == n_nodes
 
     # raveled shape should be the same
-    assert_array_equal(symm_conn.get_data().shape, correct_numpy_shape)
+    assert_array_equal(symm_conn.get_data(output='raveled').shape,
+                       correct_numpy_shape)
 
     # should be ([n_epochs], n_nodes, n_nodes, ...) dense shape
     dense_shape = []

--- a/mne_connectivity/tests/test_envelope.py
+++ b/mne_connectivity/tests/test_envelope.py
@@ -55,7 +55,7 @@ def test_envelope_correlation():
     # using complex data
     corr = envelope_correlation(data_hilbert)
     assert_allclose(
-        np.mean(corr.get_data(), axis=0).squeeze(),
+        np.mean(corr.get_data(output='raveled'), axis=0).squeeze(),
         corr_orig.flatten()[raveled_triu_inds])
 
     # do Hilbert internally, and don't combine


### PR DESCRIPTION
PR Description
--------------

Adds a default 'compact' option to the get_data() kwarg for backwards compatibility.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-connectivity/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
