### PR TITLE
[DOC] Use `sphinx_gallery_multi_image` in decomposition example

### DIFF
--- a/examples/decoding/cohy_decomposition_plotting.py
+++ b/examples/decoding/cohy_decomposition_plotting.py
@@ -10,6 +10,8 @@ from the decomposition tools in the decoding module can be visualised and interp
 # Author: Thomas S. Binns <t.s.binns@outlook.com>
 # License: BSD (3-clause)
 
+# sphinx_gallery_multi_image = "single"
+
 # %%
 
 import mne

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ doc = [
   'sphinx',
   'sphinx-copybutton',
   'sphinx-design',
-  'sphinx-gallery>=0.17.0',
+  'sphinx-gallery>=0.18.0',
   'sphinx-issues',
   'sphinx_autodoc_typehints',
   'sphinxcontrib-bibtex',


### PR DESCRIPTION
Takes advantage of the new `sphinx_gallery_multi_image` option in v0.18 in the decomposition plotting example to make the filters and patterns easier to see.

Before:
![image](https://github.com/user-attachments/assets/e585c31b-7bb4-42a2-957a-f15df9825655)

After:
![image](https://github.com/user-attachments/assets/e2c341ea-d20c-4799-950f-fcef679b2089)
