### PR TITLE
[BUG, ENH] Improve error checking of `plot_sensors_connectivity` and add a `min_distance` parameter

### DIFF
--- a/mne_connectivity/viz/_3d.py
+++ b/mne_connectivity/viz/_3d.py
@@ -23,6 +23,7 @@ def plot_sensors_connectivity(
     info,
     con,
     picks=None,
+    *,
     cbar_label="Connectivity",
     n_con=20,
     cmap="RdBu",

--- a/mne_connectivity/viz/_3d.py
+++ b/mne_connectivity/viz/_3d.py
@@ -50,6 +50,7 @@ def plot_sensors_connectivity(
     min_distance : float
         The minimum distance required between two sensors to plot a connection between
         them, in meters. Default is 0.05 (i.e. 5 cm).
+
         .. versionadded:: 0.8
 
     Returns

--- a/mne_connectivity/viz/_3d.py
+++ b/mne_connectivity/viz/_3d.py
@@ -50,6 +50,7 @@ def plot_sensors_connectivity(
     min_distance : float
         The minimum distance required between two sensors to plot a connection between
         them, in meters. Default is 0.05 (i.e. 5 cm).
+        .. versionadded:: 0.8
 
     Returns
     -------

--- a/mne_connectivity/viz/tests/test_3d.py
+++ b/mne_connectivity/viz/tests/test_3d.py
@@ -17,22 +17,15 @@ def test_plot_sensors_connectivity(renderer):
     """Test plotting of sensors connectivity."""
     data_path = data_dir
     raw_fname = op.join(data_path, "MEG", "sample", "sample_audvis_trunc_raw.fif")
-
     raw = mne.io.read_raw_fif(raw_fname)
+    info = raw.info
     picks = mne.pick_types(
         raw.info, meg="grad", eeg=False, stim=False, eog=True, exclude="bads"
     )
     n_channels = len(picks)
-    con = np.random.RandomState(42).randn(n_channels, n_channels)
-    info = raw.info
-    with pytest.raises(TypeError, match="must be an instance of Info"):
-        plot_sensors_connectivity(info="foo", con=con, picks=picks)
-    with pytest.raises(ValueError, match="Connectivity data must be a 2D array"):
-        plot_sensors_connectivity(info=info, con=np.expand_dims(con, 3), picks=picks)
-    with pytest.raises(ValueError, match="2D array of shape (n_channels, n_channels)"):
-        plot_sensors_connectivity(info=info, con=con[:, :-1], picks=picks)
-    with pytest.raises(ValueError, match="does not correspond to the size"):
-        plot_sensors_connectivity(info=info, con=con[::2, ::2], picks=picks)
+    rng = np.random.default_rng(42)
+    con = rng.standard_normal((n_channels, n_channels))
+
     cmap = "viridis"
     fig = plot_sensors_connectivity(info=info, con=con, picks=picks, cmap=cmap)
     # check colormap
@@ -45,3 +38,40 @@ def test_plot_sensors_connectivity(renderer):
     # check title
     title = list(fig.plotter.scalar_bars.values())[0].GetTitle()
     assert title == "Connectivity"
+
+
+@testing.requires_testing_data
+def test_plot_sensors_connectivity_error_catch(renderer):
+    """Test `plot_sensors_connectivity` catches errors."""
+    # Get data to plot
+    data_path = data_dir
+    raw_fname = op.join(data_path, "MEG", "sample", "sample_audvis_trunc_raw.fif")
+    raw = mne.io.read_raw_fif(raw_fname)
+    info = raw.info
+    picks = mne.pick_types(
+        raw.info, meg="grad", eeg=False, stim=False, eog=True, exclude="bads"
+    )
+    n_channels = len(picks)
+    rng = np.random.default_rng(42)
+    con = rng.standard_normal((n_channels, n_channels))
+
+    # Check errors caught
+    # bad Info type
+    with pytest.raises(TypeError, match="must be an instance of Info"):
+        plot_sensors_connectivity(info="foo", con=con, picks=picks)
+    # bad connectivity array shape
+    with pytest.raises(ValueError, match="Connectivity data must be a 2D array"):
+        plot_sensors_connectivity(info=info, con=np.expand_dims(con, 2), picks=picks)
+    with pytest.raises(ValueError, match=r"array of shape \(n_channels, n_channels\)"):
+        plot_sensors_connectivity(info=info, con=con[:, :-1], picks=picks)
+    # mismatched channels and picks
+    with pytest.raises(ValueError, match="does not correspond to the size"):
+        plot_sensors_connectivity(info=info, con=con[::2, ::2], picks=picks)
+    # bad minimum distance
+    with pytest.raises(ValueError, match="distance between sensors must be greater"):
+        plot_sensors_connectivity(info=info, con=con, picks=picks, min_distance=0)
+    with pytest.raises(ValueError, match="distance between sensors must be greater"):
+        plot_sensors_connectivity(info=info, con=con, picks=picks, min_distance=-1)
+    # no surviving connections for minimum distance
+    with pytest.raises(ValueError, match=r"No.*connections were at least.*apart"):
+        plot_sensors_connectivity(info=info, con=con, picks=picks, min_distance=1e6)


### PR DESCRIPTION
Addresses #148, discussed in call with @larsoner.

Have gone with options (2) & (3) suggested above. This involves:
- An option to specify the minimum distance required between sensors for a connection to be plotted (default was 5 cm, which has been retained).
- A check that if no connections survive the minimum distance requirement, a more descriptive error message is raised.
    - The message suggests increasing the number of connections being plotted or decreasing the minimum distance (would help in cases like https://mne.discourse.group/t/problem-with-different-methods-in-sensor-connectivity-example/7548/4)
    - The message also suggests checking that the coordinates of channels are not NaNs (would help in cases like https://mne.discourse.group/t/error-while-trying-to-call-plot-sensors-connectivity/9128)

