### PR TITLE
[GSOC] Store multivariate connectivity filters

### DIFF
--- a/mne_connectivity/spectral/epochs_multivariate.py
+++ b/mne_connectivity/spectral/epochs_multivariate.py
@@ -179,6 +179,15 @@ class _EpochMeanMultivariateConEstBase(_AbstractConEstBase):
             self._acc, (self.n_signals, self.n_signals, self.n_freqs, self.n_times)
         ).transpose(3, 2, 0, 1)
 
+    def reshape_results(self):
+        """Remove time dimension from results, if necessary."""
+        if self.n_times == 0:
+            self.con_scores = self.con_scores[..., 0]
+            if self.patterns is not None:
+                self.patterns = self.patterns[..., 0]
+            if self.filters is not None:
+                self.filters = self.filters[..., 0]
+
 
 class _MultivariateCohEstBase(_EpochMeanMultivariateConEstBase):
     """Base estimator for multivariate coherency methods.
@@ -322,13 +331,6 @@ class _MultivariateCohEstBase(_EpochMeanMultivariateConEstBase):
             )
 
         return np.real(T)  # make T real if check passes
-
-    def reshape_results(self):
-        """Remove time dimension from results, if necessary."""
-        if self.n_times == 0:
-            self.con_scores = self.con_scores[..., 0]
-            if self.patterns is not None:
-                self.patterns = self.patterns[..., 0]
 
 
 def _invsqrtm(C, T, n_seeds):
@@ -1026,11 +1028,6 @@ class _GCEstBase(_EpochMeanMultivariateConEstBase):
         W = np.matmul(W.transpose(0, 2, 1), W)
 
         return V[np.ix_(times, seeds, seeds)] - W
-
-    def reshape_results(self):
-        """Remove time dimension from con. scores, if necessary."""
-        if self.n_times == 0:
-            self.con_scores = self.con_scores[:, :, 0]
 
 
 def _gc_compute_H(A, C, K, z_k, I_n, I_m):


### PR DESCRIPTION
## Problem

One requirement of the decoding module we will introduce in the GSoC project is access to the multivariate filters, which are currently computed in the connectivity estimator class, but never stored. Discussed in more detail in #182.

I thought submitting this as a separate PR from the wider decoding module would help keep diff size small and make reviewing the changes easier.

## Solution

Add a `filters` attribute to the multivariate connectivity estimator classes similar to the existing `patterns` attribute.

However, since this will only be required in the case of the connectivity estimator being used in the decoding module (not with `spectral_connectivity_epochs/time()` functions), also add a `store_filters` flag which is by default `False`.
https://github.com/tsbinns/mne-connectivity/blob/fc7e2a71924f7ead47b8024a10458014c0043526/mne_connectivity/spectral/epochs_multivariate.py#L197-L202

When `store_filters=True`, the `filters` attribute will be set as a placeholder array where filters can be stored (again, similar to how `patterns` works), however when `False`, `filters` will remain as `None` to reduce memory usage.
https://github.com/tsbinns/mne-connectivity/blob/fc7e2a71924f7ead47b8024a10458014c0043526/mne_connectivity/spectral/epochs_multivariate.py#L220-L223

It would be sufficient to pass `store_filters` to the `_MultivariateCohEstBase` estimator class and have the `filters` attribute there, however I have passed `store_filters` to the parent `_EpochMeanMultivariateConEstBase` class and have the `filters` attribute here. This keeps things in line with the `patterns` attribute which is also currently only used for daughters of the `_MultivariateCohEstBase`, but this may not be the case in the future if other filter-based non-coherency methods are implemented, so this approach is more flexible and forward-looking.
https://github.com/tsbinns/mne-connectivity/blob/fc7e2a71924f7ead47b8024a10458014c0043526/mne_connectivity/spectral/epochs_multivariate.py#L103-L119

Other than that, it's a very simple case of just storing the filters when appropriate.
**MIC**
https://github.com/tsbinns/mne-connectivity/blob/fc7e2a71924f7ead47b8024a10458014c0043526/mne_connectivity/spectral/epochs_multivariate.py#L474-L476

**CaCoh**
https://github.com/tsbinns/mne-connectivity/blob/fc7e2a71924f7ead47b8024a10458014c0043526/mne_connectivity/spectral/epochs_multivariate.py#L672-L674

Since `store_filters` is by default `False`, no behaviour has been changed. Since this is also an internal feature there are no new unit tests to add at this stage (would all come when the decoding module is implemented proper).

## Other points

When implementing this, I also realised it was also possible to refactor the `reshape_results()` method in the multivariate connectivity estimator classes which were separately implemented for the coherency and Granger methods but doing the same thing, so that has been cleaned up.
https://github.com/tsbinns/mne-connectivity/blob/fc7e2a71924f7ead47b8024a10458014c0043526/mne_connectivity/spectral/epochs_multivariate.py#L182-L189
