### PR TITLE
type-check data input to spectral_connectivity_time

### DIFF
--- a/mne_connectivity/spectral/tests/test_spectral.py
+++ b/mne_connectivity/spectral/tests/test_spectral.py
@@ -1528,6 +1528,10 @@ def test_multivar_spectral_connectivity_time_error_catch(method, mode):
     indices = (np.array([[0, 1]]), np.array([[2, 3]]))
     freqs = np.arange(10, 25 + 1)
 
+    # test type-checking of data
+    with pytest.raises(TypeError, match="must be an instance of Epochs or a NumPy arr"):
+        spectral_connectivity_time(data="foo", freqs=freqs)
+
     # check bad indices without nested array caught
     with pytest.raises(
         TypeError, match="multivariate indices must contain array-likes"

--- a/mne_connectivity/spectral/time.py
+++ b/mne_connectivity/spectral/time.py
@@ -11,7 +11,7 @@ import xarray as xr
 from mne.epochs import BaseEpochs
 from mne.parallel import parallel_func
 from mne.time_frequency import dpss_windows, tfr_array_morlet, tfr_array_multitaper
-from mne.utils import logger, verbose
+from mne.utils import _validate_type, logger, verbose
 
 from ..base import EpochSpectralConnectivity, SpectralConnectivity
 from ..utils import _check_multivariate_indices, check_indices, fill_doc
@@ -339,6 +339,7 @@ def spectral_connectivity_time(
     events = None
     event_id = None
     # extract data from Epochs object
+    _validate_type(data, (np.ndarray, BaseEpochs), "`data`", "Epochs or a NumPy array")
     if isinstance(data, BaseEpochs):
         names = data.ch_names
         sfreq = data.info["sfreq"]


### PR DESCRIPTION
PR Description
--------------

Make it easier to figure out what went wrong when `spectral_connectivity_time` is passed a Raw instead of Epochs.

https://mne.discourse.group/t/inhomogeneous-shape-error-when-using-mne-connectivity-spectral-connectivity-time/8198

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-connectivity/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
