### PR TITLE
[MAINT] Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Build
+on:
+  release:
+    types: [published]
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[build]
+      - name: Build package
+        run: python -m build --sdist --wheel
+      - name: Check package
+        run: twine check --strict dist/*
+      - name: Check env vars
+        run: |
+          echo "Triggered by: ${{ github.event_name }}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+  # PyPI on release
+  pypi:
+    needs: package
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -4,3 +4,5 @@ rules:
   line-length: disable
   document-start: disable
   truthy: disable
+  new-lines:
+    type: platform


### PR DESCRIPTION
@larsoner suggested in #181 to modernise publishing to PyPI with trusted artefact publishing on release.

Was suggested to use the MNE-BIDS-Pipeline workflow as a template and removing the username/password stuff: https://github.com/mne-tools/mne-bids-pipeline/blob/main/.github/workflows/release.yml

Haven't touched the existing `publish_release.yml` workflow. Very minor but wasn't sure if we should use this name, rename to `release.yml`, ygm.

Also had to add a new rule to the `.yamllint.yml` config for pre-commit yamllint check to pass on my windows machine due to unix vs. dos line endings.