### PR TITLE
unpin pytest

### DIFF
--- a/mne_connectivity/tests/test_envelope.py
+++ b/mne_connectivity/tests/test_envelope.py
@@ -204,4 +204,5 @@ def test_symmetric_orth(ndim, generator):
     Z_bad = Z.copy()
     Z_bad[0] = Z[1] + Z[2]
     with pytest.warns(RuntimeWarning, match="rank deficient"):
-        symmetric_orth(Z_bad)
+        with pytest.warns(RuntimeWarning, match="did not converge"):
+            symmetric_orth(Z_bad)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,8 +107,8 @@ test = [
   'mne-connectivity[gui]',
   'pandas',
   'pymatreader',
-  'pytest-cov',
   'pytest',
+  'pytest-cov',
   'statsmodels',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ test = [
   'pandas',
   'pymatreader',
   'pytest-cov',
-  'pytest<8.0.0',
+  'pytest',
   'statsmodels',
 ]
 


### PR DESCRIPTION
cf. https://github.com/mne-tools/mne-python/issues/12789

Locally for me all tests pass except for 3 symmetric_orth runs (2-False, 3-False, and 3-True). **They pass on pytest 7.4.4** so this needs digging into