### PR TITLE
MAINT: Update for 1.2 and bump version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,5 @@
 version: 2.1
 
-_xvfb: &xvfb
-  name: Start Xvfb virtual framebuffer
-  command: |
-    echo "export DISPLAY=:99" >> $BASH_ENV
-    /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1280x1024x24 -ac +extension GLX +render -noreset -nolisten tcp -nolisten unix
-
-
 jobs:
     build_docs:
       docker:
@@ -41,6 +34,7 @@ jobs:
             command: |
               set -e
               echo "set -e" >> $BASH_ENV
+              ./tools/setup_xvfb.sh
               echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV
               echo "export XDG_RUNTIME_DIR=/tmp/runtime-circleci" >> $BASH_ENV
               echo "export MNE_FULL_DATE=true" >> $BASH_ENV
@@ -61,9 +55,6 @@ jobs:
                 echo "Merging $(cat merge.txt)";
                 git pull --ff-only upstream "refs/pull/$(cat merge.txt)/merge";
               fi
-
-        - run:
-            <<: *xvfb
 
         # Load pip cache
         - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
         - restore_cache:
             keys:
               - user-install-bin-cachev1
-              
+
         - run:
             name: Get Python running and install dependencies
             command: |
@@ -110,8 +110,8 @@ jobs:
               - data-cache-bst-resting
 
         - run:
-            name: Check PyQt5
-            command: LD_DEBUG=libs python -c "from PyQt5.QtWidgets import QApplication, QWidget; app = QApplication([])"
+            name: Check PyQt6
+            command: LD_DEBUG=libs python -c "from PyQt6.QtWidgets import QApplication, QWidget; app = QApplication([])"
 
         # Look at what we have and fail early if there is some library conflict
         - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
     build_docs:
       docker:
-        - image: circleci/python:3.8.5-buster
+        - image: cimg/base:current-22.04
       steps:
         - restore_cache:
             keys:
@@ -33,14 +33,22 @@ jobs:
             name: Set BASH_ENV
             command: |
               set -e
-              echo "set -e" >> $BASH_ENV
               ./tools/setup_xvfb.sh
+              sudo apt install -qq graphviz optipng python3.10-venv python3-venv libxft2 ffmpeg
+              python3.10 -m venv ~/python_env
+              echo "set -e" >> $BASH_ENV
               echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV
               echo "export XDG_RUNTIME_DIR=/tmp/runtime-circleci" >> $BASH_ENV
               echo "export MNE_FULL_DATE=true" >> $BASH_ENV
-              source tools/get_minimal_commands.sh
-              echo "export MNE_3D_BACKEND=pyvista" >> $BASH_ENV
+              echo "export MNE_3D_BACKEND=pyvistaqt" >> $BASH_ENV
+              echo "export MNE_3D_OPTION_MULTI_SAMPLES=1" >> $BASH_ENV
+              echo "export MNE_BROWSER_BACKEND=qt" >> $BASH_ENV
+              echo "export MNE_BROWSER_PRECOMPUTE=false" >> $BASH_ENV
               echo "export PATH=~/.local/bin/:$PATH" >> $BASH_ENV
+              echo "export DISPLAY=:99" >> $BASH_ENV
+              echo "source ~/python_env/bin/activate" >> $BASH_ENV
+              mkdir -p ~/.local/bin
+              ln -s ~/python_env/bin/python ~/.local/bin/python
               echo "BASH_ENV:"
               cat $BASH_ENV
               mkdir -p ~/mne_data

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,10 +28,8 @@ jobs:
       architecture: $(PYTHON_ARCH)
       addToPath: true
     condition: eq(variables['TEST_MODE'], 'pip')
-  - powershell: |
-      Set-StrictMode -Version Latest
-      $ErrorActionPreference = "Stop"
-      $PSDefaultParameterValues['*:ErrorAction']='Stop'
+  - bash: |
+      set -e
       pip install --upgrade --pre numpy scipy matplotlib "h5py<3.7"
       pip install https://api.github.com/repos/mne-tools/mne-python/zipball/main
       pip install --upgrade -r requirements.txt -r requirements_testing.txt codecov

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,8 +18,8 @@ jobs:
   strategy:
     maxParallel: 4
     matrix:
-      Python39-64bit-full-pip:
-        PYTHON_VERSION: '3.9'
+      Python310-64bit-full-pip:
+        PYTHON_VERSION: '3.10'
         PYTHON_ARCH: 'x64'
   steps:
   - task: UsePythonVersion@0
@@ -32,7 +32,7 @@ jobs:
       Set-StrictMode -Version Latest
       $ErrorActionPreference = "Stop"
       $PSDefaultParameterValues['*:ErrorAction']='Stop'
-      pip install --upgrade --pre numpy scipy matplotlib
+      pip install --upgrade --pre numpy scipy matplotlib "h5py<3.7"
       pip install https://api.github.com/repos/mne-tools/mne-python/zipball/main
       pip install --upgrade -r requirements.txt -r requirements_testing.txt codecov
     displayName: 'Install dependencies with pip'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -252,6 +252,7 @@ try:
         warnings.filterwarnings("ignore", category=DeprecationWarning)
         import pyvista
     pyvista.OFF_SCREEN = False
+    pyvista.BUILDING_GALLERY = True
 except Exception:
     pass
 else:

--- a/mne_connectivity/__init__.py
+++ b/mne_connectivity/__init__.py
@@ -6,7 +6,7 @@
 #
 # License: BSD (3-clause)
 
-__version__ = '0.4dev0'
+__version__ = '0.4.0'
 
 from .base import (Connectivity, EpochConnectivity, EpochSpectralConnectivity,
                    EpochSpectroTemporalConnectivity, EpochTemporalConnectivity,

--- a/mne_connectivity/conftest.py
+++ b/mne_connectivity/conftest.py
@@ -8,7 +8,6 @@ import pytest
 import os
 import gc
 import warnings
-from distutils.version import LooseVersion
 
 from mne.utils import _check_qt_version
 

--- a/mne_connectivity/conftest.py
+++ b/mne_connectivity/conftest.py
@@ -32,6 +32,8 @@ def pytest_configure(config):
     # Epochs class
     ignore:.*There were no Annotations stored in.*:RuntimeWarning
     always::ResourceWarning
+    # pydarkstyle
+    ignore:.*Setting theme='dark' is not yet supported.*:RuntimeWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()

--- a/mne_connectivity/conftest.py
+++ b/mne_connectivity/conftest.py
@@ -77,11 +77,8 @@ def matplotlib_config():
     orig = cbook.CallbackRegistry
 
     class CallbackRegistryReraise(orig):
-        def __init__(self, exception_handler=None):
-            args = ()
-            if LooseVersion(matplotlib.__version__) >= LooseVersion('2.1'):
-                args += (exception_handler,)
-            super(CallbackRegistryReraise, self).__init__(*args)
+        def __init__(self, exception_handler=None, signals=None):
+            super(CallbackRegistryReraise, self).__init__(exception_handler)
 
     cbook.CallbackRegistry = CallbackRegistryReraise
 

--- a/mne_connectivity/spectral/epochs.py
+++ b/mne_connectivity/spectral/epochs.py
@@ -5,11 +5,10 @@
 # License: BSD (3-clause)
 
 from functools import partial
-from inspect import getmembers
+import inspect
 
 import numpy as np
 from mne.epochs import BaseEpochs
-from mne.fixes import _get_args
 from mne.parallel import parallel_func
 from mne.source_estimate import _BaseSourceEstimate
 from mne.time_frequency.multitaper import (_csd_from_mt,
@@ -668,9 +667,9 @@ def _get_n_epochs(epochs, n):
 
 def _check_method(method):
     """Test if a method implements the required interface."""
-    interface_members = [m[0] for m in getmembers(_AbstractConEstBase)
+    interface_members = [m[0] for m in inspect.getmembers(_AbstractConEstBase)
                          if not m[0].startswith('_')]
-    method_members = [m[0] for m in getmembers(method)
+    method_members = [m[0] for m in inspect.getmembers(method)
                       if not m[0].startswith('_')]
 
     for member in interface_members:
@@ -749,7 +748,7 @@ def _check_estimators(method, mode):
             con_method_types.append(this_method)
 
     # determine how many arguments the compute_con_function needs
-    n_comp_args = [len(_get_args(mtype.compute_con))
+    n_comp_args = [len(inspect.signature(mtype.compute_con).parameters)
                    for mtype in con_method_types]
 
     # we currently only support 3 arguments

--- a/tools/circleci_dependencies.sh
+++ b/tools/circleci_dependencies.sh
@@ -1,24 +1,12 @@
 #!/bin/bash -ef
 
-echo "Working around PyQt5 bugs"
-# https://github.com/ContinuumIO/anaconda-issues/issues/9190#issuecomment-386508136
-# https://github.com/golemfactory/golem/issues/1019
-sudo apt update
-sudo apt install libosmesa6 libglx-mesa0 libopengl0 libglx0 libdbus-1-3 \
-	libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
-	libxcb-render-util0 libxcb-shape0 libxcb-xfixes0 libxcb-xinerama0 \
-	graphviz optipng
-if [ ! -f /usr/lib/x86_64-linux-gnu/libxcb-util.so.1 ]; then
-	sudo ln -s /usr/lib/x86_64-linux-gnu/libxcb-util.so.0 /usr/lib/x86_64-linux-gnu/libxcb-util.so.1
-fi
-
 echo "Installing setuptools and sphinx"
 python -m pip install --progress-bar off --upgrade "pip!=20.3.0" setuptools wheel
 python -m pip install --upgrade --progress-bar off --pre sphinx
 
 echo "Installing doc build dependencies"
 python -m pip uninstall -y pydata-sphinx-theme
-python -m pip install --upgrade --progress-bar off --only-binary matplotlib -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
+python -m pip install --upgrade --progress-bar off --only-binary matplotlib PyQt6 -r requirements.txt -r requirements_testing.txt -r requirements_doc.txt
 python -m pip install --upgrade --progress-bar off https://github.com/mne-tools/mne-python/zipball/main
 python -m pip install --progress-bar off https://github.com/sphinx-gallery/sphinx-gallery/zipball/master https://github.com/pyvista/pyvista/zipball/main https://github.com/pyvista/pyvistaqt/zipball/main
 python -m pip install -e .

--- a/tools/setup_xvfb.sh
+++ b/tools/setup_xvfb.sh
@@ -1,5 +1,15 @@
 #!/bin/bash -ef
 
+# this is only relevant for GitHub Actions, but it avoids
+# https://github.com/actions/virtual-environments/issues/323
+# via
+# https://github.community/t/ubuntu-latest-apt-repository-list-issues/17182/10#M4501
+for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do
+    echo "Removing $apt_file"
+    sudo rm $apt_file
+done
+
+# This also includes the libraries necessary for PyQt5/PyQt6
 sudo apt update
-sudo apt install -yqq libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0
+sudo apt install -yqq xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libopengl0 libegl1 libosmesa6 mesa-utils libxcb-shape0
 /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset


### PR DESCRIPTION
@adam2392 we need to remove `_get_args` to comply with 1.2's removal of it. @adam2392 could you merge this if happy and cut a 0.4.0 release?

cc @drammock this one needed an update due to `_get_args`