### PR TITLE
[DOC] Update functon-container cross-references and fix incorrect types

### DIFF
--- a/mne_connectivity/base.py
+++ b/mne_connectivity/base.py
@@ -888,7 +888,9 @@ class SpectralConnectivity(BaseConnectivity, SpectralMixin):
 
     See Also
     --------
+    mne_connectivity.phase_slope_index
     mne_connectivity.spectral_connectivity_epochs
+    mne_connectivity.spectral_connectivity_time
     """
 
     expected_n_dim = 2
@@ -998,6 +1000,11 @@ class SpectroTemporalConnectivity(BaseConnectivity, SpectralMixin, TimeMixin):
     %(spec_method)s
     %(n_epochs_used)s
     %(connectivity_kwargs)s
+
+    See Also
+    --------
+    mne_connectivity.phase_slope_index
+    mne_connectivity.spectral_connectivity_epochs
     """
 
     def __init__(
@@ -1045,6 +1052,10 @@ class EpochSpectralConnectivity(SpectralConnectivity):
     %(method)s
     %(spec_method)s
     %(connectivity_kwargs)s
+
+    See Also
+    --------
+    mne_connectivity.spectral_connectivity_time
     """
 
     # whether or not the connectivity occurs over epochs
@@ -1090,6 +1101,11 @@ class EpochTemporalConnectivity(TemporalConnectivity):
     %(indices)s
     %(method)s
     %(connectivity_kwargs)s
+
+    See Also
+    --------
+    mne_connectivity.envelope_correlation
+    mne_connectivity.vector_auto_regression
     """
 
     # whether or not the connectivity occurs over epochs
@@ -1179,7 +1195,6 @@ class Connectivity(BaseConnectivity):
     See Also
     --------
     mne_connectivity.vector_auto_regression
-    mne_connectivity.envelope_correlation
     """
 
     def __init__(
@@ -1224,7 +1239,6 @@ class EpochConnectivity(BaseConnectivity):
     See Also
     --------
     mne_connectivity.vector_auto_regression
-    mne_connectivity.envelope_correlation
     """
 
     # whether or not the connectivity occurs over epochs

--- a/mne_connectivity/effective.py
+++ b/mne_connectivity/effective.py
@@ -46,7 +46,7 @@ def phase_slope_index(
     A positive value means that time series 0 is ahead of time series 1 and
     a negative value means the opposite.
 
-    The PSI is computed from the coherency (see spectral_connectivity_epochs),
+    The PSI is computed from the coherency (see :func:`spectral_connectivity_epochs`),
     details can be found in :footcite:`NolteEtAl2008`.
 
     Parameters
@@ -103,16 +103,13 @@ def phase_slope_index(
 
     Returns
     -------
-    conn : instance of Connectivity
-        Computed connectivity measure(s). Either a
-        ``SpectralConnnectivity``, or ``SpectroTemporalConnectivity``
-        container. The shape of each array is either
-        (n_signals ** 2, n_bands) mode: 'multitaper' or 'fourier'
-        (n_signals ** 2, n_bands, n_times) mode: 'cwt_morlet'
-        when "indices" is None, or
-        (n_con, n_bands) mode: 'multitaper' or 'fourier'
-        (n_con, n_bands, n_times) mode: 'cwt_morlet'
-        when "indices" is specified and "n_con = len(indices[0])".
+    conn : instance of SpectralConnectivity or SpectroTemporalConnectivity
+        Computed connectivity measure(s). Either a :class:`SpectralConnectivity`, or
+        :class:`SpectroTemporalConnectivity` container. The shape of each array is
+        either (n_signals ** 2, n_bands) mode: 'multitaper' or 'fourier' (n_signals **
+        2, n_bands, n_times) mode: 'cwt_morlet' when "indices" is None, or (n_con,
+        n_bands) mode: 'multitaper' or 'fourier' (n_con, n_bands, n_times) mode:
+        'cwt_morlet' when "indices" is specified and "n_con = len(indices[0])".
 
     See Also
     --------

--- a/mne_connectivity/envelope.py
+++ b/mne_connectivity/envelope.py
@@ -40,7 +40,7 @@ def envelope_correlation(
         the correlation matrix will not be returned with
         absolute values.
     log : bool
-        If True (default False), square and take the log before orthonalizing
+        If True (default False), square and take the log before orthogonalizing
         envelopes or computing correlations.
     absolute : bool
         If True (default), then take the absolute value of correlation
@@ -51,7 +51,7 @@ def envelope_correlation(
 
     Returns
     -------
-    corr : instance of EpochConnectivity
+    corr : instance of EpochTemporalConnectivity
         The pairwise orthogonal envelope correlations.
         This matrix is symmetric. The array
         will have three dimensions, the first of which is ``n_epochs``.
@@ -59,21 +59,21 @@ def envelope_correlation(
 
     See Also
     --------
-    mne_connectivity.EpochConnectivity
+    mne_connectivity.EpochTemporalConnectivity
 
     Notes
     -----
     This function computes the power envelope correlation between
     orthogonalized signals :footcite:`HippEtAl2012,KhanEtAl2018`.
 
-    If you would like to combine Epochs after the fact using some
-    function over the Epochs axis, see the ``combine`` function from
-    `EpochConnectivity` classes.
+    If you would like to combine Epochs after the fact using some function over the
+    Epochs axis, see the :meth:`~EpochTemporalConnectivity.combine` method of the
+    :class:`EpochTemporalConnectivity` class.
 
     References
     ----------
     .. footbibliography::
-    """  # noqa
+    """
     _check_option("orthogonalize", orthogonalize, (False, "pairwise"))
     from scipy.signal import hilbert
 

--- a/mne_connectivity/spectral/epochs.py
+++ b/mne_connectivity/spectral/epochs.py
@@ -728,10 +728,11 @@ def spectral_connectivity_epochs(
 
     Returns
     -------
-    con : array | list of array
-        Computed connectivity measure(s). Either an instance of
-        ``SpectralConnectivity`` or ``SpectroTemporalConnectivity``.
-        The shape of the connectivity result will be:
+    con : instance of SpectralConnectivity or SpectroTemporalConnectivity | list
+        Computed connectivity measure(s). An instance of :class:`SpectralConnectivity`,
+        :class:`SpectroTemporalConnectivity`, or a list of instances corresponding to
+        connectivity measures if several connectivity measures are specified. The shape
+        of the connectivity result will be:
 
         - ``(n_cons, n_freqs)`` for multitaper or fourier modes
         - ``(n_cons, n_freqs, n_times)`` for cwt_morlet mode
@@ -759,8 +760,8 @@ def spectral_connectivity_epochs(
     measure is stationary. The spectral measures implemented in this function
     are computed across Epochs. **Thus, spectral measures computed with only
     one Epoch will result in errorful values and spectral measures computed
-    with few Epochs will be unreliable.** Please see
-    ``spectral_connectivity_time`` for time-resolved connectivity estimation.
+    with few Epochs will be unreliable.** Please see :func:`spectral_connectivity_time`
+    for time-resolved connectivity estimation.
 
     The spectral densities can be estimated using a multitaper method with
     digital prolate spheroidal sequence (DPSS) windows, a discrete Fourier

--- a/mne_connectivity/spectral/time.py
+++ b/mne_connectivity/spectral/time.py
@@ -165,16 +165,15 @@ def spectral_connectivity_time(
 
     Returns
     -------
-    con : instance of Connectivity | list
+    con : instance of EpochSpectralConnectivity or SpectralConnectivity | list
         Computed connectivity measure(s). An instance of
-        :class:`EpochSpectralConnectivity`, :class:`SpectralConnectivity`
-        or a list of instances corresponding to connectivity measures if
-        several connectivity measures are specified.
-        The shape of each connectivity dataset is (n_epochs, n_cons, n_freqs).
-        When "indices" is None and a bivariate method is called,
-        "n_cons = n_signals ** 2", or if a multivariate method is called
-        "n_cons = 1". When "indices" is specified, "n_con = len(indices[0])"
-        for bivariate and multivariate methods.
+        :class:`EpochSpectralConnectivity`, :class:`SpectralConnectivity`, or a list of
+        instances corresponding to connectivity measures if several connectivity
+        measures are specified. The shape of each connectivity dataset is ([n_epochs,]
+        n_cons, n_freqs). When "indices" is None and a bivariate method is called,
+        "n_cons = n_signals ** 2", or if a multivariate method is called "n_cons = 1".
+        When "indices" is specified, "n_con = len(indices[0])" for bivariate and
+        multivariate methods.
 
     See Also
     --------

--- a/mne_connectivity/vector_ar/var.py
+++ b/mne_connectivity/vector_ar/var.py
@@ -54,13 +54,14 @@ def vector_auto_regression(
 
     Returns
     -------
-    conn : Connectivity | TemporalConnectivity | EpochConnectivity
+    conn : Connectivity | EpochConnectivity | EpochTemporalConnectivity
         The connectivity data estimated.
 
     See Also
     --------
     mne_connectivity.Connectivity
     mne_connectivity.EpochConnectivity
+    mne_connectivity.EpochTemporalConnectivity
 
     Notes
     -----
@@ -126,7 +127,7 @@ def vector_auto_regression(
     References
     ----------
     .. footbibliography::
-    """  # noqa
+    """
     if model not in ["avg-epochs", "dynamic"]:
         raise ValueError(
             f'"model" parameter must be one of ' f"(avg-epochs, dynamic), not {model}."


### PR DESCRIPTION
Discussed partially in call with @larsoner & @wmvanvliet.

There is a `See Also` section of the docstrings where connectivity functions link to the connectivity containers they return, and the container classes like to the connectivity functions they are returned from. These references were not present everywhere, and I wanted to make them consistent.

However, I found there were existing references where functions were linking to classes they did not return, and classes were linking to functions they were not returned from. There were also cases where the types of container classes returned in connectivity function docstrings were wrong.

There is also an inconsistency where the `Connectivity` class is sometimes used as an indicator of the generic `BaseConnectivity` class, and sometimes used to refer to the `Connectivity` class specifically. Just thought this could be a potential point of confusion. E.g. `Connectivity` is listed as the sole accepted class type in `plot_connectivity_circle` when anything inheriting from `BaseConnectivity` is allowed.
In this case I didn't change anything because I wasn't sure if others consider it problematic.