### PR TITLE
[MAINT] Add `plot_sensors_connectivity` data shape check

### DIFF
--- a/mne_connectivity/viz/_3d.py
+++ b/mne_connectivity/viz/_3d.py
@@ -57,6 +57,11 @@ def plot_sensors_connectivity(
 
     renderer = _get_renderer(size=(600, 600), bgcolor=(0.5, 0.5, 0.5))
 
+    if con.ndim != 2 or con.shape[0] != con.shape[1]:
+        raise ValueError(
+            "Connectivity data must be a 2D array of shape (channels, channels)"
+        )
+
     picks = _picks_to_idx(info, picks)
     if len(picks) != len(con):
         raise ValueError(

--- a/mne_connectivity/viz/_3d.py
+++ b/mne_connectivity/viz/_3d.py
@@ -59,7 +59,8 @@ def plot_sensors_connectivity(
 
     if con.ndim != 2 or con.shape[0] != con.shape[1]:
         raise ValueError(
-            "Connectivity data must be a 2D array of shape (channels, channels)"
+            "Connectivity data must be a 2D array of shape (n_channels, n_channels), "
+            f"got shape {con.shape}"
         )
 
     picks = _picks_to_idx(info, picks)

--- a/mne_connectivity/viz/tests/test_3d.py
+++ b/mne_connectivity/viz/tests/test_3d.py
@@ -27,6 +27,10 @@ def test_plot_sensors_connectivity(renderer):
     info = raw.info
     with pytest.raises(TypeError, match="must be an instance of Info"):
         plot_sensors_connectivity(info="foo", con=con, picks=picks)
+    with pytest.raises(ValueError, match="Connectivity data must be a 2D array"):
+        plot_sensors_connectivity(info=info, con=np.expand_dims(con, 3), picks=picks)
+    with pytest.raises(ValueError, match="2D array of shape (channels, channels)"):
+        plot_sensors_connectivity(info=info, con=con[:, :-1], picks=picks)
     with pytest.raises(ValueError, match="does not correspond to the size"):
         plot_sensors_connectivity(info=info, con=con[::2, ::2], picks=picks)
     cmap = "viridis"

--- a/mne_connectivity/viz/tests/test_3d.py
+++ b/mne_connectivity/viz/tests/test_3d.py
@@ -29,7 +29,7 @@ def test_plot_sensors_connectivity(renderer):
         plot_sensors_connectivity(info="foo", con=con, picks=picks)
     with pytest.raises(ValueError, match="Connectivity data must be a 2D array"):
         plot_sensors_connectivity(info=info, con=np.expand_dims(con, 3), picks=picks)
-    with pytest.raises(ValueError, match="2D array of shape (channels, channels)"):
+    with pytest.raises(ValueError, match="2D array of shape (n_channels, n_channels)"):
         plot_sensors_connectivity(info=info, con=con[:, :-1], picks=picks)
     with pytest.raises(ValueError, match="does not correspond to the size"):
         plot_sensors_connectivity(info=info, con=con[::2, ::2], picks=picks)


### PR DESCRIPTION
PR Description
--------------

Discussed in call with @larsoner.

`plot_sensors_connectivity` expects data to be a 2D (channels x channels) array, however the input shape is never checked. This PR adds such a check and corresponding unit tests.

No similar problem for `plot_connectivity_circle`, as data shape is checked here.