### PR TITLE
Fix imag data being discarded for `get_data` with dense output

### DIFF
--- a/doc/changes/dev/412.bugfix.rst
+++ b/doc/changes/dev/412.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where the :meth:`get_data() <mne_connectivity.Connectivity.get_data>` method of connectivity containers discarded the imaginary part of complex-valued data when ``output="dense"``, by `Thomas Binns`_.

--- a/mne_connectivity/base.py
+++ b/mne_connectivity/base.py
@@ -739,21 +739,21 @@ class BaseConnectivity(DynamicMixin, EpochMixin):
             if "times" in self.dims:
                 new_shape.append(len(self.coords["times"]))
 
-            # handle things differently if indices is defined
-            if isinstance(self.indices, tuple):
-                # TODO: improve this to be more memory efficient
-                # from all-to-all connectivity structure
-                data = np.zeros(new_shape)
-                data[:] = np.nan
+            if isinstance(self.indices, tuple) or self.indices == "symmetric":
+                if np.iscomplexobj(self._data):
+                    fill_value = np.nan + 1j * np.nan
+                else:
+                    fill_value = np.nan
+                data = np.full(new_shape, fill_value=fill_value, dtype=self._data.dtype)
 
+            if isinstance(self.indices, tuple):
+                # handle things differently if indices is defined
                 row_idx, col_idx = self.indices
                 if self.is_epoched:
                     data[:, row_idx, col_idx, ...] = self._data
                 else:
                     data[row_idx, col_idx, ...] = self._data
             elif self.indices == "symmetric":
-                data = np.zeros(new_shape)
-
                 # get the upper/lower triangular indices
                 row_triu_inds, col_triu_inds = np.triu_indices(self.n_nodes, k=0)
                 if self.is_epoched:

--- a/mne_connectivity/tests/test_connectivity.py
+++ b/mne_connectivity/tests/test_connectivity.py
@@ -427,3 +427,21 @@ def test_metadata_handling(func, tmpdir, epochs):
     else:
         assert isinstance(new_conn.metadata, pd.DataFrame)
         assert metadata.empty
+
+
+@pytest.mark.parametrize("indices", ["all", "symmetric", "tril"])
+def test_get_data_complex(indices):
+    """Test that get_data works properly with complex data."""
+    n_nodes = 3
+    data = np.ones((n_nodes * n_nodes), dtype=np.complex128)
+    if indices == "symmetric":
+        triu_inds = np.triu_indices(n_nodes, k=0)
+        data = data[np.ravel_multi_index(triu_inds, (n_nodes, n_nodes))]
+    if indices == "tril":
+        indices = np.tril_indices(n_nodes, k=-1)
+        data = data[np.ravel_multi_index(indices, (n_nodes, n_nodes))]
+
+    conn = Connectivity(data=data, indices=indices, n_nodes=n_nodes)
+    for output in ["raveled", "dense"]:
+        out_data = conn.get_data(output=output)
+        assert np.iscomplexobj(out_data)


### PR DESCRIPTION
Found when playing around with stuff for #372.

When `output="dense"` used with `get_data`, the data gets returned as an array with a new shape.

However, this wasn't taking into account data's dtype, so complex-valued data was getting stuffed into a real-valued array.

Adds some tests with this that would fail on main.