### PR TITLE
[ENH, MRG] remove duplicated code, add deprecation for subplot indexing [skip ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             name: Complete checkout
             command: |
               if ! git remote -v | grep upstream; then
-                git remote add upstream git://github.com/mne-tools/mne-connectivity.git
+                git remote add upstream https://github.com/mne-tools/mne-connectivity.git
               fi
               git fetch upstream
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
     displayName: 'Install MNE-Connectivity'
   - bash: |
       set -e
-      git clone --depth 1 git://github.com/pyvista/gl-ci-helpers.git
+      git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
       powershell gl-ci-helpers/appveyor/install_opengl.ps1
   - script: python -c "import mne; print(mne.sys_info())"
     displayName: 'Print config'

--- a/doc/authors.inc
+++ b/doc/authors.inc
@@ -3,3 +3,4 @@
 .. _Britta Westner: https://github.com/britta-wstnr
 .. _Alexander Kroner: https://github.com/alexanderkroner
 .. _Richard Höchenberger: https://github.com/hoechenberger
+.. _Alex Rockhill: https://github.com/alexrockhill

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -100,6 +100,7 @@ numpydoc_xref_aliases = {
     'Axes': 'matplotlib.axes.Axes',
     'Figure': 'matplotlib.figure.Figure',
     'Axes3D': 'mpl_toolkits.mplot3d.axes3d.Axes3D',
+    'PolarAxes': 'matplotlib.projections.polar.PolarAxes',
     'ColorbarBase': 'matplotlib.colorbar.ColorbarBase',
     # joblib
     'joblib.Parallel': 'joblib.Parallel',

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -24,7 +24,7 @@ Version 0.4 (Unreleased)
 Enhancements
 ~~~~~~~~~~~~
 
-- Add ``node_height`` to :func:`mne_connectivity.plot_connectivity_circle` and enable passing a polar ``ax``, by `Alex Rockhill`_ :gh:`88`
+- Add ``node_height`` to :func:`mne_connectivity.viz.plot_connectivity_circle` and enable passing a polar ``ax``, by `Alex Rockhill`_ :gh:`88`
 
 Bug
 ~~~

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -24,7 +24,7 @@ Version 0.4 (Unreleased)
 Enhancements
 ~~~~~~~~~~~~
 
--
+- Add ``node_height`` to :func:`mne_connectivity.plot_connectivity_circle` and enable passing a polar ``ax``, by `Alex Rockhill`_ :gh:`88`
 
 Bug
 ~~~

--- a/examples/connectivity_classes.py
+++ b/examples/connectivity_classes.py
@@ -16,6 +16,7 @@ how we can interact with the connectivity class.
 #
 # License: BSD (3-clause)
 
+import os.path as op
 import numpy as np
 
 import mne
@@ -25,8 +26,10 @@ from mne.datasets import sample
 # %%
 # Set parameters
 data_path = sample.data_path()
-raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
-event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
+raw_fname = op.join(data_path, 'MEG', 'sample',
+                    'sample_audvis_filt-0-40_raw.fif')
+event_fname = op.join(data_path, 'MEG', 'sample',
+                      'sample_audvis_filt-0-40_raw-eve.fif')
 
 # Setup for reading the raw data
 raw = mne.io.read_raw_fif(raw_fname)

--- a/examples/cwt_sensor_connectivity.py
+++ b/examples/cwt_sensor_connectivity.py
@@ -12,6 +12,7 @@ domain using Morlet wavelets and the debiased squared weighted phase lag index
 #
 # License: BSD (3-clause)
 
+import os.path as op
 import numpy as np
 
 import mne
@@ -25,8 +26,10 @@ print(__doc__)
 ###############################################################################
 # Set parameters
 data_path = sample.data_path()
-raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
-event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
+raw_fname = op.join(data_path, 'MEG', 'sample',
+                    'sample_audvis_filt-0-40_raw.fif')
+event_fname = op.join(data_path, 'MEG', 'sample',
+                      'sample_audvis_filt-0-40_raw-eve.fif')
 
 # Setup for reading the raw data
 raw = io.read_raw_fif(raw_fname)

--- a/examples/mixed_source_space_connectivity.py
+++ b/examples/mixed_source_space_connectivity.py
@@ -15,7 +15,6 @@ is ordered based on the locations of the regions in the axial plane.
 import os.path as op
 import numpy as np
 import mne
-import matplotlib.pyplot as plt
 
 from mne.datasets import sample
 from mne import setup_volume_source_space, setup_source_space
@@ -168,11 +167,10 @@ node_angles = circular_layout(label_names, node_order, start_pos=90,
 # Plot the graph using node colors from the FreeSurfer parcellation. We only
 # show the 300 strongest connections.
 conmat = con.get_data(output='dense')[:, :, 0]
-fig = plt.figure(num=None, figsize=(8, 8), facecolor='black')
 plot_connectivity_circle(conmat, label_names, n_lines=300,
                          node_angles=node_angles, node_colors=node_colors,
                          title='All-to-All Connectivity left-Auditory '
-                         'Condition (PLI)', fig=fig)
+                         'Condition (PLI)')
 
 ###############################################################################
 # Save the figure (optional)

--- a/examples/mixed_source_space_connectivity.py
+++ b/examples/mixed_source_space_connectivity.py
@@ -14,8 +14,9 @@ is ordered based on the locations of the regions in the axial plane.
 
 import os.path as op
 import numpy as np
-import mne
+import matplotlib.pyplot as plt
 
+import mne
 from mne.datasets import sample
 from mne import setup_volume_source_space, setup_source_space
 from mne import make_forward_solution
@@ -38,10 +39,10 @@ fname_aseg = op.join(subjects_dir, subject, 'mri', 'aseg.mgz')
 fname_model = op.join(bem_dir, '%s-5120-bem.fif' % subject)
 fname_bem = op.join(bem_dir, '%s-5120-bem-sol.fif' % subject)
 
-fname_raw = data_dir + '/sample_audvis_filt-0-40_raw.fif'
-fname_trans = data_dir + '/sample_audvis_raw-trans.fif'
-fname_cov = data_dir + '/ernoise-cov.fif'
-fname_event = data_dir + '/sample_audvis_filt-0-40_raw-eve.fif'
+fname_raw = op.join(data_dir, 'sample_audvis_filt-0-40_raw.fif')
+fname_trans = op.join(data_dir, 'sample_audvis_raw-trans.fif')
+fname_cov = op.join(data_dir, 'ernoise-cov.fif')
+fname_event = op.join(data_dir, 'sample_audvis_filt-0-40_raw-eve.fif')
 
 # List of sub structures we are interested in. We select only the
 # sub structures we want to include in the source space
@@ -167,10 +168,13 @@ node_angles = circular_layout(label_names, node_order, start_pos=90,
 # Plot the graph using node colors from the FreeSurfer parcellation. We only
 # show the 300 strongest connections.
 conmat = con.get_data(output='dense')[:, :, 0]
+fig, ax = plt.subplots(figsize=(8, 8), facecolor='black',
+                       subplot_kw=dict(polar=True))
 plot_connectivity_circle(conmat, label_names, n_lines=300,
                          node_angles=node_angles, node_colors=node_colors,
                          title='All-to-All Connectivity left-Auditory '
-                         'Condition (PLI)')
+                         'Condition (PLI)', ax=ax)
+fig.tight_layout()
 
 ###############################################################################
 # Save the figure (optional)
@@ -180,5 +184,7 @@ plot_connectivity_circle(conmat, label_names, n_lines=300,
 # set when the figure was generated. If not set via savefig, the labels, title,
 # and legend will be cut off from the output png file::
 #
-#     >>> fname_fig = data_path + '/MEG/sample/plot_mixed_connect.png'
-#     >>> plt.savefig(fname_fig, facecolor='black')
+#  .. code-block:: python
+#
+#     fname_fig = op.join(data_path, 'MEG', 'sample', 'plot_mixed_connect.png')
+#     plt.savefig(fname_fig, facecolor=fig.get_facecolor())

--- a/examples/mne_inverse_label_connectivity.py
+++ b/examples/mne_inverse_label_connectivity.py
@@ -158,15 +158,15 @@ plot_connectivity_circle(con_res['pli'], label_names, n_lines=300,
 # We can also assign these connectivity plots to axes in a figure. Below we'll
 # show the connectivity plot using two different connectivity methods.
 
-fig = plt.figure(num=None, figsize=(8, 4), facecolor='black')
+fig, axes = plt.subplots(1, 3, figsize=(8, 4), facecolor='black',
+                         subplot_kw=dict(polar=True))
 no_names = [''] * len(label_names)
-for ii, method in enumerate(con_methods):
+for ax, method in zip(axes, con_methods):
     plot_connectivity_circle(con_res[method], no_names, n_lines=300,
                              node_angles=node_angles, node_colors=label_colors,
                              title=method, padding=0, fontsize_colorbar=6,
-                             fig=fig, subplot=(1, 3, ii + 1))
+                             ax=ax)
 
-plt.show()
 
 ###############################################################################
 # Save the figure (optional)
@@ -175,6 +175,10 @@ plt.show()
 # By default matplotlib does not save using the facecolor, even though this was
 # set when the figure was generated. If not set via savefig, the labels, title,
 # and legend will be cut off from the output png file.
-
-# fname_fig = data_path + '/MEG/sample/plot_inverse_connect.png'
-# fig.savefig(fname_fig, facecolor='black')
+#
+# .. code-block:: python
+#
+#     import os.path as op
+#     fname_fig = op.join(data_path, 'MEG', 'sample',
+#                         'plot_inverse_connect.png')
+#     fig.savefig(fname_fig, facecolor=fig.get_facecolor())

--- a/examples/mne_inverse_label_connectivity.py
+++ b/examples/mne_inverse_label_connectivity.py
@@ -146,14 +146,17 @@ node_angles = circular_layout(label_names, node_order, start_pos=90,
 
 # Plot the graph using node colors from the FreeSurfer parcellation. We only
 # show the 300 strongest connections.
+fig, ax = plt.subplots(figsize=(8, 8), facecolor='black',
+                       subplot_kw=dict(polar=True))
 plot_connectivity_circle(con_res['pli'], label_names, n_lines=300,
                          node_angles=node_angles, node_colors=label_colors,
                          title='All-to-All Connectivity left-Auditory '
-                               'Condition (PLI)')
+                               'Condition (PLI)', ax=ax)
+fig.tight_layout()
 
 ###############################################################################
-# Make two connectivity plots in the same figure
-# ----------------------------------------------
+# Make multiple connectivity plots in the same figure
+# ---------------------------------------------------
 #
 # We can also assign these connectivity plots to axes in a figure. Below we'll
 # show the connectivity plot using two different connectivity methods.

--- a/examples/sensor_connectivity.py
+++ b/examples/sensor_connectivity.py
@@ -12,6 +12,8 @@ are used which produces strong connectvitiy in the right occipital sensors.
 #
 # License: BSD (3-clause)
 
+import os.path as op
+
 import mne
 from mne_connectivity import spectral_connectivity_epochs
 from mne.datasets import sample
@@ -22,8 +24,10 @@ print(__doc__)
 ###############################################################################
 # Set parameters
 data_path = sample.data_path()
-raw_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
-event_fname = data_path + '/MEG/sample/sample_audvis_filt-0-40_raw-eve.fif'
+raw_fname = op.join(data_path, 'MEG', 'sample',
+                    'sample_audvis_filt-0-40_raw.fif')
+event_fname = op.join(data_path, 'MEG', 'sample',
+                      'sample_audvis_filt-0-40_raw-eve.fif')
 
 # Setup for reading the raw data
 raw = mne.io.read_raw_fif(raw_fname)

--- a/mne_connectivity/base.py
+++ b/mne_connectivity/base.py
@@ -82,7 +82,7 @@ class EpochMixin:
         self : instance of Connectivity
             The altered Epoched Connectivity class.
         """
-        if type(self) != type(epoch_conn):
+        if not isinstance(self, type(epoch_conn)):
             raise ValueError(f'The type of the epoch connectivity to append '
                              f'is {type(epoch_conn)}, which does not match '
                              f'{type(self)}.')

--- a/mne_connectivity/viz/circle.py
+++ b/mne_connectivity/viz/circle.py
@@ -1,59 +1,25 @@
 """Functions to plot on circle as for connectivity."""
 
-# Authors: Alexandre Gramfort <alexandre.gramfort@inria.fr>
-#          Denis Engemann <denis.engemann@gmail.com>
-#          Martin Luessi <mluessi@nmr.mgh.harvard.edu>
+# Authors: Adam Li <adam2392@gmail.com>
+#          Alex Rockhill <aprockhill@mailbox.org>
 #
 # License: Simplified BSD
 
-
-from functools import partial
-from itertools import cycle
-
-import numpy as np
-from mne.viz.utils import plt_show
-
-
-def _plot_connectivity_circle_onpick(event, fig=None, axes=None, indices=None,
-                                     n_nodes=0, node_angles=None,
-                                     ylim=[9, 10]):
-    """Isolate connections around a single node when user left clicks a node.
-
-    On right click, resets all connections.
-    """
-    if event.inaxes != axes:
-        return
-
-    if event.button == 1:  # left click
-        # click must be near node radius
-        if not ylim[0] <= event.ydata <= ylim[1]:
-            return
-
-        # all angles in range [0, 2*pi]
-        node_angles = node_angles % (np.pi * 2)
-        node = np.argmin(np.abs(event.xdata - node_angles))
-
-        patches = event.inaxes.patches
-        for ii, (x, y) in enumerate(zip(indices[0], indices[1])):
-            patches[ii].set_visible(node in [x, y])
-        fig.canvas.draw()
-    elif event.button == 3:  # right click
-        patches = event.inaxes.patches
-        for ii in range(np.size(indices, axis=1)):
-            patches[ii].set_visible(True)
-        fig.canvas.draw()
+from mne.utils import warn
+from mne.viz.circle import _plot_connectivity_circle
 
 
 def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
                              node_angles=None, node_width=None,
-                             node_colors=None, facecolor='black',
-                             textcolor='white', node_edgecolor='black',
-                             linewidth=1.5, colormap='hot', vmin=None,
-                             vmax=None, colorbar=True, title=None,
+                             node_height=1.0, node_colors=None,
+                             facecolor='black', textcolor='white',
+                             node_edgecolor='black', linewidth=1.5,
+                             colormap='hot', vmin=None, vmax=None,
+                             colorbar=True, title=None,
                              colorbar_size=0.2, colorbar_pos=(-0.3, 0.1),
                              fontsize_title=12, fontsize_names=8,
-                             fontsize_colorbar=8, padding=6.,
-                             fig=None, subplot=111, interactive=True,
+                             fontsize_colorbar=8, padding=6., ax=None,
+                             fig=None, subplot=None, interactive=True,
                              node_linewidth=2., show=True):
     """Visualize connectivity as a circular graph.
 
@@ -77,6 +43,9 @@ def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
     node_width : float | None
         Width of each node in degrees. If None, the minimum angle between any
         two nodes is used as the width.
+    node_height : float
+        The relative height of the colored bar labeling each node. Default 1.0
+        is the standard height.
     node_colors : list of tuple | list of str
         List with the color to use for each node. If fewer colors than nodes
         are provided, the colors will be repeated. Any color supported by
@@ -111,13 +80,21 @@ def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
         Font size to use for colorbar.
     padding : float
         Space to add around figure to accommodate long labels.
+    ax : instance of matplotlib PolarAxes | None
+        The axes to use to plot the connectivity circle.
     fig : None | instance of matplotlib.figure.Figure
         The figure to use. If None, a new figure with the specified background
         color will be created.
+
+        Deprecated: will be removed in version 0.5.
+
     subplot : int | tuple, shape (3,)
         Location of the subplot when creating figures with multiple plots. E.g.
         121 or (1, 2, 1) for 1 row, 2 columns, plot 1. See
         matplotlib.pyplot.subplot.
+
+        Deprecated: will be removed in version 0.5.
+
     interactive : bool
         When enabled, left-click on a node to show only connections to that
         node. Right-click shows all connections.
@@ -130,7 +107,7 @@ def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
     -------
     fig : instance of matplotlib.figure.Figure
         The figure handle.
-    axes : instance of matplotlib.projections.polar.PolarAxes
+    ax : instance of matplotlib.projections.polar.PolarAxes
         The subplot handle.
 
     Notes
@@ -146,210 +123,32 @@ def plot_connectivity_circle(con, node_names, indices=None, n_lines=None,
     If ``facecolor`` is not set via :func:`matplotlib.pyplot.savefig`, the
     figure labels, title, and legend may be cut off in the output figure.
     """
-    import matplotlib.patches as m_patches
-    import matplotlib.path as m_path
     import matplotlib.pyplot as plt
     from mne_connectivity.base import BaseConnectivity
 
     if isinstance(con, BaseConnectivity):
         con = con.get_data()
-    n_nodes = len(node_names)
 
-    if node_angles is not None:
-        if len(node_angles) != n_nodes:
-            raise ValueError('node_angles has to be the same length '
-                             'as node_names')
-        # convert it to radians
-        node_angles = node_angles * np.pi / 180
-    else:
-        # uniform layout on unit circle
-        node_angles = np.linspace(0, 2 * np.pi, n_nodes, endpoint=False)
+    if fig is not None or subplot is not None:
+        warn('Passing a `fig` and `subplot` is deprecated and not be '
+             'supported after mne-connectivity version 0.4. Please '
+             'use the `ax` argument and pass a matplotlib axes object '
+             'with polar coordinates instead', DeprecationWarning)
+        if ax is None:  # don't overwrite ax if passed
+            if fig is None:
+                fig = plt.figure(figsize=(8, 8), facecolor=facecolor)
+            if not isinstance(subplot, tuple):
+                subplot = (subplot,)
+            ax = plt.subplot(*subplot, polar=True)
 
-    if node_width is None:
-        # widths correspond to the minimum angle between two nodes
-        dist_mat = node_angles[None, :] - node_angles[:, None]
-        dist_mat[np.diag_indices(n_nodes)] = 1e9
-        node_width = np.min(np.abs(dist_mat))
-    else:
-        node_width = node_width * np.pi / 180
-
-    if node_colors is not None:
-        if len(node_colors) < n_nodes:
-            node_colors = cycle(node_colors)
-    else:
-        # assign colors using colormap
-        try:
-            spectral = plt.cm.spectral
-        except AttributeError:
-            spectral = plt.cm.Spectral
-        node_colors = [spectral(i / float(n_nodes))
-                       for i in range(n_nodes)]
-
-    # handle 1D and 2D connectivity information
-    if con.ndim == 1:
-        if indices is None:
-            raise ValueError('indices has to be provided if con.ndim == 1')
-    elif con.ndim == 2:
-        if con.shape[0] != n_nodes or con.shape[1] != n_nodes:
-            raise ValueError('con has to be 1D or a square matrix')
-        # we use the lower-triangular part
-        indices = np.tril_indices(n_nodes, -1)
-        con = con[indices]
-    else:
-        raise ValueError('con has to be 1D or a square matrix')
-
-    # get the colormap
-    if isinstance(colormap, str):
-        colormap = plt.get_cmap(colormap)
-
-    # Make figure background the same colors as axes
-    if fig is None:
-        fig = plt.figure(figsize=(8, 8), facecolor=facecolor)
-
-    # Use a polar axes
-    if not isinstance(subplot, tuple):
-        subplot = (subplot,)
-    axes = plt.subplot(*subplot, polar=True)
-    axes.set_facecolor(facecolor)
-
-    # No ticks, we'll put our own
-    plt.xticks([])
-    plt.yticks([])
-
-    # Set y axes limit, add additional space if requested
-    plt.ylim(0, 10 + padding)
-
-    # Remove the black axes border which may obscure the labels
-    axes.spines['polar'].set_visible(False)
-
-    # Draw lines between connected nodes, only draw the strongest connections
-    if n_lines is not None and len(con) > n_lines:
-        con_thresh = np.sort(np.abs(con).ravel())[-n_lines]
-    else:
-        con_thresh = 0.
-
-    # get the connections which we are drawing and sort by connection strength
-    # this will allow us to draw the strongest connections first
-    con_abs = np.abs(con)
-    con_draw_idx = np.where(con_abs >= con_thresh)[0]
-
-    con = con[con_draw_idx]
-    con_abs = con_abs[con_draw_idx]
-    indices = [ind[con_draw_idx] for ind in indices]
-
-    # now sort them
-    sort_idx = np.argsort(con_abs)
-    del con_abs
-    con = con[sort_idx]
-    indices = [ind[sort_idx] for ind in indices]
-
-    # Get vmin vmax for color scaling
-    if vmin is None:
-        vmin = np.min(con[np.abs(con) >= con_thresh])
-    if vmax is None:
-        vmax = np.max(con)
-    vrange = vmax - vmin
-
-    # We want to add some "noise" to the start and end position of the
-    # edges: We modulate the noise with the number of connections of the
-    # node and the connection strength, such that the strongest connections
-    # are closer to the node center
-    nodes_n_con = np.zeros((n_nodes), dtype=np.int64)
-    for i, j in zip(indices[0], indices[1]):
-        nodes_n_con[i] += 1
-        nodes_n_con[j] += 1
-
-    # initialize random number generator so plot is reproducible
-    rng = np.random.mtrand.RandomState(0)
-
-    n_con = len(indices[0])
-    noise_max = 0.25 * node_width
-    start_noise = rng.uniform(-noise_max, noise_max, n_con)
-    end_noise = rng.uniform(-noise_max, noise_max, n_con)
-
-    nodes_n_con_seen = np.zeros_like(nodes_n_con)
-    for i, (start, end) in enumerate(zip(indices[0], indices[1])):
-        nodes_n_con_seen[start] += 1
-        nodes_n_con_seen[end] += 1
-
-        start_noise[i] *= ((nodes_n_con[start] - nodes_n_con_seen[start]) /
-                           float(nodes_n_con[start]))
-        end_noise[i] *= ((nodes_n_con[end] - nodes_n_con_seen[end]) /
-                         float(nodes_n_con[end]))
-
-    # scale connectivity for colormap (vmin<=>0, vmax<=>1)
-    con_val_scaled = (con - vmin) / vrange
-
-    # Finally, we draw the connections
-    for pos, (i, j) in enumerate(zip(indices[0], indices[1])):
-        # Start point
-        t0, r0 = node_angles[i], 10
-
-        # End point
-        t1, r1 = node_angles[j], 10
-
-        # Some noise in start and end point
-        t0 += start_noise[pos]
-        t1 += end_noise[pos]
-
-        verts = [(t0, r0), (t0, 5), (t1, 5), (t1, r1)]
-        codes = [m_path.Path.MOVETO, m_path.Path.CURVE4, m_path.Path.CURVE4,
-                 m_path.Path.LINETO]
-        path = m_path.Path(verts, codes)
-
-        color = colormap(con_val_scaled[pos])
-
-        # Actual line
-        patch = m_patches.PathPatch(path, fill=False, edgecolor=color,
-                                    linewidth=linewidth, alpha=1.)
-        axes.add_patch(patch)
-
-    # Draw ring with colored nodes
-    height = np.ones(n_nodes) * 1.0
-    bars = axes.bar(node_angles, height, width=node_width, bottom=9,
-                    edgecolor=node_edgecolor, lw=node_linewidth,
-                    facecolor='.9', align='center')
-
-    for bar, color in zip(bars, node_colors):
-        bar.set_facecolor(color)
-
-    # Draw node labels
-    angles_deg = 180 * node_angles / np.pi
-    for name, angle_rad, angle_deg in zip(node_names, node_angles, angles_deg):
-        if angle_deg >= 270 or angle_deg < 90:
-            ha = 'left'
-        else:
-            # Flip the label, so text is always upright
-            angle_deg += 180
-            ha = 'right'
-
-        axes.text(angle_rad, 10.4, name, size=fontsize_names,
-                  rotation=angle_deg, rotation_mode='anchor',
-                  horizontalalignment=ha, verticalalignment='center',
-                  color=textcolor)
-
-    if title is not None:
-        plt.title(title, color=textcolor, fontsize=fontsize_title,
-                  axes=axes)
-
-    if colorbar:
-        sm = plt.cm.ScalarMappable(cmap=colormap,
-                                   norm=plt.Normalize(vmin, vmax))
-        sm.set_array(np.linspace(vmin, vmax))
-        cb = plt.colorbar(sm, ax=axes, use_gridspec=False,
-                          shrink=colorbar_size,
-                          anchor=colorbar_pos)
-        cb_yticks = plt.getp(cb.ax.axes, 'yticklabels')
-        cb.ax.tick_params(labelsize=fontsize_colorbar)
-        plt.setp(cb_yticks, color=textcolor)
-
-    # Add callback for interaction
-    if interactive:
-        callback = partial(_plot_connectivity_circle_onpick, fig=fig,
-                           axes=axes, indices=indices, n_nodes=n_nodes,
-                           node_angles=node_angles)
-
-        fig.canvas.mpl_connect('button_press_event', callback)
-
-    plt_show(show)
-    return fig, axes
+    return _plot_connectivity_circle(
+        con=con, node_names=node_names, indices=indices, n_lines=n_lines,
+        node_angles=node_angles, node_width=node_width,
+        node_height=node_height, node_colors=node_colors,
+        facecolor=facecolor, textcolor=textcolor,
+        node_edgecolor=node_edgecolor, linewidth=linewidth,
+        colormap=colormap, vmin=vmin, vmax=vmax, colorbar=colorbar,
+        title=title, colorbar_size=colorbar_size, colorbar_pos=colorbar_pos,
+        fontsize_title=fontsize_title, fontsize_names=fontsize_names,
+        fontsize_colorbar=fontsize_colorbar, padding=padding, ax=ax,
+        interactive=interactive, node_linewidth=node_linewidth, show=show)

--- a/mne_connectivity/viz/tests/test_circle.py
+++ b/mne_connectivity/viz/tests/test_circle.py
@@ -83,6 +83,11 @@ def test_plot_connectivity_circle():
                              node_angles=node_angles, title='test',
                              )
 
+    fig = plt.figure()
+    with pytest.warns(DeprecationWarning, match='Passing a `fig` and '
+                                                '`subplot` is deprecated'):
+        plot_connectivity_circle(con, label_names, fig=fig, subplot=111)
+
     pytest.raises(ValueError, circular_layout, label_names, node_order,
                   group_boundaries=[-1])
     pytest.raises(ValueError, circular_layout, label_names, node_order,


### PR DESCRIPTION
This brings mne-connectivity up to date with changes to connectivity plotting and prevents getting out of sync in the future. Adds a few features from https://github.com/mne-tools/mne-python/pull/10439.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [x] PR title starts with [MRG]
- [x] [whats_new.rst](https://github.com/mne-tools/mne-connectivity/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
