### PR TITLE
Fix changelog

### DIFF
--- a/doc/changes/dev/403.other.rst
+++ b/doc/changes/dev/403.other.rst
@@ -1,1 +1,0 @@
-List ``cohy`` as a supported method in :func:`~mne_connectivity.spectral_connectivity_time`, by `Thomas Binns`_.

--- a/doc/changes/v0.8.rst
+++ b/doc/changes/v0.8.rst
@@ -1,5 +1,19 @@
-Version 0.8 (2026-03-23)
-------------------------
+Version 0.8.1 (2026-04-11)
+--------------------------
+
+Enhancements
+~~~~~~~~~~~~
+
+- List ``cohy`` as a supported method in :func:`~mne_connectivity.spectral_connectivity_time`, by `Thomas Binns`_ (:pr:`403`).
+
+Authors
+~~~~~~~
+
+* `Thomas Binns`_
+
+
+Version 0.8.0 (2026-03-23)
+--------------------------
 
 Minimum supported Python version is now 3.10.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,7 +274,7 @@ directory = "doc/changes/dev/"
 filename = "doc/changes/dev.rst"
 issue_format = "`#{issue} <https://github.com/mne-tools/mne-connectivity/pull/{issue}>`__"
 package = "mne-connectivity"
-title_format = "Version {version} ({project_date})"
+title_format = "{version} ({project_date})"
 
 [[tool.towncrier.type]]
 directory = "notable"


### PR DESCRIPTION
Removed the changelog entry for #403 which was backported to v0.8.1.

Also prevents dev changelog title link appearing as "Version Version X.Y.Z...".