### PR TITLE
[ENH] Added n_con arg to function call

### DIFF
--- a/doc/authors.inc
+++ b/doc/authors.inc
@@ -10,3 +10,4 @@
 .. _Santeri Ruuskanen: https://github.com/ruuskas
 .. _Daniel McCloy: https://dan.mccloy.info
 .. _Sam Steingold: https://github.com/sam-s
+.. _Qianliang Li: https://github.com/Avoide

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,7 +23,7 @@ Version 0.6 (unreleased)
 Enhancements
 ~~~~~~~~~~~~
 
-- 
+- Add the option to set the number of connections plotted in :func:`mne_connectivity.viz.plot_sensors_connectivity` by `Qianliang Li`_ (:pr:`133`).
 
 Bug
 ~~~

--- a/mne_connectivity/viz/_3d.py
+++ b/mne_connectivity/viz/_3d.py
@@ -23,7 +23,7 @@ FIDUCIAL_ORDER = (FIFF.FIFFV_POINT_LPA, FIFF.FIFFV_POINT_NASION,
 @fill_doc
 def plot_sensors_connectivity(info, con, picks=None,
                               cbar_label='Connectivity',
-                              n_con: int=20):
+                              n_con=20):
     """Visualize the sensor connectivity in 3D.
 
     Parameters

--- a/mne_connectivity/viz/_3d.py
+++ b/mne_connectivity/viz/_3d.py
@@ -22,7 +22,8 @@ FIDUCIAL_ORDER = (FIFF.FIFFV_POINT_LPA, FIFF.FIFFV_POINT_NASION,
 
 @fill_doc
 def plot_sensors_connectivity(info, con, picks=None,
-                              cbar_label='Connectivity'):
+                              cbar_label='Connectivity',
+                              n_con: int=20):
     """Visualize the sensor connectivity in 3D.
 
     Parameters
@@ -35,6 +36,8 @@ def plot_sensors_connectivity(info, con, picks=None,
         Indices of selected channels.
     cbar_label : str
         Label for the colorbar.
+    n_con : int
+        Number of strongest connections shown. By default 20.
 
     Returns
     -------
@@ -64,13 +67,12 @@ def plot_sensors_connectivity(info, con, picks=None,
     renderer.sphere(np.c_[sens_loc[:, 0], sens_loc[:, 1], sens_loc[:, 2]],
                     color=(1, 1, 1), opacity=1, scale=0.005)
 
-    # Get the strongest connections
-    n_con = 20  # show up to 20 connections
-    min_dist = 0.05  # exclude sensors that are less than 5cm apart
+    # Get the strongest n_con connections
     threshold = np.sort(con, axis=None)[-n_con]
     ii, jj = np.where(con >= threshold)
 
     # Remove close connections
+    min_dist = 0.05  # exclude sensors that are less than 5cm apart
     con_nodes = list()
     con_val = list()
     for i, j in zip(ii, jj):


### PR DESCRIPTION

PR Description
--------------

Moved the hard-coded variable n_con to be one of the arguments for the function call. To enable choosing the number of connections shown, instead of always 20. Added a default option, to make it compatible with previous usage.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-connectivity/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
