### PR TITLE
Fix slow pytest 9.1.x

### DIFF
--- a/mne_connectivity/conftest.py
+++ b/mne_connectivity/conftest.py
@@ -85,7 +85,7 @@ def close_all():
     plt.close("all")
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="session", autouse=True)
 def matplotlib_config():
     """Configure matplotlib for viz tests."""
     import matplotlib

--- a/mne_connectivity/viz/tests/test_circle.py
+++ b/mne_connectivity/viz/tests/test_circle.py
@@ -13,6 +13,7 @@ from mne.viz import circular_layout
 from mne_connectivity.viz import plot_connectivity_circle
 
 
+@pytest.mark.skip
 def test_plot_connectivity_circle():
     """Test plotting connectivity circle."""
     node_order = [

--- a/mne_connectivity/viz/tests/test_circle.py
+++ b/mne_connectivity/viz/tests/test_circle.py
@@ -5,7 +5,6 @@
 # License: Simplified BSD
 
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from mne.viz import circular_layout
@@ -13,7 +12,6 @@ from mne.viz import circular_layout
 from mne_connectivity.viz import plot_connectivity_circle
 
 
-@pytest.mark.skip
 def test_plot_connectivity_circle():
     """Test plotting connectivity circle."""
     node_order = [
@@ -176,4 +174,3 @@ def test_plot_connectivity_circle():
     pytest.raises(
         ValueError, circular_layout, label_names, node_order, group_boundaries=[20, 0]
     )
-    plt.close("all")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ test = [
   'mne-connectivity[gui]',
   'pandas',
   'pymatreader',
-  'pytest!=9.1.0,!=9.1.1',
+  'pytest',
   'pytest-cov',
   'statsmodels',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,17 +30,9 @@ dependencies = [
 ]
 description = 'mne-connectivity: A module for connectivity data analysis with MNE.'
 dynamic = ["version"]
-keywords = [
-  'connectivity',
-  'eeg',
-  'ieeg',
-  'meg',
-  'neuroscience',
-]
+keywords = ['connectivity', 'eeg', 'ieeg', 'meg', 'neuroscience']
 license = {file = 'LICENSE'}
-maintainers = [
-  {email = 'adam.li@columbia.edu', name = 'Adam Li'},
-]
+maintainers = [{email = 'adam.li@columbia.edu', name = 'Adam Li'}]
 name = 'mne-connectivity'
 readme = {content-type = "text/x-rst", file = 'README.rst'}
 requires-python = '>=3.10'
@@ -54,10 +46,7 @@ all = [
   'mne-connectivity[test]',
   'PyQt6',
 ]
-build = [
-  'build',
-  'twine',
-]
+build = ['build', 'twine']
 doc = [
   'intersphinx-registry',
   'memory-profiler',
@@ -78,9 +67,7 @@ doc = [
   'sphinxcontrib-bibtex',
   'sphinxcontrib-towncrier',
 ]
-full = [
-  'mne-connectivity[all]',
-]
+full = ['mne-connectivity[all]']
 gui = [
   'h5netcdf',
   'matplotlib',
@@ -142,18 +129,10 @@ precision = 2
 [tool.coverage.run]
 branch = true
 cover_pylib = false
-omit = [
-  '**/__init__.py',
-  '**/mne_connectivity/conftest.py',
-  '**/tests/**',
-]
+omit = ['**/__init__.py', '**/mne_connectivity/conftest.py', '**/tests/**']
 
 [tool.isort]
-extend_skip_glob = [
-  'doc/*',
-  'examples/*',
-  'setup.py',
-]
+extend_skip_glob = ['doc/*', 'examples/*', 'setup.py']
 line_length = 88
 multi_line_output = 3
 py_version = 39
@@ -173,6 +152,7 @@ match-dir = '^mne_connectivity.*'
 addopts = '--durations 20 --junit-xml=junit-results.xml -v -rfEXs --tb=short --color=yes'
 junit_family = 'xunit2'
 minversion = '6.0'
+testpaths = ['mne_connectivity']
 
 [tool.rstcheck]
 ignore_directives = [
@@ -221,11 +201,7 @@ ignore_roles = [
 report_level = "WARNING"
 
 [tool.ruff]
-extend-exclude = [
-  'benchmarks',
-  'doc',
-  'setup.py',
-]
+extend-exclude = ['benchmarks', 'doc', 'setup.py']
 line-length = 88
 
 [tool.ruff.lint]


### PR DESCRIPTION
Fixes #429

Locally, test suite runs with pytest 9.0.3 and 9.1.1 take the same time to run (Ubuntu 24.04, Python 3.13).

However, with pytest 9.1.1, `test_plot_connectivity_circle` (the last test that gets run) has a plot pop-up which I have to close before the tests can finish, and which I didn't see for 9.0.3.

There is a fixture that is supposed to prevent this from happening, but maybe something in 9.1.1 is preventing the fixture from working properly.

This is the only visualisation test that actually gets run, as the others are skipped due to lack of imageio-ffmpeg

Have disabled the test in question to see if that's indeed the culprit.