### PR TITLE
[DOC] Fixes #134. Indicate how to load connectivity data from disk

### DIFF
--- a/mne_connectivity/base.py
+++ b/mne_connectivity/base.py
@@ -788,6 +788,8 @@ class BaseConnectivity(DynamicMixin, EpochMixin):
     def save(self, fname):
         """Save connectivity data to disk.
 
+        Can later be loaded using the function "read_connectivity".
+
         Parameters
         ----------
         fname : str | pathlib.Path

--- a/mne_connectivity/base.py
+++ b/mne_connectivity/base.py
@@ -788,7 +788,7 @@ class BaseConnectivity(DynamicMixin, EpochMixin):
     def save(self, fname):
         """Save connectivity data to disk.
 
-        Can later be loaded using the function "read_connectivity".
+        Can later be loaded using the function :func:`mne_connectivity.io.read_connectivity`.
 
         Parameters
         ----------

--- a/mne_connectivity/base.py
+++ b/mne_connectivity/base.py
@@ -789,7 +789,7 @@ class BaseConnectivity(DynamicMixin, EpochMixin):
         """Save connectivity data to disk.
 
         Can later be loaded using the function
-        :func:`mne_connectivity.io.read_connectivity`.
+        :func:`mne_connectivity.read_connectivity`.
 
         Parameters
         ----------

--- a/mne_connectivity/base.py
+++ b/mne_connectivity/base.py
@@ -788,7 +788,8 @@ class BaseConnectivity(DynamicMixin, EpochMixin):
     def save(self, fname):
         """Save connectivity data to disk.
 
-        Can later be loaded using the function :func:`mne_connectivity.io.read_connectivity`.
+        Can later be loaded using the function
+        :func:`mne_connectivity.io.read_connectivity`.
 
         Parameters
         ----------


### PR DESCRIPTION
PR Description
--------------

It's just a simple hint to the function [mne_connectivity.read_connectivity](https://mne.tools/mne-connectivity/stable/generated/mne_connectivity.read_connectivity.html). Fixes #134.

I tried loading the data with all kinds of tools and did not succeed because I was not aware of this function.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-connectivity/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
