### PR TITLE
[MAINT] Modernise super method calls

### DIFF
--- a/mne_connectivity/base.py
+++ b/mne_connectivity/base.py
@@ -923,7 +923,7 @@ class SpectralConnectivity(BaseConnectivity, SpectralMixin):
         n_epochs_used=None,
         **kwargs,
     ):
-        super(SpectralConnectivity, self).__init__(
+        super().__init__(
             data,
             names=names,
             method=method,
@@ -980,7 +980,7 @@ class TemporalConnectivity(BaseConnectivity, TimeMixin):
         n_epochs_used=None,
         **kwargs,
     ):
-        super(TemporalConnectivity, self).__init__(
+        super().__init__(
             data,
             names=names,
             method=method,
@@ -1031,7 +1031,7 @@ class SpectroTemporalConnectivity(BaseConnectivity, SpectralMixin, TimeMixin):
         n_epochs_used=None,
         **kwargs,
     ):
-        super(SpectroTemporalConnectivity, self).__init__(
+        super().__init__(
             data,
             names=names,
             method=method,
@@ -1079,7 +1079,7 @@ class EpochSpectralConnectivity(SpectralConnectivity):
         spec_method=None,
         **kwargs,
     ):
-        super(EpochSpectralConnectivity, self).__init__(
+        super().__init__(
             data,
             freqs=freqs,
             names=names,
@@ -1116,7 +1116,7 @@ class EpochTemporalConnectivity(TemporalConnectivity):
     def __init__(
         self, data, times, n_nodes, names=None, indices="all", method=None, **kwargs
     ):
-        super(EpochTemporalConnectivity, self).__init__(
+        super().__init__(
             data,
             times=times,
             names=names,
@@ -1163,7 +1163,7 @@ class EpochSpectroTemporalConnectivity(SpectroTemporalConnectivity):
         spec_method=None,
         **kwargs,
     ):
-        super(EpochSpectroTemporalConnectivity, self).__init__(
+        super().__init__(
             data,
             names=names,
             freqs=freqs,
@@ -1210,7 +1210,7 @@ class Connectivity(BaseConnectivity):
         n_epochs_used=None,
         **kwargs,
     ):
-        super(Connectivity, self).__init__(
+        super().__init__(
             data,
             names=names,
             method=method,
@@ -1258,7 +1258,7 @@ class EpochConnectivity(BaseConnectivity):
         n_epochs_used=None,
         **kwargs,
     ):
-        super(EpochConnectivity, self).__init__(
+        super().__init__(
             data,
             names=names,
             method=method,

--- a/mne_connectivity/conftest.py
+++ b/mne_connectivity/conftest.py
@@ -116,7 +116,7 @@ def matplotlib_config():
 
     class CallbackRegistryReraise(orig):
         def __init__(self, exception_handler=None, signals=None):
-            super(CallbackRegistryReraise, self).__init__(exception_handler)
+            super().__init__(exception_handler)
 
     cbook.CallbackRegistry = CallbackRegistryReraise
 

--- a/mne_connectivity/spectral/epochs_bivariate.py
+++ b/mne_connectivity/spectral/epochs_bivariate.py
@@ -58,7 +58,7 @@ class _CohEstBase(_EpochMeanConEstBase):
     accumulate_psd = True
 
     def __init__(self, n_cons, n_freqs, n_times):
-        super(_CohEstBase, self).__init__(n_cons, n_freqs, n_times)
+        super().__init__(n_cons, n_freqs, n_times)
 
         # allocate space for accumulation of CSD
         self._acc = np.zeros(self.csd_shape, dtype=np.complex128)
@@ -114,7 +114,7 @@ class _PLVEst(_EpochMeanConEstBase):
     accumulate_psd = False
 
     def __init__(self, n_cons, n_freqs, n_times):
-        super(_PLVEst, self).__init__(n_cons, n_freqs, n_times)
+        super().__init__(n_cons, n_freqs, n_times)
 
         # allocate accumulator
         self._acc = np.zeros(self.csd_shape, dtype=np.complex128)
@@ -138,7 +138,7 @@ class _ciPLVEst(_EpochMeanConEstBase):
     accumulate_psd = False
 
     def __init__(self, n_cons, n_freqs, n_times):
-        super(_ciPLVEst, self).__init__(n_cons, n_freqs, n_times)
+        super().__init__(n_cons, n_freqs, n_times)
 
         # allocate accumulator
         self._acc = np.zeros(self.csd_shape, dtype=np.complex128)
@@ -167,7 +167,7 @@ class _PLIEst(_EpochMeanConEstBase):
     accumulate_psd = False
 
     def __init__(self, n_cons, n_freqs, n_times):
-        super(_PLIEst, self).__init__(n_cons, n_freqs, n_times)
+        super().__init__(n_cons, n_freqs, n_times)
 
         # allocate accumulator
         self._acc = np.zeros(self.csd_shape)
@@ -209,7 +209,7 @@ class _DPLIEst(_EpochMeanConEstBase):
     accumulate_psd = False
 
     def __init__(self, n_cons, n_freqs, n_times):
-        super(_DPLIEst, self).__init__(n_cons, n_freqs, n_times)
+        super().__init__(n_cons, n_freqs, n_times)
 
         # allocate accumulator
         self._acc = np.zeros(self.csd_shape)
@@ -235,7 +235,7 @@ class _WPLIEst(_EpochMeanConEstBase):
     accumulate_psd = False
 
     def __init__(self, n_cons, n_freqs, n_times):
-        super(_WPLIEst, self).__init__(n_cons, n_freqs, n_times)
+        super().__init__(n_cons, n_freqs, n_times)
 
         # store  both imag(csd) and abs(imag(csd))
         acc_shape = (2,) + self.csd_shape
@@ -274,7 +274,7 @@ class _WPLIDebiasedEst(_EpochMeanConEstBase):
     accumulate_psd = False
 
     def __init__(self, n_cons, n_freqs, n_times):
-        super(_WPLIDebiasedEst, self).__init__(n_cons, n_freqs, n_times)
+        super().__init__(n_cons, n_freqs, n_times)
         # store imag(csd), abs(imag(csd)), imag(csd)^2
         acc_shape = (3,) + self.csd_shape
         self._acc = np.zeros(acc_shape)
@@ -318,7 +318,7 @@ class _PPCEst(_EpochMeanConEstBase):
     accumulate_psd = False
 
     def __init__(self, n_cons, n_freqs, n_times):
-        super(_PPCEst, self).__init__(n_cons, n_freqs, n_times)
+        super().__init__(n_cons, n_freqs, n_times)
 
         # store csd / abs(csd)
         self._acc = np.zeros(self.csd_shape, dtype=np.complex128)

--- a/mne_connectivity/spectral/epochs_multivariate.py
+++ b/mne_connectivity/spectral/epochs_multivariate.py
@@ -190,9 +190,7 @@ class _MultivariateCohEstBase(_EpochMeanMultivariateConEstBase):
     accumulate_psd = False
 
     def __init__(self, n_signals, n_cons, n_freqs, n_times, n_jobs=1):
-        super(_MultivariateCohEstBase, self).__init__(
-            n_signals, n_cons, n_freqs, n_times, n_jobs
-        )
+        super().__init__(n_signals, n_cons, n_freqs, n_times, n_jobs)
 
     def compute_con(self, indices, ranks, n_epochs=1):
         """Compute multivariate coherency methods."""
@@ -658,7 +656,7 @@ class _GCEstBase(_EpochMeanMultivariateConEstBase):
     accumulate_psd = False
 
     def __init__(self, n_signals, n_cons, n_freqs, n_times, n_lags, n_jobs=1):
-        super(_GCEstBase, self).__init__(n_signals, n_cons, n_freqs, n_times, n_jobs)
+        super().__init__(n_signals, n_cons, n_freqs, n_times, n_jobs)
 
         self.freq_res = (self.n_freqs - 1) * 2
         if n_lags >= self.freq_res:


### PR DESCRIPTION
Modernises super method calls by removing explicit passing of class type and self, e.g.:
```
super(MyClass, self).my_method() => super().my_method()
```

Suggested by @drammock & @wmvanvliet: https://github.com/mne-tools/mne-connectivity/pull/193#discussion_r1638555743
