### PR TITLE
[DOC] Add methods list to `epochs` function and fix formatting of list in `time` function

### DIFF
--- a/mne_connectivity/spectral/epochs.py
+++ b/mne_connectivity/spectral/epochs.py
@@ -645,8 +645,26 @@ def spectral_connectivity_epochs(
     method : str | list of str
         Connectivity measure(s) to compute. These can be ``['coh', 'cohy',
         'imcoh', 'mic', 'mim', 'plv', 'ciplv', 'ppc', 'pli', 'dpli', 'wpli',
-        'wpli2_debiased', 'gc', 'gc_tr']``. Multivariate methods (``['mic',
-        'mim', 'gc', 'gc_tr]``) cannot be called with the other methods.
+        'wpli2_debiased', 'gc', 'gc_tr']``. These are:
+
+        * %(coh)s
+        * %(cohy)s
+        * %(imcoh)s
+        * %(mic)s
+        * %(mim)s
+        * %(plv)s
+        * %(ciplv)s
+        * %(ppc)s
+        * %(pli)s
+        * %(pli2_unbiased)s
+        * %(dpli)s
+        * %(wpli)s
+        * %(wpli2_debiased)s
+        * %(gc)s
+        * %(gc_tr)s
+
+        Multivariate methods (``['mic', 'mim', 'gc', 'gc_tr]``) cannot be
+        called with the other methods.
     indices : tuple of array | None
         Two arrays with indices of connections for which to compute
         connectivity. If a bivariate method is called, each array for the seeds

--- a/mne_connectivity/spectral/time.py
+++ b/mne_connectivity/spectral/time.py
@@ -69,18 +69,19 @@ def spectral_connectivity_time(
         Only the frequencies within the range specified by ``fmin`` and
         ``fmax`` are used.
     method : str | list of str
-        Connectivity measure(s) to compute. These can be
-        ``['coh', 'mic', 'mim', 'plv', 'ciplv', 'pli', 'wpli', 'gc',
-        'gc_tr']``. These are:
-        * 'coh'   : Coherence
-        * 'mic'   : Maximised Imaginary part of Coherency (MIC)
-        * 'mim'   : Multivariate Interaction Measure (MIM)
-        * 'plv'   : Phase-Locking Value (PLV)
-        * 'ciplv' : Corrected imaginary Phase-Locking Value
-        * 'pli'   : Phase-Lag Index
-        * 'wpli'  : Weighted Phase-Lag Index
-        * 'gc'    : State-space Granger Causality (GC)
-        * 'gc_tr' : State-space GC on time-reversed signals
+        Connectivity measure(s) to compute. These can be ``['coh', 'mic',
+        'mim', 'plv', 'ciplv', 'pli', 'wpli', 'gc', 'gc_tr']``. These are:
+
+        * %(coh)s
+        * %(mic)s
+        * %(mim)s
+        * %(plv)s
+        * %(ciplv)s
+        * %(pli)s
+        * %(wpli)s
+        * %(gc)s
+        * %(gc_tr)s
+
         Multivariate methods (``['mic', 'mim', 'gc', 'gc_tr]``) cannot be
         called with the other methods.
     average : bool

--- a/mne_connectivity/utils/docs.py
+++ b/mne_connectivity/utils/docs.py
@@ -68,6 +68,22 @@ docdict[
         as xarray ``attrs``.
 """
 
+docdict["coh"] = "'coh' : Coherence"
+docdict["cohy"] = "'cohy' : Coherency"
+docdict["imcoh"] = "'imcoh' : Imaginary part of coherency"
+docdict["mic"] = "'mic' : Maximised Imaginary part of Coherency (MIC)"
+docdict["mim"] = "'mim' : Multivariate Interaction Measure (MIM)"
+docdict["plv"] = "'plv' : Phase-Locking Value (PLV)"
+docdict["ciplv"] = "'ciplv' : Corrected Imaginary PLV (ciPLV)"
+docdict["ppc"] = "'ppc' : Pairwise Phase Consistency (PPC)"
+docdict["pli"] = "'pli' : Phase Lag Index (PLI)"
+docdict["pli2_unbiased"] = "'pli2_unbiased' : Unbiased estimator of squared PLI"
+docdict["dpli"] = "'dpli' : Directed PLI (DPLI)"
+docdict["wpli"] = "'wpli' : Weighted PLI (WPLI)"
+docdict["wpli2_debiased"] = "'wpli2_debiased' : Debiased estimator of squared WPLI"
+docdict["gc"] = "'gc' : State-space Granger Causality (GC)"
+docdict["gc_tr"] = "'gc_tr' : State-space GC on time-reversed signals"
+
 # Downstream container variables
 docdict[
     "freqs"


### PR DESCRIPTION
Follow up from #170:

- Added newlines before and after methods list in `spectral_connectivity_time()` to ensure it renders properly.
- Added equivalent list to `spectral_connectivity_epochs()`.
- Added definition of individual methods to `docs.py`.

@larsoner Please let me know if the definition of strings in `docs.py` works for you.

Cheers!