### PR TITLE
[MAINT] Fix failing unit tests & update CI packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,11 +78,10 @@ jobs:
             name: Get Python running and install dependencies
             command: |
               pip install git+https://github.com/mne-tools/mne-python@main
-              pip install PyQt6 pyvistaqt
-              pip install sphinx-copybutton sphinx-issues sphinx-autodoc-typehints sphinxcontrib-bibtex 
               curl https://raw.githubusercontent.com/mne-tools/mne-python/main/tools/circleci_dependencies.sh -o circleci_dependencies.sh
               chmod +x circleci_dependencies.sh
               ./circleci_dependencies.sh
+              pip install -r requirements_doc.txt
 
         - save_cache:
             key: pip-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
             name: Get Python running and install dependencies
             command: |
               pip install git+https://github.com/mne-tools/mne-python@main
-              pip install PyQt6
+              pip install PyQt6 pyvistaqt
               curl https://raw.githubusercontent.com/mne-tools/mne-python/main/tools/circleci_dependencies.sh -o circleci_dependencies.sh
               chmod +x circleci_dependencies.sh
               ./circleci_dependencies.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,7 @@ jobs:
             name: Get Python running and install dependencies
             command: |
               pip install git+https://github.com/mne-tools/mne-python@main
+              pip install PyQt6
               curl https://raw.githubusercontent.com/mne-tools/mne-python/main/tools/circleci_dependencies.sh -o circleci_dependencies.sh
               chmod +x circleci_dependencies.sh
               ./circleci_dependencies.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
             name: Get Python running and install dependencies
             command: |
               pip install git+https://github.com/mne-tools/mne-python@main
-              pip install PyQt6 pyvistaqt
+              pip install PyQt6 pyvistaqt sphinx-autodoc-typehints
               curl https://raw.githubusercontent.com/mne-tools/mne-python/main/tools/circleci_dependencies.sh -o circleci_dependencies.sh
               chmod +x circleci_dependencies.sh
               ./circleci_dependencies.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
             name: Get Python running and install dependencies
             command: |
               pip install git+https://github.com/mne-tools/mne-python@main
-              pip install PyQt6 pyvistaqt sphinx-autodoc-typehints
+              pip install PyQt6 pyvistaqt sphinx-autodoc-typehints sphinxcontrib-bibtex
               curl https://raw.githubusercontent.com/mne-tools/mne-python/main/tools/circleci_dependencies.sh -o circleci_dependencies.sh
               chmod +x circleci_dependencies.sh
               ./circleci_dependencies.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,8 @@ jobs:
             name: Get Python running and install dependencies
             command: |
               pip install git+https://github.com/mne-tools/mne-python@main
-              pip install PyQt6 pyvistaqt sphinx-autodoc-typehints sphinxcontrib-bibtex
+              pip install PyQt6 pyvistaqt
+              pip install sphinx-copybutton sphinx-issues sphinx-extensions sphinx-autodoc-typehints sphinxcontrib-bibtex 
               curl https://raw.githubusercontent.com/mne-tools/mne-python/main/tools/circleci_dependencies.sh -o circleci_dependencies.sh
               chmod +x circleci_dependencies.sh
               ./circleci_dependencies.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
             command: |
               pip install git+https://github.com/mne-tools/mne-python@main
               pip install PyQt6 pyvistaqt
-              pip install sphinx-copybutton sphinx-issues sphinx-extensions sphinx-autodoc-typehints sphinxcontrib-bibtex 
+              pip install sphinx-copybutton sphinx-issues sphinx-autodoc-typehints sphinxcontrib-bibtex 
               curl https://raw.githubusercontent.com/mne-tools/mne-python/main/tools/circleci_dependencies.sh -o circleci_dependencies.sh
               chmod +x circleci_dependencies.sh
               ./circleci_dependencies.sh

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -44,7 +44,7 @@ jobs:
         include:
           # An old one
           - os: ubuntu-latest
-            python-version: "3.8"
+            python-version: "3.9"
     steps:
       - uses: actions/checkout@v4
       - uses: pyvista/setup-headless-display-action@main
@@ -103,7 +103,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python-version: "3.8"
+            python-version: "3.9"
             mne-version: mne-main
           - os: ubuntu-latest
             python-version: "3.11"

--- a/mne_connectivity/envelope.py
+++ b/mne_connectivity/envelope.py
@@ -100,7 +100,7 @@ def envelope_correlation(data, names=None,
             data.add_annotations_to_metadata(overwrite=True)
         metadata = data.metadata
         # get the actual data in numpy
-        data = data.get_data()
+        data = data.get_data(copy=False)
     else:
         metadata = None
 

--- a/mne_connectivity/envelope.py
+++ b/mne_connectivity/envelope.py
@@ -5,6 +5,8 @@
 #
 # License: BSD (3-clause)
 
+import inspect
+
 import numpy as np
 from mne import BaseEpochs
 from mne.filter import next_fast_len
@@ -100,7 +102,11 @@ def envelope_correlation(data, names=None,
             data.add_annotations_to_metadata(overwrite=True)
         metadata = data.metadata
         # get the actual data in numpy
-        data = data.get_data(copy=False)
+        # XXX: remove logic once support for mne<1.6 is dropped
+        kwargs = dict()
+        if "copy" in inspect.getfullargspec(data.get_data).kwonlyargs:
+            kwargs["copy"] = False
+        data = data.get_data(**kwargs)
     else:
         metadata = None
 

--- a/mne_connectivity/spectral/epochs.py
+++ b/mne_connectivity/spectral/epochs.py
@@ -201,7 +201,11 @@ def _check_rank_input(rank, data, indices):
         rank = np.zeros((2, len(indices[0])), dtype=int)
 
         if isinstance(data, BaseEpochs):
-            data_arr = data.get_data(copy=False)
+            # XXX: remove logic once support for mne<1.6 is dropped
+            kwargs = dict()
+            if "copy" in inspect.getfullargspec(data.get_data).kwonlyargs:
+                kwargs["copy"] = False
+            data_arr = data.get_data(**kwargs)
         else:
             data_arr = data
 

--- a/mne_connectivity/spectral/epochs.py
+++ b/mne_connectivity/spectral/epochs.py
@@ -201,7 +201,7 @@ def _check_rank_input(rank, data, indices):
         rank = np.zeros((2, len(indices[0])), dtype=int)
 
         if isinstance(data, BaseEpochs):
-            data_arr = data.get_data()
+            data_arr = data.get_data(copy=False)
         else:
             data_arr = data
 

--- a/mne_connectivity/spectral/time.py
+++ b/mne_connectivity/spectral/time.py
@@ -325,7 +325,7 @@ def spectral_connectivity_time(data, freqs, method='coh', average=False,
         sfreq = data.info['sfreq']
         events = data.events
         event_id = data.event_id
-        n_epochs, n_signals, n_times = data.get_data().shape
+        n_epochs, n_signals, n_times = data.get_data(copy=False).shape
         # Extract metadata from the Epochs data structure.
         # Make Annotations persist through by adding them to the metadata.
         metadata = data.metadata
@@ -338,7 +338,7 @@ def spectral_connectivity_time(data, freqs, method='coh', average=False,
         if hasattr(data, 'annotations') and not annots_in_metadata:
             data.add_annotations_to_metadata(overwrite=True)
         metadata = data.metadata
-        data = data.get_data()
+        data = data.get_data(copy=False)
     else:
         data = np.asarray(data)
         n_epochs, n_signals, n_times = data.shape

--- a/mne_connectivity/spectral/time.py
+++ b/mne_connectivity/spectral/time.py
@@ -4,6 +4,8 @@
 #
 # License: BSD (3-clause)
 
+import inspect
+
 import numpy as np
 import xarray as xr
 from mne.epochs import BaseEpochs
@@ -325,7 +327,6 @@ def spectral_connectivity_time(data, freqs, method='coh', average=False,
         sfreq = data.info['sfreq']
         events = data.events
         event_id = data.event_id
-        n_epochs, n_signals, n_times = data.get_data(copy=False).shape
         # Extract metadata from the Epochs data structure.
         # Make Annotations persist through by adding them to the metadata.
         metadata = data.metadata
@@ -338,7 +339,12 @@ def spectral_connectivity_time(data, freqs, method='coh', average=False,
         if hasattr(data, 'annotations') and not annots_in_metadata:
             data.add_annotations_to_metadata(overwrite=True)
         metadata = data.metadata
-        data = data.get_data(copy=False)
+        # XXX: remove logic once support for mne<1.6 is dropped
+        kwargs = dict()
+        if "copy" in inspect.getfullargspec(data.get_data).kwonlyargs:
+            kwargs["copy"] = False
+        data = data.get_data(**kwargs)
+        n_epochs, n_signals, n_times = data.shape
     else:
         data = np.asarray(data)
         n_epochs, n_signals, n_times = data.shape

--- a/mne_connectivity/vector_ar/var.py
+++ b/mne_connectivity/vector_ar/var.py
@@ -144,7 +144,7 @@ def vector_auto_regression(
         metadata = data.metadata
 
         # get the actual data in numpy
-        data = data.get_data()
+        data = data.get_data(copy=False)
     else:
         metadata = None
 

--- a/mne_connectivity/vector_ar/var.py
+++ b/mne_connectivity/vector_ar/var.py
@@ -1,3 +1,5 @@
+import inspect
+
 import numpy as np
 import scipy
 from scipy.linalg import sqrtm
@@ -144,7 +146,12 @@ def vector_auto_regression(
         metadata = data.metadata
 
         # get the actual data in numpy
-        data = data.get_data(copy=False)
+        # get the actual data in numpy
+        # XXX: remove logic once support for mne<1.6 is dropped
+        kwargs = dict()
+        if "copy" in inspect.getfullargspec(data.get_data).kwonlyargs:
+            kwargs["copy"] = False
+        data = data.get_data(**kwargs)
     else:
         metadata = None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 scipy
-mne>=1.6
+mne>=1.3
 xarray
 netCDF4
 h5netcdf

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 scipy
-mne>=1.3
+mne>=1.6
 xarray
 netCDF4
 h5netcdf

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -13,4 +13,3 @@ sphinxcontrib-bibtex
 git+https://github.com/mne-tools/mne-bids@main
 pooch
 mne-qt-browser
-pyqt6

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -13,3 +13,4 @@ sphinxcontrib-bibtex
 git+https://github.com/mne-tools/mne-bids@main
 pooch
 mne-qt-browser
+pyqt6

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -13,3 +13,5 @@ sphinxcontrib-bibtex
 git+https://github.com/mne-tools/mne-bids@main
 pooch
 mne-qt-browser
+PyQt6
+pyvistaqt


### PR DESCRIPTION
Following [#12121](https://github.com/mne-tools/mne-python/pull/12121) in mne-python, the dev. version of MNE, the behaviour of the `Epochs.get_data()` method has been changed such that in v1.7, a copy of the data will be returned by default (rather than the current view).

Without specifying the `copy` parameter, a `FutureWarning` is raised:
`FutureWarning: The current default of copy=False will change to copy=True in 1.7. Set the value of copy explicitly to avoid this warning`

This is causing several of the CI tests to fail when using the MNE dev. version.

## Changes

Explicitly set `copy=False` in all instances where `Epochs.get_data() is called`. As I understand it the returned data is not modified itself, so returning a view should be sufficient.

**N.B.**: Since the `copy` parameter was added in MNE v1.6, we need to update the MNE version in `requirements.txt` to >= 1.6.