### PR TITLE
envelope_correlation docstring fix + minor code style fixes

### DIFF
--- a/mne_connectivity/conftest.py
+++ b/mne_connectivity/conftest.py
@@ -21,6 +21,7 @@ def pytest_configure(config):
     error::
     ignore:.*`np.bool` is a deprecated alias.*:DeprecationWarning
     ignore:.*String decoding changed with h5py.*:FutureWarning
+    ignore:.*SelectableGroups dict interface is deprecated.*:DeprecationWarning
     always::ResourceWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):

--- a/mne_connectivity/envelope.py
+++ b/mne_connectivity/envelope.py
@@ -45,7 +45,7 @@ def envelope_correlation(data, names=None,
         If True (default), then take the absolute value of correlation
         coefficients before making each epoch's correlation matrix
         symmetric (and thus before combining matrices across epochs).
-        Only used when ``orthogonalize='symmetric'``.
+        Only used when ``orthogonalize='pairwise'``.
     %(verbose)s
 
     Returns

--- a/mne_connectivity/envelope.py
+++ b/mne_connectivity/envelope.py
@@ -107,11 +107,11 @@ def envelope_correlation(data, names=None,
 
         # Get the complex envelope (allowing complex inputs allows people
         # to do raw.apply_hilbert if they want)
-        if epoch_data.dtype in (np.float32, np.float64):
+        if np.isrealobj(epoch_data):
             n_fft = next_fast_len(n_times)
             epoch_data = hilbert(epoch_data, N=n_fft, axis=-1)[..., :n_times]
 
-        if epoch_data.dtype not in (np.complex64, np.complex128):
+        if not np.iscomplexobj(epoch_data):
             raise ValueError('data.dtype must be float or complex, got %s'
                              % (epoch_data.dtype,))
         data_mag = np.abs(epoch_data)
@@ -153,7 +153,7 @@ def envelope_correlation(data, names=None,
             corr[li] = np.sum(label_data_orth * data_mag_nomean, axis=1)
             corr[li] /= data_mag_std
             corr[li] /= label_data_orth_std
-        if orthogonalize is not False:
+        if orthogonalize:
             # Make it symmetric (it isn't at this point)
             if absolute:
                 corr = np.abs(corr)

--- a/mne_connectivity/envelope.py
+++ b/mne_connectivity/envelope.py
@@ -107,7 +107,7 @@ def envelope_correlation(data, names=None,
 
         # Get the complex envelope (allowing complex inputs allows people
         # to do raw.apply_hilbert if they want)
-        if np.isrealobj(epoch_data):
+        if np.issubdtype(epoch_data.dtype, np.floating):
             n_fft = next_fast_len(n_times)
             epoch_data = hilbert(epoch_data, N=n_fft, axis=-1)[..., :n_times]
 

--- a/mne_connectivity/tests/test_envelope.py
+++ b/mne_connectivity/tests/test_envelope.py
@@ -94,7 +94,7 @@ def test_envelope_correlation():
     assert_allclose(corr.squeeze(), corr_orig)
 
     # degenerate
-    with pytest.raises(ValueError, match='float'):
+    with pytest.raises(ValueError, match='dtype must be float or complex'):
         envelope_correlation(data.astype(int))
     with pytest.raises(ValueError, match='entry in data must be 2D'):
         envelope_correlation(data[np.newaxis])


### PR DESCRIPTION
- fix to docstring of `envelope_correlation`, where non-existent param value `orthogonalize='symmetric'` is referred to.
- a few minor code style changes that I noticed along the way

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-connectivity/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
