### PR TITLE
Fix failing unit tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -51,7 +51,7 @@ jobs:
           pyvista: false
       - name: Install dependencies
         run: |
-          pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip setuptools wheel
           pip install --upgrade --upgrade-strategy eager .[test]
       - if: matrix.mne-version == 'mne-stable'
         run: pip install --upgrade mne

--- a/benchmarks/bench_var.py
+++ b/benchmarks/bench_var.py
@@ -7,6 +7,7 @@ This file benchmarks mne-connectivity VAR implementation
 against that of statsmodels to prevent us from creating
 a dependency on statsmodels.
 """
+
 import numpy as np
 from memory_profiler import profile
 from statsmodels.tsa.vector_ar.var_model import VAR

--- a/benchmarks/single_epoch_conn.py
+++ b/benchmarks/single_epoch_conn.py
@@ -3,10 +3,11 @@
 Generate Test Dataset for Spectral Connectivity Over Time With Frites
 =====================================================================
 
-As of v0.3, mne-connectivity ported over an implementation for 
+As of v0.3, mne-connectivity ported over an implementation for
 spectral connectivity over epochs. This file will generate the test
 dataset used with Frites v0.4.1.
 """
+
 import mne
 import numpy as np
 from frites.conn import conn_spec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ test = [
   'pandas',
   'pymatreader',
   'PyQt6',
-  'pytest',
+  'pytest<8',
   'pytest-cov',
   'statsmodels',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,8 +110,8 @@ test = [
   'pandas',
   'pymatreader',
   'PyQt6',
-  'pytest<8.0.0',
   'pytest-cov',
+  'pytest<8.0.0',
   'statsmodels',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ test = [
   'pandas',
   'pymatreader',
   'PyQt6',
-  'pytest<8',
+  'pytest<8.0.0',
   'pytest-cov',
   'statsmodels',
 ]


### PR DESCRIPTION
Codestyle checks are failing due to `benchmarks/bench_var.py` and `benchmarks/single_epoch_conn.py` not being properly formatted. See e.g. #163, #171 for failing checks.

Have now run black on these files to hopefully fix things.
