### PR TITLE
Update time.py due to error in spectral_connectivity_time

### DIFF
--- a/doc/authors.inc
+++ b/doc/authors.inc
@@ -6,3 +6,4 @@
 .. _Alex Rockhill: https://github.com/alexrockhill
 .. _Szonja Weigl: https://github.com/weiglszonja
 .. _Kenji Marshall: https://github.com/kenjimarshall
+.. _Sezan Mert: https://github.com/SezanMert

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -30,7 +30,8 @@ Enhancements
 Bug
 ~~~
 
-- Fix the output of :func:`mne_connectivity.spectral_connectivity_epochs` when ``faverage=True``, allowing one to save the Connectivity object, by `Adam Li`_ and `Szonja Weigl`_ :gh:`91`
+- Fix the output of :func:`mne_connectivity.spectral_connectivity_epochs` when ``faverage=True``, allowing one to save the Connectivity object, by `Adam Li`_ and `Szonja Weigl`_ (:gh:`91`)
+- Fix the incompatibility of dimensions of frequencies in the creation of ``EpochSpectroTemporalConnectivity`` object in :func:`mne_connectivity.spectral_connectivity_time` by providing the frequencies of interest into the object, rather than the frequencies used in the time-frequency decomposition by `Adam Li`_ and `Sezan Mert`_ (:gh:`98`)
 
 API
 ~~~
@@ -44,6 +45,7 @@ Authors
 * `Adam Li`_
 * `Alex Rockhill`_
 * `Szonja Weigl`_
+* `Sezan Mert`_
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`
 

--- a/mne_connectivity/spectral/time.py
+++ b/mne_connectivity/spectral/time.py
@@ -221,7 +221,7 @@ def spectral_connectivity_time(data, names=None, method='coh', indices=None,
     # create a Connectivity container
     indices = 'symmetric'
     conn = EpochSpectroTemporalConnectivity(
-        conn, freqs=freqs, times=times,
+        conn, freqs=f_vec, times=times,
         n_nodes=n_signals, names=names, indices=indices, method=method,
         spec_method=mode, events=events, event_id=event_id, metadata=metadata)
 


### PR DESCRIPTION
PR Description
--------------

It is the prospective solution of #95 

It fixes the incompatibility of dimensions of frequencies in the creation of EpochSpectroTemporalConnectivity object on line 223 by providing the frequencies of interest into the object, rather than the frequencies used in the time-frequency decomposition. 

Merge Checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-connectivity/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
