### PR TITLE
[DOC] Improve documentation of freqs

### DIFF
--- a/mne_connectivity/spectral/epochs.py
+++ b/mne_connectivity/spectral/epochs.py
@@ -790,12 +790,15 @@ def spectral_connectivity_epochs(
         Spectrum estimation mode can be either: 'multitaper', 'fourier', or
         'cwt_morlet'. Ignored if ``data`` is an
         :class:`~mne.time_frequency.EpochsSpectrum` object.
-    fmin : float | tuple of float
+    fmin : float | tuple of float | None
         The lower frequency of interest. Multiple bands are defined using
-        a tuple, e.g., (8., 20.) for two bands with 8Hz and 20Hz lower freq.
+        a tuple, e.g., (8., 20.) for two bands with 8 Hz and 20 Hz lower freq.
+        If `None`, the frequency corresponding to 5 cycles based on the epoch
+        length is used. For example, with an epoch length of 1 sec, the lower
+        frequency would be 5 / 1 sec = 5 Hz.
     fmax : float | tuple of float
         The upper frequency of interest. Multiple bands are dedined using
-        a tuple, e.g. (13., 30.) for two band with 13Hz and 30Hz upper freq.
+        a tuple, e.g. (13., 30.) for two band with 13 Hz and 30 Hz upper freq.
     fskip : int
         Omit every "(fskip + 1)-th" frequency bin to decimate in frequency
         domain.
@@ -828,8 +831,10 @@ def spectral_connectivity_epochs(
         bandwidth. Only used in 'multitaper' mode. Ignored if ``data`` is an
         :class:`~mne.time_frequency.EpochsSpectrum` object.
     cwt_freqs : array
-        Array of frequencies of interest. Only used in 'cwt_morlet' mode. Ignored if
-        ``data`` is an :class:`~mne.time_frequency.EpochsSpectrum` object.
+        Array of frequencies of interest. Only used in 'cwt_morlet' mode. Only
+        the frequencies within the range specified by ``fmin`` and ``fmax`` are
+        used. Ignored if ``data`` is an
+        :class:`~mne.time_frequency.EpochsSpectrum` object.
     cwt_n_cycles : float | array of float
         Number of cycles. Fixed number or one per frequency. Only used in 'cwt_morlet'
         mode. Ignored if ``data`` is an :class:`~mne.time_frequency.EpochsSpectrum`

--- a/mne_connectivity/spectral/epochs.py
+++ b/mne_connectivity/spectral/epochs.py
@@ -793,7 +793,7 @@ def spectral_connectivity_epochs(
     fmin : float | tuple of float | None
         The lower frequency of interest. Multiple bands are defined using
         a tuple, e.g., (8., 20.) for two bands with 8 Hz and 20 Hz lower freq.
-        If `None`, the frequency corresponding to 5 cycles based on the epoch
+        If ``None``, the frequency corresponding to 5 cycles based on the epoch
         length is used. For example, with an epoch length of 1 sec, the lower
         frequency would be 5 / 1 sec = 5 Hz.
     fmax : float | tuple of float

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ doc = [
   'pooch',
   'pydata-sphinx-theme==0.14.1',
   'PyQt6',
-  'sphinx',
+  'sphinx!=8.1.0',
   'sphinx-copybutton',
   'sphinx-design',
   'sphinx-gallery>=0.17.0',


### PR DESCRIPTION
Creating this PR after brief discussion with @tsbinns. I can also create a formal issue if needed, but for the moment this is a pure documentation PR.
In brief, I was confused by the behavior of ``cwt_freqs``, ``fmin`` and ``fmax``, especially if both ``cwt_freqs`` plus one of the other parameters was specified. Apparently, ``fmin`` and ``fmax`` supersede the ``cwt_freqs`` parameter, which was not evident from the documentation, so I tried to improve the description to make it a bit clearer. I can add more examples, if you think even more detail is needed.
Additionally, I noticed that the parameter ``None`` of ``fmin``, was not documented, even though it is the default, so I added this, too.
I ran make on the docs and they seem to render fine locally. Let me know if you need anything else.

PR Description
--------------

- Add None as parameter option, as this is actually the default case
- Add description of the behavior of fmin=None
- Add spaces between number and unit Hz (SI style convention)
- Improve description of cwt_freqs behavior for the case when fmin and fmax are also defined by user.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-connectivity/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
