### PR TITLE
[DOC] Switch Granger causality to expected failing example

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -342,6 +342,7 @@ sphinx_gallery_conf = {
     "matplotlib_animations": True,
     "compress_images": ("images", "thumbnails"),
     "image_scrapers": scrapers,
+    "expected_failing_examples": ["../examples/granger_causality.py"],
 }
 
 # sphinxcontrib-bibtex

--- a/examples/granger_causality.py
+++ b/examples/granger_causality.py
@@ -12,6 +12,7 @@ data is discussed :footcite:`WinklerEtAl2016`.
 
 # Author: Thomas S. Binns <t.s.binns@outlook.com>
 # License: BSD (3-clause)
+# sphinx_gallery_failing_thumbnail = False
 # sphinx_gallery_thumbnail_number = 3
 
 # %%
@@ -411,20 +412,16 @@ rank = np.count_nonzero(s >= s[0] * 1e-4)  # 1e-4 is the 'closeness' criteria
 
 # %%
 
-try:
-    spectral_connectivity_epochs(
-        epochs,
-        method=["gc"],
-        indices=indices_ab,
-        fmin=5,
-        fmax=30,
-        rank=None,
-        gc_n_lags=20,
-        verbose=False,
-    )  # A => B
-    print("Success!")
-except RuntimeError as error:
-    print("\nCaught the following error:\n" + repr(error))
+spectral_connectivity_epochs(
+    epochs,
+    method=["gc"],
+    indices=indices_ab,
+    fmin=5,
+    fmax=30,
+    rank=None,
+    gc_n_lags=20,
+    verbose=False,
+)  # A => B
 
 ###############################################################################
 # Rigorous checks are implemented to identify any such instances which would

--- a/mne_connectivity/utils/docs.py
+++ b/mne_connectivity/utils/docs.py
@@ -83,7 +83,7 @@ mt_low_bias : bool (default True)
 
 docdict["cwt_freqs"] = """
 cwt_freqs : array of int or float | None (default None)
-    The frequencies of interest in Hz. Must not be ``None`` and only used if
+    The frequencies of interest in Hz. Must not be `None` and only used if
     ``mode='cwt_morlet'``.
 """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ doc = [
   'sphinx',
   'sphinx-copybutton',
   'sphinx-design',
-  'sphinx-gallery',
+  'sphinx-gallery>=0.17.0',
   'sphinx-issues',
   'sphinx_autodoc_typehints',
   'sphinxcontrib-bibtex',


### PR DESCRIPTION
PR Description
--------------

Something that was discussed a while ago with @larsoner when the Granger causality example was first written but had to be postponed until new config options were added to sphinx-gallery:
- The GC example ends with a `try except` statement that is expected to fail
- It was suggested to remove the `try except` and just allow the error to be raised as long as the example is marked in sphinx as an expected failing example
- The problem was that expected failing examples automatically get a thumbnail with the word "BROKEN" which could not be overridden, and I felt this gave the wrong impression that there was a problem with the whole example
- In the new sphinx-gallery v0.17, support was added allowing this behaviour to be changed such that we can allow the GC example to fail while still giving it a proper thumbnail

Also a very small change to the decomposition docstring I overlooked before where a `None` wasn't being picked up as a type for intersphinx to link to.