### PR TITLE
MAINT: Use explicitly public APIs

### DIFF
--- a/mne_connectivity/conftest.py
+++ b/mne_connectivity/conftest.py
@@ -36,6 +36,8 @@ def pytest_configure(config):
     # imageio-ffmpeg (still happening as of version 0.4.8):
     ignore:pkg_resources is deprecated as an API:DeprecationWarning
     ignore:Deprecated call to `pkg_resources.declare_namespace.*:DeprecationWarning
+    # HDF5
+    ignore:`product` is deprecated as of NumPy.*:DeprecationWarning
     """  # noqa: E501
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()

--- a/mne_connectivity/spectral/tests/test_spectral.py
+++ b/mne_connectivity/spectral/tests/test_spectral.py
@@ -144,7 +144,10 @@ def test_spectral_connectivity_parallel(method, mode, tmp_path):
 
         read_con = read_connectivity(tmp_file)
         assert_array_almost_equal(con.get_data(), read_con.get_data())
-        assert repr(con) == repr(read_con)
+        # split `repr` before the file size (`~23 kB` for example)
+        a = repr(con).split('~')[0]
+        b = repr(read_con).split('~')[0]
+        assert a == b
 
 
 @pytest.mark.parametrize('method', ['coh', 'cohy', 'imcoh', 'plv',

--- a/mne_connectivity/tests/test_connectivity.py
+++ b/mne_connectivity/tests/test_connectivity.py
@@ -5,14 +5,13 @@
 import os
 from mne.annotations import Annotations
 from mne.epochs import BaseEpochs
-from mne.io.meas_info import create_info
 
 import numpy as np
 import pandas as pd
 import pytest
 from numpy.testing import assert_array_equal
 from mne.io import RawArray
-from mne import make_fixed_length_epochs
+from mne import make_fixed_length_epochs, create_info
 
 from mne_connectivity import (Connectivity, EpochConnectivity,
                               EpochSpectralConnectivity,


### PR DESCRIPTION
In https://github.com/mne-tools/mne-python/pull/11903 we're trying to make some mne/io stuff private. This changes mne-connectivity to use the explicitly public API

Locally I also had this failure in testing:
```
mne_connectivity/spectral/tests/test_spectral.py:147: in test_spectral_connectivity_parallel
    assert repr(con) == repr(read_con)
E   AssertionError: assert '<SpectralCon...3, 9, ~23 kB>' == '<SpectralCon...3, 9, ~22 kB>'
E     Skipping 85 identical leading characters in diff, use -v to show
E     - : 3, 9, ~22 kB>
E     ?           ^
E     + : 3, 9, ~23 kB>
E     ?           ^
```
so this modifies the test to ignore the tiny file size difference