### PR TITLE
[BUG] Inconsistent lengths of `indices` and `rank` does not raise an error 

### DIFF
--- a/mne_connectivity/spectral/epochs_multivariate.py
+++ b/mne_connectivity/spectral/epochs_multivariate.py
@@ -48,6 +48,12 @@ def _check_rank_input(rank, data, indices):
         rank = tuple((np.array(rank[0]), np.array(rank[1])))
 
     else:
+        if (
+            len(rank) != 2 or len(rank[0]) != len(indices[0]) or
+            len(rank[1]) != len(indices[1])
+        ):
+            raise ValueError('rank argument must have shape (2, n_cons), '
+                             'according to n_cons in the indices')
         for seed_idcs, target_idcs, seed_rank, target_rank in zip(
                 indices[0], indices[1], rank[0], rank[1]):
             if not (0 < seed_rank <= len(seed_idcs) and

--- a/mne_connectivity/spectral/tests/test_spectral.py
+++ b/mne_connectivity/spectral/tests/test_spectral.py
@@ -657,6 +657,16 @@ def test_multivar_spectral_connectivity_epochs_error_catch(method, mode):
         spectral_connectivity_epochs(
             data, method=method, mode=mode, indices=indices,
             sfreq=sfreq, rank=too_high_rank, cwt_freqs=cwt_freqs)
+    too_few_rank = ([], [])
+    with pytest.raises(ValueError, match='rank argument must have shape'):
+        spectral_connectivity_epochs(
+            data, method=method, mode=mode, indices=indices,
+            sfreq=sfreq, rank=too_few_rank, cwt_freqs=cwt_freqs)
+    too_much_rank = (np.array([2, 2]), np.array([2, 2]))
+    with pytest.raises(ValueError, match='rank argument must have shape'):
+        spectral_connectivity_epochs(
+            data, method=method, mode=mode, indices=indices,
+            sfreq=sfreq, rank=too_much_rank, cwt_freqs=cwt_freqs)
 
     # check rank-deficient data caught
     bad_data = data.copy()
@@ -1236,6 +1246,16 @@ def test_multivar_spectral_connectivity_time_error_catch(method, mode):
         spectral_connectivity_time(
             data, freqs, method=method, indices=indices, sfreq=sfreq,
             mode=mode, rank=too_high_rank)
+    too_few_rank = ([], [])
+    with pytest.raises(ValueError, match='rank argument must have shape'):
+        spectral_connectivity_time(
+            data, freqs, method=method, indices=indices, sfreq=sfreq,
+            mode=mode, rank=too_few_rank)
+    too_much_rank = (np.array([2, 2]), np.array([2, 2]))
+    with pytest.raises(ValueError, match='rank argument must have shape'):
+        spectral_connectivity_time(
+            data, freqs, method=method, indices=indices, sfreq=sfreq,
+            mode=mode, rank=too_much_rank)
 
     # check all-to-all conn. computed for MIC/MIM when no indices given
     if method in ['mic', 'mim']:


### PR DESCRIPTION
## Problem

A small but notable bug I just came across:

`indices` and `rank` should both have shape `(2, n_cons)`, however if the number of connections differs, e.g.
```
indices = ([[0, 1], [2, 3]],  # 2 seeds
           [[4, 5], [6, 7]])  # 2 targets

rank = ([2],  # 1 seed
        [2])  # 1 target
```
this does not immediately raise an error. Instead, the use of `zip` elsewhere in the code to iterate over the entries of `indices` and `rank` for each connection means that only the results for the smallest number of connections (in the above example 1 of 2) would be processed.

Example of where `zip` is used:
https://github.com/mne-tools/mne-connectivity/blob/28c3895754626b1ebc6b4dc8523079b52ac8f6b7/mne_connectivity/spectral/epochs_multivariate.py#L185-L186

<br>

## Proposed fix

Simply adding a check in `_check_rank_input` that the number of connections in `indices` and `rank` match is enough to catch this early on:

https://github.com/mne-tools/mne-connectivity/blob/28c3895754626b1ebc6b4dc8523079b52ac8f6b7/mne_connectivity/spectral/epochs_multivariate.py#L51-L56

<br>

I have also updated the unit tests to reflect this change.

<br>

Sorry for letting this slip through!