### PR TITLE
[MAINT] Remove pinned pyvista from doc dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ doc = [
   'pooch',
   'pydata-sphinx-theme>=0.14.1',
   'PyQt6',
-  'pyvista<0.46',
   'sphinx!=8.1.0',
   'sphinx-copybutton',
   'sphinx-design',


### PR DESCRIPTION
Reverts my workaround in #308 based on the recent updates to the pyvista dev branch (e.g., https://github.com/pyvista/pyvista/pull/7712; see #309).
