### PR TITLE
unpin website theme

### DIFF
--- a/doc/_static/style.css
+++ b/doc/_static/style.css
@@ -4,9 +4,10 @@
     --pst-font-family-monospace: 'Source Code Pro', var(--pst-font-family-monospace-system);
 }
 
-a[class^="sphx-glr-backref-module-mne_hfo"] {
-  /* make all MNE-BIDS backrefs bold */
+a[class^="sphx-glr-backref-module-mne_connectivity"] {
+  /* make all MNE-Connectivity backrefs bold */
   font-weight: 800;
+  color: var(--pst-color-link);
 }
 
 span.option {
@@ -19,7 +20,7 @@ html[data-theme="light"] {
     --sg-download-a-background-color: var(--pst-color-primary);
     --sg-download-a-background-image: unset;
     --sg-download-a-border-color: var(--pst-color-border);
-    --sg-download-a-color: #fff;
+    --sg-download-a-color: var(--sd-color-primary-text);
     --sg-download-a-hover-background-color: var(--pst-color-primary-highlight);
     --sg-download-a-hover-box-shadow-1: none;
     --sg-download-a-hover-box-shadow-2: none;
@@ -29,21 +30,24 @@ html[data-theme="dark"] {
     --sg-download-a-background-color: var(--pst-color-primary);
     --sg-download-a-background-image: unset;
     --sg-download-a-border-color: var(--pst-color-border);
-    --sg-download-a-color: #000;
+    --sg-download-a-color: var(--sd-color-primary-text);
     --sg-download-a-hover-background-color: var(--pst-color-primary-highlight);
     --sg-download-a-hover-box-shadow-1: none;
     --sg-download-a-hover-box-shadow-2: none;
 }
 
 /* script/notebook download buttons */
-div.sphx-glr-download a {
+.sphx-glr-download a.download {
     border-radius: 0.5rem;
     /* ↓↓↓↓↓↓↓ these two rules copied from sphinx-design */
     box-shadow: 0 .125rem .25rem var(--sd-color-shadow) !important;
+    text-decoration: none;
     transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
 }
-
-div.sphx-glr-download a code {
+.sphx-glr-download a.download::before {
+    color: var(--sg-download-a-color);
+}
+.sphx-glr-download a.download code {
     color: var(--sg-download-a-color);
 }
 /* ************************************************* truncate version string */

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -259,6 +259,10 @@ html_theme = "pydata_sphinx_theme"
 templates_path = ["_templates"]
 html_static_path = ["_static"]
 html_css_files = ["style.css"]
+html_sidebars = {
+    "whats_new": [],
+    "install": [],
+}
 
 switcher_version_match = "dev" if "dev" in release else version
 
@@ -281,6 +285,7 @@ html_theme_options = {
         "json_url": "https://mne.tools/mne-connectivity/dev/_static/versions.json",
         "version_match": switcher_version_match,
     },
+    "back_to_top_button": False,
 }
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
@@ -346,6 +351,7 @@ sphinx_gallery_conf = {
     "compress_images": ("images", "thumbnails"),
     "image_scrapers": scrapers,
     "expected_failing_examples": ["../examples/granger_causality.py"],
+    "show_signature": False,
 }
 
 # sphinxcontrib-bibtex

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _whats_new:
 
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,17 +19,17 @@ Version 0.8 (in dev)
 
 Enhancements
 ~~~~~~~~~~~~
-
+*(none yet)*
 
 
 Bug
 ~~~
-
+*(none yet)*
 
 
 Authors
 ~~~~~~~
-
+*(none yet)*
 
 
 :doc:`Find out what was new in previous releases <whats_new_previous_releases>`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ doc = [
   'nilearn',
   'numpydoc',
   'pooch',
-  'pydata-sphinx-theme==0.14.1',
+  'pydata-sphinx-theme>=0.14.1',
   'PyQt6',
   'sphinx!=8.1.0',
   'sphinx-copybutton',


### PR DESCRIPTION
PR Description
--------------

use the latest released PyData Sphinx Theme. Main motivation is reduce dev pain (if a dev installs MNE-Connectivity after installing MNE-Python, it will downgrade the theme).

I synced a few parts of `conf.py` and `_static/style.css` with MNE-Python, but stopped short of the primary/secondary color switch from teal-purple to blue-orange like we did on the MNE-Python site. We may want to do that eventually to bring things into "brand alignment" but right now MNE-Connectivity doesn't even have a logo and the teal/purple scheme looks fine, so I left it alone.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-connectivity/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
