### PR TITLE
Allow multivariate data to be returned in a dense form

### DIFF
--- a/examples/handling_ragged_arrays.py
+++ b/examples/handling_ragged_arrays.py
@@ -86,8 +86,80 @@ from mne_connectivity import spectral_connectivity_epochs
 # MNE-Connectivity combine information across the different channels into a
 # single (time-)frequency-resolved connectivity spectrum, regardless of the
 # number of seed and target channels, so ragged arrays are not a concern here.
+
+########################################################################################
+# Extracting data for multivariate connectivity
+# ---------------------------------------------
 #
-# However, the maximised imaginary part of coherency (MIC) method also returns
+# Below, we compute multivariate connectivity using the maximised imaginary part of
+# coherency (MIC) (see :doc:`mic_mim` for more information). Just like for bivariate
+# connectivity, we can extract the connectivity in 'raveled' and 'dense' forms.
+
+# %%
+
+# Create random data
+data = np.random.randn(10, 5, 200)  # epochs x channels x times
+sfreq = 50
+ragged_indices = (
+    [[0, 1], [0, 1, 2, 3]],  # seeds
+    [[2, 3, 4], [4]],  # targets
+)
+
+# Compute multivariate connectivity
+con = spectral_connectivity_epochs(
+    data,
+    method="mic",
+    indices=ragged_indices,
+    sfreq=sfreq,
+    fmin=10,
+    fmax=30,
+    verbose=False,
+)
+
+########################################################################################
+# The 'raveled' form directly returns the connectivity data that is stored in the
+# connectivity object, that is, an array of shape ``(n_connections, ...)``, where
+# ``...`` represents the remaining dimensions of the connectivity data (e.g.
+# frequencies, times).
+
+# %%
+
+raveled_data = con.get_data(output="raveled")
+print(f"Raveled connectivity shape: {raveled_data.shape} (connections x freqs)")
+
+########################################################################################
+# In contrast, the 'dense' form requires a manipulation of the data into a square matrix
+# of shape ``(n_nodes, n_nodes, ...)``. Since in the context of multivariate
+# connectivity, a node can be a set of multiple channels, it is not possible to treat
+# each row/column of the dense matrix as the entry for a single channel, as you would
+# for bivariate connectivity.
+#
+# Because of this, the multivariate indices are mapped into a new 'dense' matrix space,
+# which allows a square matrix to be returned. To ensure the mapping from the original
+# multivariate indices to the new dense matrix space is traceable, the tuple of
+# multivariate nodes in the original indices are returned. This contains the (unmasked
+# form) of each node, in the position where it exists in the dense matrix space.
+
+# %%
+
+dense_data, multivariate_nodes = con.get_data(output="dense")
+print(
+    f"Multivariate nodes: {tuple(node.tolist() for node in multivariate_nodes)}; "
+    f"{len(multivariate_nodes)} total"
+)
+print(f"Dense connectivity shape: {dense_data.shape} (nodes x nodes x freqs)")
+
+# This mapping is done by taking the set of channels that define each node and assigning
+# them a new index based on where they appear in the original seed indices, and then
+# target indices.
+mapped_indices = (np.array([0, 1]), np.array([2, 3]))
+assert np.all(raveled_data == dense_data[mapped_indices[0], mapped_indices[1]])
+
+########################################################################################
+# Working with spatial patterns of connectivity from ragged indices
+# -----------------------------------------------------------------
+#
+# The maximised imaginary part of coherency (MIC) method also returns
 # spatial patterns of connectivity, which show the contribution of each channel
 # to the dimensionality-reduced connectivity estimate (explained in more detail
 # in :doc:`mic_mim`). Because these patterns are returned for each channel,
@@ -101,56 +173,39 @@ from mne_connectivity import spectral_connectivity_epochs
 
 # %%
 
-# create random data
-data = np.random.randn(10, 5, 200)  # epochs x channels x times
-sfreq = 50
-ragged_indices = ([[0, 1], [0, 1, 2, 3]], [[2, 3, 4], [4]])  # seeds  # targets
-
-# compute connectivity
-con = spectral_connectivity_epochs(
-    data,
-    method="mic",
-    indices=ragged_indices,
-    sfreq=sfreq,
-    fmin=10,
-    fmax=30,
-    verbose=False,
-)
 patterns = np.array(con.attrs["patterns"])
 padded_indices = con.indices
 n_freqs = con.get_data().shape[-1]
 n_cons = len(ragged_indices[0])
 max_n_chans = max(len(inds) for inds in ([*ragged_indices[0], *ragged_indices[1]]))
 
-# show that the padded indices entries are masked
+# Show that the padded indices entries are masked
 assert np.sum(padded_indices[0][0].mask) == 2  # 2 padded channels
 assert np.sum(padded_indices[1][0].mask) == 1  # 1 padded channels
 assert np.sum(padded_indices[0][1].mask) == 0  # 0 padded channels
 assert np.sum(padded_indices[1][1].mask) == 3  # 3 padded channels
 
-# patterns have shape [seeds/targets x cons x max channels x freqs (x times)]
+# Patterns have shape [seeds/targets x cons x max channels x freqs (x times)]
 assert patterns.shape == (2, n_cons, max_n_chans, n_freqs)
 
-# show that the padded patterns entries are all np.nan
+# Show that the padded patterns entries are all np.nan
 assert np.all(np.isnan(patterns[0, 0, 2:]))  # 2 padded channels
 assert np.all(np.isnan(patterns[1, 0, 3:]))  # 1 padded channels
 assert not np.any(np.isnan(patterns[0, 1]))  # 0 padded channels
 assert np.all(np.isnan(patterns[1, 1, 1:]))  # 3 padded channels
 
-# extract patterns for first connection using the ragged indices
+# Extract patterns for first connection using the ragged indices
 seed_patterns_con1 = patterns[0, 0, : len(ragged_indices[0][0])]
 target_patterns_con1 = patterns[1, 0, : len(ragged_indices[1][0])]
 
-# extract patterns for second connection using the padded, masked indices
+# Extract patterns for second connection using the padded, masked indices
 seed_patterns_con2 = patterns[0, 1, : padded_indices[0][1].count()]
 target_patterns_con2 = patterns[1, 1, : padded_indices[1][1].count()]
 
-# show that shapes of patterns are correct
+# Show that shapes of patterns are correct
 assert seed_patterns_con1.shape == (2, n_freqs)  # channels (0, 1)
 assert target_patterns_con1.shape == (3, n_freqs)  # channels (2, 3, 4)
 assert seed_patterns_con2.shape == (4, n_freqs)  # channels (0, 1, 2, 3)
 assert target_patterns_con2.shape == (1, n_freqs)  # channels (4)
 
 print("Assertions completed successfully!")
-
-# %%

--- a/examples/handling_ragged_arrays.py
+++ b/examples/handling_ragged_arrays.py
@@ -92,8 +92,8 @@ from mne_connectivity import spectral_connectivity_epochs
 # ---------------------------------------------
 #
 # Below, we compute multivariate connectivity using the maximised imaginary part of
-# coherency (MIC) (see :doc:`mic_mim` for more information). Just like for bivariate
-# connectivity, we can extract the connectivity in 'raveled' and 'dense' forms.
+# coherency (MIC; see :doc:`mic_mim` for more information). Just like for bivariate
+# connectivity, we can extract the connectivity in ``'raveled'`` and ``'dense'`` forms.
 
 # %%
 
@@ -117,9 +117,9 @@ con = spectral_connectivity_epochs(
 )
 
 ########################################################################################
-# The 'raveled' form directly returns the connectivity data that is stored in the
-# connectivity object, that is, an array of shape ``(n_connections, ...)``, where
-# ``...`` represents the remaining dimensions of the connectivity data (e.g.
+# The ``'raveled'`` form directly returns the connectivity data that is stored in the
+# connectivity object. That is, an array of shape ``(n_connections, ...)``, where
+# ``...`` represents the remaining dimensions of the connectivity data (e.g.,
 # frequencies, times).
 
 # %%
@@ -128,31 +128,39 @@ raveled_data = con.get_data(output="raveled")
 print(f"Raveled connectivity shape: {raveled_data.shape} (connections x freqs)")
 
 ########################################################################################
-# In contrast, the 'dense' form requires a manipulation of the data into a square matrix
-# of shape ``(n_nodes, n_nodes, ...)``. Since in the context of multivariate
+# In contrast, the ``'dense'`` form requires a manipulation of the data into a square
+# matrix of shape ``(n_nodes, n_nodes, ...)``. Since in the context of multivariate
 # connectivity, a node can be a set of multiple channels, it is not possible to treat
-# each row/column of the dense matrix as the entry for a single channel, as you would
-# for bivariate connectivity.
+# each row/column of the dense matrix as the entry for a single channel (as you would
+# for bivariate connectivity).
 #
-# Because of this, the multivariate indices are mapped into a new 'dense' matrix space,
+# Because of this, the multivariate indices are mapped into a new dense matrix space,
 # which allows a square matrix to be returned. To ensure the mapping from the original
-# multivariate indices to the new dense matrix space is traceable, the tuple of
+# multivariate indices to the new dense matrix space is traceable, a tuple of
 # multivariate nodes in the original indices are returned. This contains the (unmasked
 # form) of each node, in the position where it exists in the dense matrix space.
 
 # %%
 
 dense_data, multivariate_nodes = con.get_data(output="dense")
-print(
-    f"Multivariate nodes: {tuple(node.tolist() for node in multivariate_nodes)}; "
-    f"{len(multivariate_nodes)} total"
-)
 print(f"Dense connectivity shape: {dense_data.shape} (nodes x nodes x freqs)")
 
 # This mapping is done by taking the set of channels that define each node and assigning
 # them a new index based on where they appear in the original seed indices, and then
 # target indices.
+print(
+    f"Original ragged indices: seeds {ragged_indices[0]}; targets {ragged_indices[1]}"
+)
+print(
+    f"Multivariate nodes: {tuple(node.tolist() for node in multivariate_nodes)}; "
+    f"{len(multivariate_nodes)} total"
+)
 mapped_indices = (np.array([0, 1]), np.array([2, 3]))
+print(
+    f"Mapped indices in dense matrix space: "
+    f"seeds {[node.tolist() for node in mapped_indices[0]]}; "
+    f"targets {[node.tolist() for node in mapped_indices[1]]}"
+)
 assert np.all(raveled_data == dense_data[mapped_indices[0], mapped_indices[1]])
 
 ########################################################################################

--- a/mne_connectivity/base.py
+++ b/mne_connectivity/base.py
@@ -18,7 +18,12 @@ from mne.utils import (
     warn,
 )
 
-from mne_connectivity.utils import _prepare_xarray_mne_data_structures, fill_doc
+from mne_connectivity.utils import (
+    _check_if_multivariate_indices,
+    _get_unique_multivariate_nodes_and_indices,
+    _prepare_xarray_mne_data_structures,
+    fill_doc,
+)
 from mne_connectivity.viz import plot_connectivity_circle
 
 
@@ -733,14 +738,49 @@ class BaseConnectivity(EpochMixin):
             - ``'compact'`` (default) will return ``'raveled'`` if ``indices`` were
               defined as a tuple of arrays, or ``'dense'`` if ``indices='all'``
 
-            Multivariate connectivity data cannot be returned in a dense form.
-
         Returns
         -------
         data : array
             The output connectivity data.
+        multivariate_nodes : tuple of array
+            Returned if the connectivity data is multivariate with ``self.indices``
+            defined as a tuple of arrays, and ``output='dense'``. Used to map from the
+            original set of indices to the dense matrix space. See notes for more
+            information.
+
+        Notes
+        -----
+        Because multivariate connectivity data can involve multiple channels per
+        connection, it is not possible to represent the data in a dense matrix form
+        where each row/column represent a single channel.
+
+        Instead, the multivariate data is mapped into a new space, based on the set of
+        channels that define each node. E.g., the multivariate indices::
+
+            (
+                [[0, 1], [0, 1], [2, 3]],  # seeds
+                [[2, 3], [4, 5], [4, 5]]   # targets
+            )
+
+        contains the following sets of channels: ``[0, 1]`` (node 0); ``[2, 3]``
+        (node 1); and ``[4, 5]`` (node 2). Based on this, the multivariate indices can
+        be mapped to a new space with indices::
+
+            (
+                [0, 0, 1],  # seeds
+                [1, 2, 2]   # targets
+            )
+
+        For a dense connectivity matrix, this would return a ``(3, 3)`` upper-triangular
+        array.
+
+        To ensure the mapping from the original multivariate indices to the new dense
+        matrix space is traceable, ``multivariate_nodes`` is returned, which contains
+        each node in the position where it exists in the dense matrix space. For the
+        above example, ``multivariate_nodes`` would be ``[[0, 1], [2, 3], [4, 5]]``.
         """
         _check_option("output", output, ["raveled", "dense", "compact"])
+        multivariate_nodes = None
 
         if output == "compact":
             if self.indices in ["all", "symmetric"]:
@@ -751,22 +791,18 @@ class BaseConnectivity(EpochMixin):
         if output == "raveled":
             data = self._data
         else:
-            if (
-                isinstance(self.indices, tuple)
-                and not np.all(
-                    [np.issubdtype(type(ind), int) for ind in self.indices[0]]
+            # Check if indices are for multivariate connectivity
+            if isinstance(self.indices, tuple) and _check_if_multivariate_indices(
+                self.indices
+            ):
+                # Remap multivariate indices from channels to the unique nodes
+                # (nodes here are considered a set of channels)
+                multivariate_nodes, indices = (
+                    _get_unique_multivariate_nodes_and_indices(self.indices)
                 )
-                and not np.all(
-                    [np.issubdtype(type(ind), int) for ind in self.indices[1]]
-                )
-            ):  # i.e. check if multivariate results based on nested indices
-                # multivariate results cannot be returned in a dense form as a single
-                # set of results would correspond to multiple entries in the matrix, and
-                # there could also be cases where multiple results correspond to the
-                # same entries in the matrix.
-                raise ValueError(
-                    "cannot return multivariate connectivity data in a dense form"
-                )
+                n_nodes = len(multivariate_nodes)
+            else:
+                indices, n_nodes = self.indices, self.n_nodes
 
             # get the new shape of the data array
             if self.is_epoched:
@@ -777,7 +813,7 @@ class BaseConnectivity(EpochMixin):
             # handle the case where model order is defined in VAR connectivity
             # and thus appends the connectivity matrices side by side, so the
             # shape is N x N * lags
-            new_shape.extend([self.n_nodes, self.n_nodes])
+            new_shape.extend([n_nodes, n_nodes])
             if "components" in self.dims:
                 new_shape.append(len(self.coords["components"]))
             if "freqs" in self.dims:
@@ -785,23 +821,23 @@ class BaseConnectivity(EpochMixin):
             if "times" in self.dims:
                 new_shape.append(len(self.coords["times"]))
 
-            if isinstance(self.indices, tuple) or self.indices == "symmetric":
+            if isinstance(indices, tuple) or indices == "symmetric":
                 if np.iscomplexobj(self._data):
                     fill_value = np.nan + 1j * np.nan
                 else:
                     fill_value = np.nan
                 data = np.full(new_shape, fill_value=fill_value, dtype=self._data.dtype)
 
-            if isinstance(self.indices, tuple):
+            if isinstance(indices, tuple):
                 # handle things differently if indices is defined
-                row_idx, col_idx = self.indices
+                row_idx, col_idx = indices
                 if self.is_epoched:
                     data[:, row_idx, col_idx, ...] = self._data
                 else:
                     data[row_idx, col_idx, ...] = self._data
-            elif self.indices == "symmetric":
+            elif indices == "symmetric":
                 # get the upper/lower triangular indices
-                row_triu_inds, col_triu_inds = np.triu_indices(self.n_nodes, k=0)
+                row_triu_inds, col_triu_inds = np.triu_indices(n_nodes, k=0)
                 if self.is_epoched:
                     data[:, row_triu_inds, col_triu_inds, ...] = self._data
                     data[:, col_triu_inds, row_triu_inds, ...] = self._data
@@ -811,6 +847,8 @@ class BaseConnectivity(EpochMixin):
             else:
                 data = self._data.reshape(new_shape)
 
+        if multivariate_nodes is not None:
+            return data, multivariate_nodes
         return data
 
     def rename_nodes(self, mapping):

--- a/mne_connectivity/base.py
+++ b/mne_connectivity/base.py
@@ -776,8 +776,9 @@ class BaseConnectivity(EpochMixin):
 
         To ensure the mapping from the original multivariate indices to the new dense
         matrix space is traceable, ``multivariate_nodes`` is returned, which contains
-        each node in the position where it exists in the dense matrix space. For the
-        above example, ``multivariate_nodes`` would be ``[[0, 1], [2, 3], [4, 5]]``.
+        the (unmasked form) of each node in the position where it exists in the dense
+        matrix space. For the above example, ``multivariate_nodes`` would be
+        ``[[0, 1], [2, 3], [4, 5]]``.
         """
         _check_option("output", output, ["raveled", "dense", "compact"])
         multivariate_nodes = None

--- a/mne_connectivity/tests/test_connectivity.py
+++ b/mne_connectivity/tests/test_connectivity.py
@@ -149,25 +149,11 @@ def test_connectivity_containers(conn_cls, n_components):
     with pytest.raises(ValueError, match="Indices can only be"):
         conn_cls(data=correct_numpy_input, indices="square", n_nodes=2, **extra_kwargs)
 
-    indices = ([0, 1], [1, 0])
     conn = conn_cls(data=correct_numpy_input, n_nodes=3, **extra_kwargs)
 
     # test that get_data works as intended
     with pytest.raises(ValueError, match="Invalid value for the 'output' parameter"):
         conn.get_data(output="blah")
-    with pytest.raises(
-        ValueError, match="cannot return multivariate connectivity data in a dense form"
-    ):
-        multivar_conn = conn_cls(
-            data=correct_numpy_input,
-            n_nodes=n_nodes,
-            indices=(
-                [[ind] for ind in range(n_nodes**2)],
-                [[ind] for ind in range(n_nodes**2)],
-            ),
-            **extra_kwargs,
-        )
-        multivar_conn.get_data(output="dense")
 
     assert conn.shape == tuple(correct_numpy_shape)
     assert conn.get_data(output="raveled").shape == tuple(correct_numpy_shape)
@@ -196,6 +182,7 @@ def test_connectivity_containers(conn_cls, n_components):
     assert_array_equal(orig_names, conn.names)
 
     # test connectivity instantiation with indices
+    indices = ([0, 1], [1, 0])
     indexed_numpy_shape, index_kwargs = _prep_correct_connectivity_input(
         conn_cls, n_nodes=n_nodes, symmetric=False, n_epochs=n_epochs, indices=indices
     )
@@ -244,6 +231,44 @@ def test_connectivity_containers(conn_cls, n_components):
             for idx in range(len(dense_shape))
         ]
     )
+
+
+def test_get_multivariate_data():
+    """Test that get_data works properly with multivariate data."""
+    indices = (
+        np.array([[0, 1], [0, 1], [2, 3]]),
+        np.array([[2, 3], [4, 5], [4, 5]]),
+    )  # should map to upper-triangular elements
+
+    # Find individual channels and nodes (sets of channels) in the data
+    chans, nodes = set(), set()
+    for seed, target in zip(*indices):
+        for ch in seed:
+            chans.add(ch)
+        for ch in target:
+            chans.add(ch)
+        nodes.add(tuple(seed))
+        nodes.add(tuple(target))
+
+    data = np.arange(len(indices[0]), dtype=np.float64)
+    con = Connectivity(data=data, indices=indices, n_nodes=len(chans))
+
+    # Check no manipulation is performed for raveled output
+    matrix = con.get_data(output="raveled")
+    assert isinstance(matrix, np.ndarray)  # just data expected
+    assert_array_equal(data, matrix)
+
+    # Check that output gets mapped to new space for dense output
+    out = con.get_data(output="dense")
+    assert isinstance(out, tuple)  # data and multivariate_nodes expected
+    assert len(out) == 2
+    matrix, multivariate_nodes = out
+    assert isinstance(matrix, np.ndarray)
+    assert isinstance(multivariate_nodes, tuple)
+    assert np.all(isinstance(ind, np.ndarray) for ind in multivariate_nodes)
+    triu_indices = np.triu_indices(len(nodes), k=1)
+    # TODO VERSION: use [*triu_indices] when Py3.10 dropped
+    assert_array_equal(matrix[triu_indices[0], triu_indices[1]], data)
 
 
 @pytest.mark.parametrize(

--- a/mne_connectivity/utils/__init__.py
+++ b/mne_connectivity/utils/__init__.py
@@ -1,6 +1,8 @@
 from .docs import fill_doc
 from .utils import (
+    _check_if_multivariate_indices,
     _check_multivariate_indices,
+    _get_unique_multivariate_nodes_and_indices,
     _prepare_xarray_mne_data_structures,
     check_indices,
     degree,

--- a/mne_connectivity/utils/utils.py
+++ b/mne_connectivity/utils/utils.py
@@ -376,3 +376,40 @@ def _prepare_xarray_mne_data_structures(conn_obj):
         conn_obj.attrs["event_id_vals"] = list(conn_obj.event_id.values())
 
     return conn_obj
+
+
+def _check_if_multivariate_indices(indices):
+    """Check if indices are for multivariate connectivity."""
+    return not np.all(
+        [np.issubdtype(type(ind), int) for ind in indices[0]]
+    ) and not np.all([np.issubdtype(type(ind), int) for ind in indices[1]])
+
+
+def _get_unique_multivariate_nodes_and_indices(indices):
+    """Get the unique multivariate nodes from the indices parameter."""
+    unique_nodes = []
+    for node_ind in (*indices[0], *indices[1]):
+        if isinstance(node_ind, np.ma.MaskedArray):
+            node_ind = node_ind.compressed()
+        node_ind = tuple(node_ind)
+        if node_ind not in unique_nodes:
+            unique_nodes.append(node_ind)
+    unique_nodes = tuple(np.array(node) for node in unique_nodes)
+
+    node_indices = ([], [])
+    for seed, target in zip(*indices):
+        if isinstance(seed, np.ma.MaskedArray):
+            seed = seed.compressed()
+        if isinstance(target, np.ma.MaskedArray):
+            target = target.compressed()
+        for node_idx, node in enumerate(unique_nodes):
+            if np.array_equal(node, seed):
+                node_indices[0].append(node_idx)
+                break
+        for node_idx, node in enumerate(unique_nodes):
+            if np.array_equal(node, target):
+                node_indices[1].append(node_idx)
+                break
+    node_indices = (np.array(node_indices[0]), np.array(node_indices[1]))
+
+    return unique_nodes, node_indices


### PR DESCRIPTION
Fixes #458

Remaps multivariate indices into the unique nodes of the connectivity, allowing multivariate connectivity to be represented in a dense form.