### PR TITLE
Bump CircleCI runner image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build_docs:
     machine:
-      image: ubuntu-2404:current
+      image: ubuntu-2604:2026.05.1
     steps:
       - restore_cache:
           keys:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ jobs:
       - uses: actions/checkout@v7
       - name: Set up Python
         uses: actions/setup-python@v6
-        with:
-          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Docs can no longer build after https://github.com/mne-tools/mne-python/pull/13978 (changed `/tools/circleci_bash_env.sh`, which we use).

Try to adapt the changes for MNE-Conn here.