### PR TITLE
[MAINT] Run CIs on MNE-stable and update to latest Python version

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -66,7 +66,6 @@ jobs:
         if: matrix.mne-version == 'mne-main'
         run: pip install git+https://github.com/mne-tools/mne-python@main
       - run: python -c "import mne; print(mne.datasets.testing.data_path(verbose=True))"
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
       - name: Display versions and environment information
         run: |
           echo $TZ

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -30,10 +30,7 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.13"
             mne-version: mne-stable
-          - os: macos-13  # Intel
-            python-version: "3.13"
-            mne-version: mne-main
-          - os: macos-14  # arm64
+          - os: macos-latest
             python-version: "3.13"
             mne-version: mne-main
           - os: windows-latest

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -25,16 +25,19 @@ jobs:
             python-version: "3.10"
             mne-version: mne-main
           - os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.13"
             mne-version: mne-main
+          - os: ubuntu-latest
+            python-version: "3.13"
+            mne-version: mne-stable
           - os: macos-13  # Intel
-            python-version: "3.12"
+            python-version: "3.13"
             mne-version: mne-main
           - os: macos-14  # arm64
-            python-version: "3.12"
+            python-version: "3.13"
             mne-version: mne-main
           - os: windows-latest
-            python-version: "3.12"
+            python-version: "3.13"
             mne-version: mne-main
     env:
       TZ: Europe/Berlin
@@ -56,7 +59,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install --upgrade --upgrade-strategy eager .[test]
-      - if: matrix.mne-version == 'mne-stable'
+      - name: Install MNE (stable)
+        if: matrix.mne-version == 'mne-stable'
         run: pip install --upgrade mne
       - name: Install MNE (main)
         if: matrix.mne-version == 'mne-main'


### PR DESCRIPTION
Suggested by @larsoner. Currently only run unit tests on `mne-main` which can lead to bugs slipping through (e.g. #286).

This adds a test for the stable MNE version on Ubuntu. Should it be tested on more platforms like in [MNE-BIDS](https://github.com/mne-tools/mne-bids/blob/4f12d190d19a201a5b74fa1c8aaedac4d87775c8/.github/workflows/unit_tests.yml#L145-L147)?

Also updates the latest Python version tested from 3.12 to 3.13.