### PR TITLE
[MAINT] Fix codespell error

### DIFF
--- a/examples/compare_coherency_methods.py
+++ b/examples/compare_coherency_methods.py
@@ -512,7 +512,7 @@ fig.suptitle("Coh vs. ImCoh\n$\pm$45° & $\pm$90° interactions")
 # Conclusion
 # ----------
 #
-# Altogether, there are clear scenarious in which different coherency-based
+# Altogether, there are clear scenarios in which different coherency-based
 # methods are appropriate.
 #
 # Methods based on the imaginary part of coherency alone (ImCoh, MIC, MIM)


### PR DESCRIPTION
New codespell version catches a spelling mistake that was previously being missed: "scenarious" which should be "scenarios" in the `compare_coherency_methods.py` example.