### PR TITLE
Treat lags as separate dim

### DIFF
--- a/mne_connectivity/vector_ar/tests/test_var.py
+++ b/mne_connectivity/vector_ar/tests/test_var.py
@@ -280,6 +280,10 @@ def test_vector_auto_regression():
         conn.get_data().mean(axis=0), single_conn.get_data(), decimal=1
     )
 
+    # compute single var with multiple lags
+    single_conn_plags = vector_auto_regression(data, model="avg-epochs", lags=2)
+    single_conn_plags.get_data("dense")  # just check data can be reshaped properly
+
     # compute residuals
     residuals = data - parr_conn.predict(data)
     assert residuals.shape == data.shape


### PR DESCRIPTION
PR Description
--------------

Fixes #330.

Treats lags in `avg-epochs` models with lags > 1 as a separate time dimension for storage in `TemporalConnetivity` objects.
Also updates the unit tests to check this data can be accessed.
