### PR TITLE
[MRG] Fix evoked surrogate cutpoint handling

### DIFF
--- a/doc/changes/dev/447.bugfix.rst
+++ b/doc/changes/dev/447.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug in :func:`~mne_connectivity.make_surrogate_evoked_data` where sampled cutpoints were interpreted as numbers of sections instead of split indices, by `Rebecca Stevenson`_.

--- a/doc/changes/names.inc
+++ b/doc/changes/names.inc
@@ -11,6 +11,7 @@
 .. _Mina Jamshidi: https://github.com/minajamshidi
 .. _Mohammad Orabe: https://github.com/orabe
 .. _Qianliang Li: https://github.com/Avoide
+.. _Rebecca Stevenson: https://github.com/RebeccaStevenson
 .. _Richard Höchenberger: https://github.com/hoechenberger
 .. _Richard Köhler: https://github.com/richardkoehler
 .. _Salman Qasim: https://github.com/seqasim

--- a/mne_connectivity/datasets/surrogate.py
+++ b/mne_connectivity/datasets/surrogate.py
@@ -373,7 +373,7 @@ def _shuffle_coefficients_within_epochs(
         for epoch_i in range(data_arr.shape[0]):
             for chan_i in range(data_arr.shape[1]):
                 surr = np.array_split(
-                    data_arr[epoch_i, chan_i], cutpoints[epoch_i, chan_i], axis=-1
+                    data_arr[epoch_i, chan_i], [cutpoints[epoch_i, chan_i]], axis=-1
                 )
                 surr.reverse()
                 surrogate_arr[epoch_i, chan_i] = np.concatenate(surr, axis=-1)

--- a/mne_connectivity/datasets/tests/test_datasets.py
+++ b/mne_connectivity/datasets/tests/test_datasets.py
@@ -336,6 +336,34 @@ def test_make_surrogate_data_deprecation():
         make_surrogate_data(data, n_shuffles=5)
 
 
+def test_make_surrogate_evoked_data_fourier_magnitude_consistency():
+    """Test evoked surrogates preserve each time series' Fourier magnitudes."""
+    rng = np.random.default_rng(42)
+    data = rng.standard_normal((3, 2, 101))
+    epochs = EpochsArray(
+        data=data,
+        info=create_info(ch_names=2, sfreq=100.0, ch_types="eeg"),
+        verbose=False,
+    )
+
+    surrogates = make_surrogate_evoked_data(
+        epochs,
+        n_shuffles=3,
+        rng_seed=7,
+        return_generator=False,
+    )
+    expected_magnitudes = np.abs(np.fft.rfft(data, axis=-1))
+
+    for surrogate in surrogates:
+        actual_magnitudes = np.abs(np.fft.rfft(surrogate.get_data(), axis=-1))
+        np.testing.assert_allclose(
+            actual_magnitudes,
+            expected_magnitudes,
+            rtol=1e-12,
+            atol=1e-12,
+        )
+
+
 @pytest.mark.parametrize(("snr", "should_be_significant"), ([0.7, True], [0.2, False]))
 @pytest.mark.parametrize(
     ("use_coeffs", "state", "method"),

--- a/mne_connectivity/datasets/tests/test_datasets.py
+++ b/mne_connectivity/datasets/tests/test_datasets.py
@@ -516,33 +516,6 @@ def test_make_surrogate_resting_data_kind_consistency():
             ), "Surrogate data not consistent across epochs and spectral coeffs."
 
 
-@pytest.mark.parametrize(
-    "surrogate_func", [make_surrogate_resting_data, make_surrogate_evoked_data]
-)
-def test_make_surrogate_data_generator(surrogate_func):
-    """Test `return_generator` parameter works in `make_surrogate_xxx_data`."""
-    # Generate random data for packaging into Epochs
-    n_epochs = 5
-    n_chans = 6
-    n_times = 200
-    sfreq = 50
-    rng = np.random.default_rng(44)
-    data = rng.random((n_epochs, n_chans, n_times))
-    info = create_info(ch_names=n_chans, sfreq=sfreq, ch_types="eeg")
-    epochs = EpochsArray(data=data, info=info)
-    coeffs = epochs.compute_tfr(
-        method="morlet", freqs=np.arange(5, sfreq // 2), output="complex"
-    )
-
-    # Test generator (not) returned when requested
-    for input_data in (epochs, coeffs):
-        for return_generator, expects in zip([True, False], [Generator, list]):
-            surrogate_data = surrogate_func(
-                data=input_data, n_shuffles=5, return_generator=return_generator
-            )
-            assert isinstance(surrogate_data, expects), type(surrogate_data)
-
-
 def test_make_surrogate_evoked_data_fourier_magnitude_consistency():
     """Test evoked surrogates preserve each time series' Fourier magnitudes."""
     rng = np.random.default_rng(42)
@@ -569,6 +542,33 @@ def test_make_surrogate_evoked_data_fourier_magnitude_consistency():
             rtol=1e-12,
             atol=1e-12,
         )
+
+
+@pytest.mark.parametrize(
+    "surrogate_func", [make_surrogate_resting_data, make_surrogate_evoked_data]
+)
+def test_make_surrogate_data_generator(surrogate_func):
+    """Test `return_generator` parameter works in `make_surrogate_xxx_data`."""
+    # Generate random data for packaging into Epochs
+    n_epochs = 5
+    n_chans = 6
+    n_times = 200
+    sfreq = 50
+    rng = np.random.default_rng(44)
+    data = rng.random((n_epochs, n_chans, n_times))
+    info = create_info(ch_names=n_chans, sfreq=sfreq, ch_types="eeg")
+    epochs = EpochsArray(data=data, info=info)
+    coeffs = epochs.compute_tfr(
+        method="morlet", freqs=np.arange(5, sfreq // 2), output="complex"
+    )
+
+    # Test generator (not) returned when requested
+    for input_data in (epochs, coeffs):
+        for return_generator, expects in zip([True, False], [Generator, list]):
+            surrogate_data = surrogate_func(
+                data=input_data, n_shuffles=5, return_generator=return_generator
+            )
+            assert isinstance(surrogate_data, expects), type(surrogate_data)
 
 
 @pytest.mark.parametrize(

--- a/mne_connectivity/datasets/tests/test_datasets.py
+++ b/mne_connectivity/datasets/tests/test_datasets.py
@@ -527,20 +527,14 @@ def test_make_surrogate_evoked_data_fourier_magnitude_consistency():
     )
 
     surrogates = make_surrogate_evoked_data(
-        epochs,
-        n_shuffles=3,
-        rng_seed=7,
-        return_generator=False,
+        epochs, n_shuffles=3, rng_seed=7, return_generator=False
     )
     expected_magnitudes = np.abs(np.fft.rfft(data, axis=-1))
 
     for surrogate in surrogates:
         actual_magnitudes = np.abs(np.fft.rfft(surrogate.get_data(), axis=-1))
         np.testing.assert_allclose(
-            actual_magnitudes,
-            expected_magnitudes,
-            rtol=1e-12,
-            atol=1e-12,
+            actual_magnitudes, expected_magnitudes, rtol=1e-12, atol=1e-12
         )
 
 

--- a/mne_connectivity/datasets/tests/test_datasets.py
+++ b/mne_connectivity/datasets/tests/test_datasets.py
@@ -336,34 +336,6 @@ def test_make_surrogate_data_deprecation():
         make_surrogate_data(data, n_shuffles=5)
 
 
-def test_make_surrogate_evoked_data_fourier_magnitude_consistency():
-    """Test evoked surrogates preserve each time series' Fourier magnitudes."""
-    rng = np.random.default_rng(42)
-    data = rng.standard_normal((3, 2, 101))
-    epochs = EpochsArray(
-        data=data,
-        info=create_info(ch_names=2, sfreq=100.0, ch_types="eeg"),
-        verbose=False,
-    )
-
-    surrogates = make_surrogate_evoked_data(
-        epochs,
-        n_shuffles=3,
-        rng_seed=7,
-        return_generator=False,
-    )
-    expected_magnitudes = np.abs(np.fft.rfft(data, axis=-1))
-
-    for surrogate in surrogates:
-        actual_magnitudes = np.abs(np.fft.rfft(surrogate.get_data(), axis=-1))
-        np.testing.assert_allclose(
-            actual_magnitudes,
-            expected_magnitudes,
-            rtol=1e-12,
-            atol=1e-12,
-        )
-
-
 @pytest.mark.parametrize(("snr", "should_be_significant"), ([0.7, True], [0.2, False]))
 @pytest.mark.parametrize(
     ("use_coeffs", "state", "method"),
@@ -569,6 +541,34 @@ def test_make_surrogate_data_generator(surrogate_func):
                 data=input_data, n_shuffles=5, return_generator=return_generator
             )
             assert isinstance(surrogate_data, expects), type(surrogate_data)
+
+
+def test_make_surrogate_evoked_data_fourier_magnitude_consistency():
+    """Test evoked surrogates preserve each time series' Fourier magnitudes."""
+    rng = np.random.default_rng(42)
+    data = rng.standard_normal((3, 2, 101))
+    epochs = EpochsArray(
+        data=data,
+        info=create_info(ch_names=2, sfreq=100.0, ch_types="eeg"),
+        verbose=False,
+    )
+
+    surrogates = make_surrogate_evoked_data(
+        epochs,
+        n_shuffles=3,
+        rng_seed=7,
+        return_generator=False,
+    )
+    expected_magnitudes = np.abs(np.fft.rfft(data, axis=-1))
+
+    for surrogate in surrogates:
+        actual_magnitudes = np.abs(np.fft.rfft(surrogate.get_data(), axis=-1))
+        np.testing.assert_allclose(
+            actual_magnitudes,
+            expected_magnitudes,
+            rtol=1e-12,
+            atol=1e-12,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
PR Description
--------------

`make_surrogate_evoked_data()` samples one cutpoint for every epoch and channel, but it passed each scalar cutpoint directly as `indices_or_sections` to `np.array_split()`. NumPy interprets a scalar integer as the number of sections, not as a split index. The current implementation could therefore divide a time series into a randomly selected number of chunks and reverse their order instead of making one cut and exchanging the two resulting blocks.

This pull request wraps each cutpoint in a one-element list, so `np.array_split()` treats it as the location of a single split. It also adds a regression test verifying that every generated surrogate preserves the Fourier magnitudes of each epoch/channel time series, as a one-cut circular shift should.

closes #446

Validation
----------

- `pytest mne_connectivity/datasets/tests/test_datasets.py -k surrogate -q` with MNE 1.12.1: 17 passed, 98 deselected
- `pre-commit run --files mne_connectivity/datasets/surrogate.py mne_connectivity/datasets/tests/test_datasets.py doc/changes/names.inc doc/changes/dev/447.bugfix.rst`: all applicable checks passed

AI-authorship disclosure
------------------------

The scalar-versus-split-index mismatch, the numerical reproduction, the proposed correction and regression test, and this pull-request draft were identified and written by OpenAI Codex running the GPT-5.6 SOL model at max reasoning effort. The human submitter requested the investigation and reviewed the draft before any submission.

Merge checklist
---------------

Maintainer, please confirm the following before merging:

- [ ] All comments resolved
- [ ] This is not your own PR
- [ ] All CIs are happy
- [ ] PR title starts with [MRG]
- [ ] [whats_new.rst](https://github.com/mne-tools/mne-connectivity/blob/main/doc/whats_new.rst) is updated
- [ ] PR description includes phrase "closes <#issue-number>"
