### PR TITLE
[BUG] Fix including bad channels in computations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # Ruff mne_connectivity
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.11
+    rev: v0.12.12
     hooks:
       - id: ruff
         name: ruff lint mne_connectivity
@@ -10,7 +10,7 @@ repos:
 
   # Ruff tutorials and examples
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.11
+    rev: v0.12.12
     hooks:
       - id: ruff
         name: ruff lint tutorials and examples

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -33,6 +33,7 @@ Bug
 ~~~
 
 - Improve the documentation of the ``fmin`` and ``cwt_freqs`` parameters in the :func:`~mne_connectivity.spectral_connectivity_epochs` function, by `Richard Köhler`_ and `Daniel McCloy`_ (:pr:`242`).
+- Ignore bad channels in computations in :func:`~mne_connectivity.envelope_correlation` and :func:`~mne_connectivity.vector_auto_regression`, and in :func:`~mne_connectivity.spectral_connectivity_epochs`, :func:`~mne_connectivity.spectral_connectivity_time`, and :func:`~mne_connectivity.phase_slope_index` when indices are not specified, by `Thomas Binns`_ (:pr:`334`).
 
 API
 ~~~

--- a/mne_connectivity/base.py
+++ b/mne_connectivity/base.py
@@ -707,8 +707,8 @@ class BaseConnectivity(DynamicMixin, EpochMixin):
         else:
             if (
                 isinstance(self.indices, tuple)
-                and not isinstance(self.indices[0], int)
-                and not isinstance(self.indices[1], int)
+                and not np.all(isinstance(ind, int) for ind in self.indices[0])
+                and not np.all(isinstance(ind, int) for ind in self.indices[1])
             ):  # i.e. check if multivariate results based on nested indices
                 # multivariate results cannot be returned in a dense form as a single
                 # set of results would correspond to multiple entries in the matrix, and

--- a/mne_connectivity/base.py
+++ b/mne_connectivity/base.py
@@ -707,8 +707,12 @@ class BaseConnectivity(DynamicMixin, EpochMixin):
         else:
             if (
                 isinstance(self.indices, tuple)
-                and not np.all(isinstance(ind, int) for ind in self.indices[0])
-                and not np.all(isinstance(ind, int) for ind in self.indices[1])
+                and not np.all(
+                    [np.issubdtype(type(ind), int) for ind in self.indices[0]]
+                )
+                and not np.all(
+                    [np.issubdtype(type(ind), int) for ind in self.indices[1]]
+                )
             ):  # i.e. check if multivariate results based on nested indices
                 # multivariate results cannot be returned in a dense form as a single
                 # set of results would correspond to multiple entries in the matrix, and

--- a/mne_connectivity/envelope.py
+++ b/mne_connectivity/envelope.py
@@ -178,9 +178,9 @@ def envelope_correlation(
                 label_data_orth_std[label_data_orth_std == 0] = 1
 
             # correlation is dot product divided by variances
-            corr[li, picks] = np.sum(label_data_orth * data_mag_nomean, axis=1)
-            corr[li, picks] /= data_mag_std
-            corr[li, picks] /= label_data_orth_std
+            corr[picks[li], picks] = np.sum(label_data_orth * data_mag_nomean, axis=1)
+            corr[picks[li], picks] /= data_mag_std
+            corr[picks[li], picks] /= label_data_orth_std
         if orthogonalize:
             # Make it symmetric (it isn't at this point)
             if absolute:

--- a/mne_connectivity/spectral/tests/test_spectral.py
+++ b/mne_connectivity/spectral/tests/test_spectral.py
@@ -8,7 +8,12 @@ import pytest
 from mne import EpochsArray, SourceEstimate, create_info
 from mne.filter import filter_data
 from mne.utils import check_version
-from numpy.testing import assert_allclose, assert_array_almost_equal, assert_array_less
+from numpy.testing import (
+    assert_allclose,
+    assert_array_almost_equal,
+    assert_array_equal,
+    assert_array_less,
+)
 
 from mne_connectivity import (
     SpectralConnectivity,
@@ -1183,6 +1188,74 @@ def test_multivar_spectral_connectivity_flipped_indices():
     assert not np.all(con_st.get_data() == con_ts.get_data())
     assert_allclose(con_st.get_data()[:, 0], con_st_ts.get_data()[:, 0])
     assert_allclose(con_ts.get_data()[:, 0], con_st_ts.get_data()[:, 1])
+
+
+@pytest.mark.parametrize("method", ["coh", "cacoh"])
+@pytest.mark.parametrize("picks", [None, "all", "goods"])
+@pytest.mark.parametrize("data_as_spectra", [False, True])
+def test_spectral_connectivity_bad_channels(method, picks, data_as_spectra):
+    """Test spectral_connectivity_epochs bad channels handling.
+
+    Important to test indices handling with both bivariate and multivariate methods.
+    """
+    # Simulate data
+    rng = np.random.default_rng(0)
+    n_epochs = 2
+    n_channels = 3  # do not change!
+    sfreq = 50
+    data = rng.standard_normal((n_epochs, n_channels, sfreq))
+    info = create_info(n_channels, sfreq, "eeg")
+    data = EpochsArray(data, info)
+    if data_as_spectra:
+        data = data.compute_psd(method="welch", output="complex")
+
+    # Mark a channel as bad
+    data.info["bads"] = [data.ch_names[1]]
+
+    # Create indices
+    if picks is not None:
+        if picks == "all":  # explicit bad inclusion
+            indices = (np.array([1, 2, 2]), np.array([0, 0, 1]))
+        else:  # ("goods") explicit bad exclusion
+            indices = (np.array([2]), np.array([0]))
+        if method != "coh":  # multivariate indices must be nested
+            indices = tuple([[i] for i in ind] for ind in indices)
+        n_cons = len(indices[0])
+    else:
+        indices = None  # implicit bad exclusion
+        n_cons = n_channels**2 if method == "coh" else 1
+
+    # Compute connectivity
+    con = spectral_connectivity_epochs(data, method=method, indices=indices)
+    n_freqs = len(con.freqs)
+
+    # Check connectivity object properties
+    assert con.n_nodes == n_channels
+    assert con.names == data.ch_names
+
+    # Check dense shape same regardless of indices (not for multivariate connectivity)
+    if method == "coh":
+        assert con.get_data("dense").shape == (n_channels, n_channels, n_freqs)
+
+    # Check raveled shape and contents depends on indices
+    raveled_data = np.abs(con.get_data("raveled"))  # abs for CaCoh
+    assert raveled_data.shape == (n_cons, n_freqs)  # n_cons depends on picks
+    if picks is not None:
+        # with "all" channels used, bads entries are present and are non-zero
+        # with "goods" channels used, bads entries are non-existent
+        # in both cases, all entries are non-zero
+        assert_array_less(0, raveled_data)
+        if method != "coh":  # check shape of patterns (1 channel per connection)
+            assert np.shape(con.attrs["patterns"]) == (2, n_cons, 1, n_freqs)
+    else:  # indices=None → all-to-all connectivity
+        if method == "coh":  # bads entries present, but filled with zeros
+            assert_array_equal(raveled_data[[3, 7]], 0)  # bads indices
+            # (use np.ravel_multi_index to find dense array indices in raveled array)
+        else:  # only good channs used for single multivar connection (so all non-zero)
+            assert_array_less(0, raveled_data)
+            # but we can check shape (all chans) and entries (bads=zeros) of patterns
+            assert np.shape(con.attrs["patterns"]) == (2, n_cons, n_channels, n_freqs)
+            assert_array_equal(0, np.array(con.attrs["patterns"])[:, :, 1, :])
 
 
 @pytest.mark.parametrize("kind", ("epochs", "ndarray", "stc", "combo"))

--- a/mne_connectivity/tests/test_envelope.py
+++ b/mne_connectivity/tests/test_envelope.py
@@ -7,6 +7,7 @@
 
 import numpy as np
 import pytest
+from mne import EpochsArray, create_info
 from mne.utils import catch_logging, use_log_level
 from numpy.testing import assert_allclose, assert_array_equal, assert_array_less
 from scipy.signal import hilbert
@@ -151,6 +152,21 @@ def test_envelope_correlation():
     ft_vals[np.isnan(ft_vals)] = 0
     corr_log = envelope_correlation(data, log=True, absolute=False)
     assert_allclose(corr_log.get_data(output="dense").squeeze(), ft_vals)
+
+
+def test_envelope_correlation_bad_channels():
+    """Test bad channels are ignored in envelope_correlation."""
+    rng = np.random.default_rng(0)
+    n_epochs, n_signals, n_times = 2, 3, 64
+    data = rng.standard_normal(size=(n_epochs, n_signals, n_times))
+    info = create_info(n_signals, sfreq=n_times, ch_types="eeg")
+    info["bads"] = ["1"]
+    data = EpochsArray(data, info)
+    corr = envelope_correlation(data)
+
+    assert corr.n_nodes == n_signals
+    assert corr.names == data.ch_names
+    assert corr.get_data().shape[1:3] == (n_signals, n_signals)
 
 
 @pytest.mark.parametrize(

--- a/mne_connectivity/tests/test_envelope.py
+++ b/mne_connectivity/tests/test_envelope.py
@@ -155,7 +155,7 @@ def test_envelope_correlation():
 
 
 def test_envelope_correlation_bad_channels():
-    """Test bad channels are ignored in envelope_correlation."""
+    """Test bad channels are handled properly in envelope_correlation."""
     rng = np.random.default_rng(0)
     n_epochs, n_signals, n_times = 1, 3, 64
     data = rng.standard_normal(size=(n_epochs, n_signals, n_times))

--- a/mne_connectivity/tests/test_envelope.py
+++ b/mne_connectivity/tests/test_envelope.py
@@ -157,7 +157,7 @@ def test_envelope_correlation():
 def test_envelope_correlation_bad_channels():
     """Test bad channels are ignored in envelope_correlation."""
     rng = np.random.default_rng(0)
-    n_epochs, n_signals, n_times = 2, 3, 64
+    n_epochs, n_signals, n_times = 1, 3, 64
     data = rng.standard_normal(size=(n_epochs, n_signals, n_times))
     info = create_info(n_signals, sfreq=n_times, ch_types="eeg")
     info["bads"] = ["1"]
@@ -166,6 +166,7 @@ def test_envelope_correlation_bad_channels():
 
     assert corr.n_nodes == n_signals
     assert corr.names == data.ch_names
+    assert_array_equal(corr.get_data()[:, [0, 1, 1, 2], [1, 0, 2, 1], :], 0)  # bads
     assert corr.get_data().shape[1:3] == (n_signals, n_signals)
 
 

--- a/mne_connectivity/vector_ar/tests/test_var.py
+++ b/mne_connectivity/vector_ar/tests/test_var.py
@@ -313,7 +313,7 @@ def test_vector_auto_regression():
 
 @pytest.mark.parametrize("model", ["avg-epochs", "dynamic"])
 def test_vector_auto_regression_bad_channels(model):
-    """Test bad channels are ignored in vector_auto_regression."""
+    """Test bad channels are handled properly in vector_auto_regression."""
     rng = np.random.default_rng(0)
     n_epochs, n_signals, n_times = 1, 3, 64
     data = rng.standard_normal(size=(n_epochs, n_signals, n_times))


### PR DESCRIPTION
PR Description
--------------

Fixes #323.

When `indices=None` (`spec_conn_epochs/time`, `phase_slope_index`) or when no `indices`  parameter is supported (`envelope_correlation`, `vector_auto_regression`), bad channels are now ignored from connectivity computations.

However, entries for these bad channels will still be considered in the dense representation of the matrices as per this discussion: https://github.com/mne-tools/mne-connectivity/issues/323#issuecomment-3286402064
