### PR TITLE
[BUG] n_jobs=-1 not working in spectral_connectivity_epochs

### DIFF
--- a/mne_connectivity/spectral/epochs.py
+++ b/mne_connectivity/spectral/epochs.py
@@ -912,7 +912,7 @@ def spectral_connectivity_epochs(
     .. footbibliography::
     """
     if n_jobs != 1:
-        parallel, my_epoch_spectral_connectivity, _ = parallel_func(
+        parallel, my_epoch_spectral_connectivity, n_jobs = parallel_func(
             _epoch_spectral_connectivity, n_jobs, verbose=verbose
         )
 
@@ -1094,7 +1094,7 @@ def spectral_connectivity_epochs(
                     n_cons=n_cons, n_freqs=n_freqs, n_times=n_times_spectrum
                 )
                 if method[mtype_i] in _multivariate_methods:
-                    method_params.update(dict(n_signals=n_signals_use))
+                    method_params.update(dict(n_signals=n_signals_use, n_jobs=n_jobs))
                     if method[mtype_i] in _gc_methods:
                         method_params.update(dict(n_lags=gc_n_lags))
                 con_methods.append(mtype(**method_params))


### PR DESCRIPTION
Suggested fix for #176 where `n_jobs=-1` does not result in CSD computation being properly parallelised over epochs.

This fix makes sure `n_jobs=-1` is converted to the maximum number of workers before CSD computation occurs.

I think also when refactoring some of the multivariate connectivity methods some months ago the `n_jobs` parameter was not being properly passed to the classes. This is also now fixed.

As far as I understand, these issues are specific to `spectral_connectivity_epochs()` and do not affect `spectral_connectivity_time()`.

The current unit tests for parallelisation were only using `n_jobs > 1` and never `n_jobs=-1`. However, even if `n_jobs=-1` was being used this issue would not be caught, as the tests only check that multiple workers can be allocated (which they can) but not that e.g. the proper number of epoch blocks are worked on in parallel.
Not sure how this could be checked. Is there some way the logging output could be queried?