### PR TITLE
[MAINT] Clean up CI pins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,13 +76,11 @@ jobs:
 
       - run:
           name: Get Python running and install dependencies
-          # Install mne-bids dev version: https://github.com/mne-tools/mne-connectivity/pull/237
           command: |
             pip install git+https://github.com/mne-tools/mne-python@main
             curl https://raw.githubusercontent.com/mne-tools/mne-python/main/tools/circleci_dependencies.sh -o circleci_dependencies.sh
             chmod +x circleci_dependencies.sh
             ./circleci_dependencies.sh
-            pip install .[doc] git+https://github.com/mne-tools/mne-bids@main
 
       - save_cache:
           key: pip-cache

--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -32,8 +32,6 @@ jobs:
           pyvista: false
       - uses: mamba-org/setup-micromamba@v2
         with:
-          # https://github.com/mamba-org/setup-micromamba/issues/225
-          micromamba-version: 1.5.10-0
           environment-file: environment.yml
           create-args: >- # beware the >- instead of |, we don't split on newlines but on spaces
             python=${{ env.PYTHON_VERSION }}


### PR DESCRIPTION
- Removes the dev version of mne-bids for an issue which was sorted in https://github.com/mne-tools/mne-bids/pull/1312
- Removes an old pinned version of micromamba for an issue (https://github.com/mamba-org/setup-micromamba/issues/225) which should now be fixed in current version
