### PR TITLE
Update indexing to make consistent

### DIFF
--- a/.github/workflows/linux_conda.yml
+++ b/.github/workflows/linux_conda.yml
@@ -36,9 +36,6 @@ jobs:
           create-args: >- # beware the >- instead of |, we don't split on newlines but on spaces
             python=${{ env.PYTHON_VERSION }}
       - run: |
-          curl https://raw.githubusercontent.com/mne-tools/mne-python/main/tools/get_minimal_commands.sh -o get_minimal_commands.sh
-          chmod +x get_minimal_commands.sh
-          source ./get_minimal_commands.sh
           pip install .[test]
         name: 'Install dependencies'
       - run: pip install git+https://github.com/mne-tools/mne-python@main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,240 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents when working with code in this repository.
+
+## What this is
+
+MNE-Connectivity estimates connectivity between sensors or sources of neurophysiological
+data (MEG, EEG, iEEG) and stores the result in xarray-backed container classes. MNE-Python
+owns what comes in (`Epochs`, `SourceEstimate`, plain arrays) and the spectral machinery
+(multitaper, Morlet, `EpochsTFR`); this package owns everything from the cross-spectral
+density onward, plus the containers, their netCDF I/O, and the connectivity-specific
+visualization.
+
+## Follow MNE-Python's conventions
+
+This package is a subsidiary of MNE-Python. Unless something below says otherwise, follow
+[MNE-Python's AGENTS.md](https://github.com/mne-tools/mne-python/blob/main/AGENTS.md)
+(read it rather than guessing): naming, numpydoc style with its local deviations, absolute
+and lazily-nested imports, `@verbose`, shared docstrings via `@fill_doc`, `# TODO VERSION`
+markers, towncrier changelog fragments, compact tests, license rules for adapted code, and
+in particular its
+[policy on AI assistance](https://github.com/mne-tools/mne-python/blob/main/CONTRIBUTING.md#policy-on-ai-assistance-in-contributions):
+
+- Work test-first: write (or extend) a test that fails for the right reason, then make it
+  pass. Promote anything a throwaway script caught into a real test.
+- Do not open pull requests, push, or commit unless explicitly asked; the human submitting
+  the change must review, understand, and disclose AI use in the PR description.
+- Keep changes minimal and scoped to the request; mention, don't silently fix, unrelated
+  problems you notice.
+
+What does *not* carry over from MNE-Python:
+
+- There are no lazy `__init__.pyi` stubs. The public API is the explicit import list in
+  `mne_connectivity/__init__.py` (plus `mne_connectivity.decoding` and
+  `mne_connectivity.viz`), and anything public must also be listed in `doc/api.rst` or
+  Sphinx cross-references to it will not resolve.
+- The docdict is this package's own (`mne_connectivity/utils/docs.py`, used via
+  `from .utils import fill_doc`), *not* MNE's — MNE's entries are not visible here. Grep
+  that file before writing a parameter description by hand.
+- Deprecations do not use `@mne.utils.deprecated`. The pattern is `mne.utils.warn(...,
+  FutureWarning)` at the top of the function plus a `.. version-deprecated:: X.Y` note in
+  the docstring, saying what to use instead and naming the version that removes it (see
+  `datasets/surrogate.py` and `datasets/frequency.py`).
+- Tests use simulated data (`make_signals_in_freq_bands`, `make_surrogate_*`), not the MNE
+  testing dataset; only `viz/tests/test_3d.py` needs the dataset.
+- There is no `make ruff`; run `pre-commit run -a` (or `make pre-commit`). Most other
+  Makefile targets are stale copies from MNE-Python and still reference `mne`.
+
+## Project context
+
+The next release is v1.0 and it is deliberately a breaking one — separating array-like from
+MNE-object inputs, requiring precomputed spectra, reworking all-to-all vs. symmetric
+indexing, moving Granger causality to dedicated functions, and dropping VAR-/epoch-specific
+methods from containers that should never have had them. See
+[#440](https://github.com/mne-tools/mne-connectivity/issues/440) and the "Upcoming breaking
+changes" section of `doc/changes/v0.9.rst` before designing anything that touches those
+areas.
+
+## Verify before you trust this file
+
+Most changes here are made by humans, and nothing keeps this file in sync with the code.
+What it describes — especially in the two sections that follow — is meant to be the
+*durable* shape of the package, but specific names, string options, and parameter sets do
+change, and indexing in particular is actively being reworked. So treat this file as a map
+of where to look, not as an API reference: grep for the name, read the current docstring or
+docdict entry, and check the behavior in a REPL before you rely on it.
+
+If something here turns out to be stale, update this file as part of your change and
+mention it. If the drift is real but outside the scope of what you were asked to do, say so
+in your summary rather than quietly working around it.
+
+## Layout
+
+- `base.py` — the connectivity containers: an `xarray.DataArray` of data plus mixins that
+  add the epoch, frequency, and time dimensions. Storage layout, `get_data`, `save`,
+  node renaming, and the VAR-model methods all live here.
+- `spectral/` — the two spectral entry points. `spectral_connectivity_epochs` uses
+  estimator classes that accumulate over epochs (bivariate and multivariate ones in
+  separate modules); `spectral_connectivity_time` is a separate per-epoch implementation.
+  The method registries and the lists that classify methods by capability sit next to the
+  estimators.
+- `effective.py`, `envelope.py`, `wsmi.py`, `vector_ar/` — the non-spectral estimators, one
+  concern each. VAR model coefficients ride in a container and drive its `predict`/
+  `simulate` methods.
+- `decoding/` — scikit-learn-style estimators (`fit`/`transform`, trailing-underscore
+  attributes, their own plotting methods).
+- `datasets/` — simulated data with known ground truth; most tests are built on it.
+- `io.py` — the netCDF round-trip. `viz/` — the plotting entry points (`plot_connectivity`
+  for matrices, `plot_spectral_connectivity`/`plot_temporal_connectivity` for lines with
+  circle-plot overviews, `plot_spectrotemporal_connectivity` for images) sharing one
+  `helpers.py`, plus the older circle and 3D plots that are thin wrappers over MNE-Python.
+- `utils/` — this package's docdict and the `indices` helpers.
+
+## Things that bite
+
+- **Connectivity data is stored raveled, not dense**, with the number of stored connections
+  depending on how `indices` was specified; the container reshapes on request. `get_data()`
+  defaults to a "compact" format whose shape therefore depends on how the object was
+  constructed — ask for the format you actually want rather than inferring it.
+- **`indices` is the central abstraction and the one most in flux.** It spans string forms
+  (all-to-all, triangular) and explicit tuples of seed/target arrays, with different rules
+  for bivariate vs. multivariate methods and for directed vs. undirected ones, and
+  reconstructing a dense matrix from a partial one is not always possible. Read the current
+  `indices` docdict entry and the helpers in `utils/` and route through them; do not
+  type-sniff or hard-code the accepted values inline.
+- **Multivariate connections are ragged** — each connection has its own number of seed and
+  target channels — so they are padded into rectangular masked arrays with a sentinel fill
+  value, including on disk. A sentinel must never reach fancy indexing, where it silently
+  means "some real channel". `examples/handling_ragged_arrays.py` is the user-facing
+  explanation.
+- A multivariate "node" is a *set* of channels, not a channel, so dense output for
+  multivariate data cannot be a plain per-channel matrix and the call returns extra
+  information to map back. Code that assumes a bare array back breaks on multivariate input.
+- **The two spectral entry points are independent implementations** with overlapping but
+  unequal sets of supported methods; bivariate methods are written twice. Adding or changing
+  a method means the registries, the per-method capability lists, the docdict entry, the
+  method lists in both docstrings, and the parametrized tests — check whether it belongs in
+  both before assuming it does.
+- Multivariate methods carry machinery bivariate ones do not (rank reduction, multiple
+  components, spatial patterns, model order), and not every multivariate method supports
+  every piece: the capability lists next to the estimators are the source of truth, not the
+  method name. Granger causality is the numerically fragile one — the solver raises on
+  non-convergence, and reducing rank is usually the fix.
+- Container state ends up as xarray `attrs` and must survive a netCDF round-trip: no `None`,
+  no dicts, no nested structures — which is why some attributes are stored in a flattened
+  or padded form. Add an attribute, add a save/read round-trip assertion.
+- **Container attributes are handed out by reference.** `con.names` returns the list living
+  in the xarray `attrs`, not a copy, so `names = con.names; names[idx] = ...` renames the
+  nodes on the object the caller passed in — and on any list they built it from. Copy before
+  you write.
+- **`con.indices` is not one type.** Depending on how the object was built it comes back as
+  `None`, a string, a tuple of 1-D integer arrays, a 2-D padded masked array, or a tuple of
+  *lists* of variable-length arrays. Anything that indexes into it (`indices[0][picks]`) has
+  to handle all of them, so normalize once at the entry point rather than type-sniffing later.
+- **Channel-level `picks`/`exclude` do not map onto connections one-to-one**, because a
+  connection has two endpoints. Say explicitly whether a connection survives when *any* or
+  *all* of its endpoints do — `picks` usually means "any", `exclude` usually means "none" —
+  and make the docstring and the code agree.
+- MNE-Python is a moving target here: CI runs against both `mne` stable and `mne` main, and
+  a few private MNE APIs are used. Prefer public API, and guard imports with `try`/`except
+  ImportError` plus a `# TODO VERSION` comment when you can't.
+
+## Tests
+
+```bash
+pytest mne_connectivity              # ~600 tests
+pytest -n auto mne_connectivity      # what CI does; ~1.5 min on a fast laptop
+pytest -n 0 --pdb mne_connectivity/spectral/tests/test_spectral.py -k cacoh
+```
+
+Warnings are errors (see `mne_connectivity/conftest.py`). The spectral tests dominate the
+runtime, so `-n auto` is worth it, and adding another `@pytest.mark.parametrize` axis over
+all methods is expensive — extend an existing test where you can.
+
+Simulate rather than load: `make_signals_in_freq_bands` gives you two "regions" with a known
+interaction in a known band, which is what most tests assert against. `viz/tests/test_3d.py`
+needs the MNE testing dataset plus pyvistaqt and Qt (skipped otherwise); run Qt/PyVista tests
+headless with `xvfb-run -a` or `QT_QPA_PLATFORM=offscreen`.
+
+Interactive Matplotlib plots are driven with `_fake_click` / `_fake_keypress` /
+`_fake_scroll` from `mne.viz.utils`, which work on any figure — these are plain Matplotlib
+figures, not MNE-Python's browser `MNEFigure`, so there is no `fig._fake_*` method to reach
+for. Call `fig.canvas.draw()` before faking events, or the coordinates go through
+pre-layout transforms; clicking a line at its own data coordinates also fires `pick_event`.
+
+Run `pre-commit run -a` before handing work back.
+
+## Check the numbers, not just the shapes
+
+This is a numerical package: a change can produce an array of exactly the right shape and
+still be wrong. Assertions on `.shape` and `pytest.raises` are the cheap half of the work.
+Before calling a change done, pin the values down against something you know independently:
+
+- simulated data with a known interaction (`make_signals_in_freq_bands`) — the connectivity
+  should peak in the simulated band and sit near the noise floor elsewhere;
+- an equivalence that must hold — a multivariate method with one channel per seed/target
+  against its bivariate counterpart, `gc_tr` against `gc` computed on time-reversed data,
+  a directed method against itself with seeds and targets swapped, a symmetric method
+  against its transpose, `spectral_connectivity_epochs` against
+  `spectral_connectivity_time` on the same data (within tolerance);
+- known bounds and identities — coherence in [0, 1], `imcoh` zero for zero-lag coupling,
+  `dpli` at 0.5 for no preferred direction;
+- a save/read round-trip through `read_connectivity` whenever containers are touched.
+
+Keep exploratory scripts in scratch space, and promote whatever they caught into a real test.
+
+## Look at it before you believe it
+
+Plotting code can pass every assertion and still be wrong on screen. Before calling a visual
+change done, render a representative figure, actually look at the PNG, *and* print the
+artists' properties — the two catch different bugs. A squashed colorbar or an unreadable
+pile of labels is obvious in an image and invisible to assertions; a connection drawn in the
+colormap's "bad" color merely looks dark until you print `line.get_color()`.
+
+```python
+import matplotlib; matplotlib.use("agg")
+fig, (line_ax, circle_ax) = plot_spectral_connectivity(con, show=False)
+fig.canvas.draw()  # constrained layout: transforms are not final until this runs
+fig.savefig("shot.png")  # then read the PNG
+print([line.get_color() for line in line_ax.lines], line_ax.get_title())
+```
+
+When you change plotting code that already exists, do it as an A/B. Script a battery of
+cases that saves one PNG per case — recording an exception as an outcome too, so the same
+script runs against both versions — render it, `git checkout HEAD -- <the files you
+touched>`, render into a second directory, restore, and compare the two pixel-wise. Most
+cases should come back identical, which is what tells you a refactor really was a no-op, and
+every difference should be one you can name and defend as a fix.
+
+The docstring is the test plan: exercise every documented *form* of every parameter, not
+just the common one — a shape the docstring promises but nothing ever plots (`(2,)`
+alongside `(n, 2)`) is exactly where these functions break. Cover the degenerate ends too:
+one connection, two nodes, a constant-valued array, all-negative data. For multivariate
+results those are not edge cases but the normal shape of a seed-and-target analysis, and
+because warnings are errors a `RuntimeWarning` out of a zero-width color range is a test
+failure, not a cosmetic complaint.
+
+Honor `show` through `mne.viz.utils.plt_show` rather than calling `plt.show()`, which warns
+under the Agg backend the tests run on, and return the figure(s) you made.
+
+## Changelog
+
+User-facing changes need `doc/changes/dev/<PR-number>.<type>.rst` (types: `notable`,
+`dependency`, `bugfix`, `apichange`, `newfeature`, `other`). One short sentence ending with
+the contributor's name link, e.g. "Fix bug where X did Y, by `Jane Doe`_." — read a couple of
+the entries in `doc/changes/v0.9.rst` first. The name anchor must exist in
+`doc/changes/names.inc` (pre-commit keeps that file sorted). A CI job enforces the fragment;
+the `no-changelog-entry-needed` label is the escape hatch.
+
+The `<PR-number>` for a not-yet-opened PR is one more than the highest number currently in
+use; issues and PRs share one sequence, so query the most recently created of either:
+
+```bash
+gh api "repos/mne-tools/mne-connectivity/issues?state=all&per_page=1&sort=created&direction=desc" \
+    --jq '.[0].number'
+```
+
+New functionality should generally also show up in an example under `examples/` (built by
+sphinx-gallery into the docs) for discoverability. Build the docs with `make -C doc html`,
+or `make -C doc html-noplot` to skip running the examples.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+See @AGENTS.md for guidance on working with this repository.

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -102,8 +102,12 @@ Visualization functions
 .. autosummary::
    :toctree: generated/
 
+   plot_connectivity
    plot_sensors_connectivity
    plot_connectivity_circle
+   plot_spectral_connectivity
+   plot_temporal_connectivity
+   plot_spectrotemporal_connectivity
 
 Dataset functions
 =================

--- a/doc/changes/dev/460.newfeature.rst
+++ b/doc/changes/dev/460.newfeature.rst
@@ -1,0 +1,1 @@
+Add :func:`mne_connectivity.plot_connectivity`, :func:`mne_connectivity.plot_spectral_connectivity`, :func:`mne_connectivity.plot_temporal_connectivity`, and :func:`mne_connectivity.plot_spectrotemporal_connectivity` for visualising connectivity results, by `Thomas Binns`_.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -107,6 +107,7 @@ numpydoc_xref_ignore = {
     "object",
     "self.verbose",
     # shapes
+    "n",
     "n_times",
     "obj",
     "n_chan",

--- a/examples/compare_connectivity_over_time_over_trial.py
+++ b/examples/compare_connectivity_over_time_over_trial.py
@@ -10,6 +10,31 @@ A brief background on the difference between the two conditions is provided,
 followed by examples on simulated data and real EEG data.
 
 """
+
+# Author: Qianliang Li <glia@dtu.dk>
+#
+# License: BSD (3-clause)
+#
+# sphinx_gallery_thumbnail_number = 12
+
+import mne
+import numpy as np
+from mne.datasets import sample
+
+from mne_connectivity import (
+    Connectivity,
+    TemporalConnectivity,
+    spectral_connectivity_epochs,
+    spectral_connectivity_time,
+)
+from mne_connectivity.viz import (
+    plot_connectivity,
+    plot_sensors_connectivity,
+    plot_temporal_connectivity,
+)
+
+rng = np.random.default_rng(1234)  # set seed for reproducibility
+
 ###############################################################################
 # Background
 # ----------
@@ -70,22 +95,6 @@ followed by examples on simulated data and real EEG data.
 # we will employ them on two simulated cases and also analyze a real
 # visual task dataset.
 
-# Author: Qianliang Li <glia@dtu.dk>
-#
-# License: BSD (3-clause)
-
-import matplotlib.pyplot as plt
-import mne
-import numpy as np
-from mne.datasets import sample
-
-from mne_connectivity import spectral_connectivity_epochs, spectral_connectivity_time
-from mne_connectivity.viz import plot_sensors_connectivity
-
-rng = np.random.default_rng(1234)  # set seed for reproducibility
-
-print(__doc__)
-
 ###############################################################################
 # Simulated examples
 # ------------------
@@ -99,8 +108,8 @@ print(__doc__)
 
 n_epochs = 5  # number of simulated epochs
 n_channels = 3  # number of channels
-n_times = 2000  # number of sample points
-sfreq = 250  # Set sampling freq
+n_times = 300  # number of sample points
+sfreq = 100  # Set sampling freq
 data = rng.random((n_epochs, n_channels, n_times))  # generate random data
 
 # In case 1, we overwrite all epochs with the data from the first epoch
@@ -111,7 +120,7 @@ ch_names = ["C3", "Cz", "C4"]  # three random channel names
 info = mne.create_info(ch_names, sfreq, ch_types="eeg")  # create info object
 data_epoch = mne.EpochsArray(data, info)  # create EpochsArray
 
-data_epoch.plot(scalings=0.75)  # Visualize the data
+data_epoch.plot(n_epochs=2, scalings=0.6)  # Visualize the data
 
 ###############################################################################
 # First we compute connectivity over trials.
@@ -129,17 +138,8 @@ freqs = np.linspace(min_freq, max_freq, int((max_freq - min_freq) * 4 + 1))
 fmin = tuple([list(Freq_Bands.values())[f][0] for f in range(len(Freq_Bands))])
 fmax = tuple([list(Freq_Bands.values())[f][1] for f in range(len(Freq_Bands))])
 
-# We will try two different connectivity measurements as an example
+# Compute connectivity for two different connectivity measures over trials
 connectivity_methods = ["coh", "plv"]
-n_con_methods = len(connectivity_methods)
-
-# Pre-allocatate memory for the connectivity matrices
-con_epochs_array = np.zeros(
-    (n_con_methods, n_channels, n_channels, n_freq_bands, n_times)
-)
-con_epochs_array[con_epochs_array == 0] = np.nan  # nan matrix
-
-# Compute connectivity over trials
 con_epochs = spectral_connectivity_epochs(
     data_epoch,
     method=connectivity_methods,
@@ -150,10 +150,6 @@ con_epochs = spectral_connectivity_epochs(
     fmax=fmax,
     faverage=True,
 )
-
-# Get data as connectivity matrices
-for c in range(n_con_methods):
-    con_epochs_array[c] = con_epochs[c].get_data(output="dense")
 
 ###############################################################################
 # As previously mentioned, connectivity over trials can give connectivity
@@ -166,48 +162,25 @@ for c in range(n_con_methods):
 # :class:`mne_connectivity.SpectralConnectivity`, which does not have
 # single timepoint resolution.
 
-con_epochs_array = np.mean(con_epochs_array, axis=4)  # average over timepoints
-
 # In this example, we will just show alpha
 foi = list(Freq_Bands.keys()).index("alpha")  # frequency of interest
 
-
-# Define function for plotting con matrices
-def plot_con_matrix(con_data, n_con_methods):
-    """Visualize the connectivity matrix."""
-    fig, ax = plt.subplots(1, n_con_methods, figsize=(6 * n_con_methods, 6))
-    for c in range(n_con_methods):
-        # Plot with imshow
-        con_plot = ax[c].imshow(con_data[c, :, :, foi], cmap="binary", vmin=0, vmax=1)
-        # Set title
-        ax[c].set_title(connectivity_methods[c])
-        # Add colorbar
-        fig.colorbar(con_plot, ax=ax[c], shrink=0.7, label="Connectivity")
-        # Fix labels
-        ax[c].set_xticks(range(len(ch_names)))
-        ax[c].set_xticklabels(ch_names)
-        ax[c].set_yticks(range(len(ch_names)))
-        ax[c].set_yticklabels(ch_names)
-        print(
-            f"Connectivity method: {connectivity_methods[c]}\n"
-            + f"{con_data[c,:,:,foi]}"
-        )
-    return fig
-
-
-plot_con_matrix(con_epochs_array, n_con_methods)
+for con in con_epochs:
+    con_array = con.get_data()
+    con_array = np.mean(con_array, axis=2)  # average over timepoints
+    con_array = con_array[..., foi]  # select frequency band of interest
+    con_method = Connectivity(
+        con_array, con.n_nodes, con.names, con.indices, con.method
+    )
+    plot_connectivity(
+        con_method, info=data_epoch.info, node_labels="names", vmin=0.0, vmax=1.0
+    )
 
 ###############################################################################
 # We see that when using repeated trials without any noise, the phase coupling
 # between the three electrodes over trials are exactly 1.
 #
 # We will now compute connectivity over time.
-
-# Pre-allocatate memory for the connectivity matrices
-con_time_array = np.zeros(
-    (n_con_methods, n_epochs, n_channels, n_channels, n_freq_bands)
-)
-con_time_array[con_time_array == 0] = np.nan  # nan matrix
 
 # Compute connectivity over time
 con_time = spectral_connectivity_time(
@@ -219,22 +192,22 @@ con_time = spectral_connectivity_time(
     fmin=fmin,
     fmax=fmax,
     faverage=True,
+    average=True,  # average over epochs
 )
 
-# Get data as connectivity matrices
-for c in range(n_con_methods):
-    con_time_array[c] = con_time[c].get_data(output="dense")
-
 ###############################################################################
-# Notice that the connectivity over time function by default gives connectivity
-# for each epoch. We will average over epochs to show similar matrices as
-# before, but it could also be done in the function itself by setting
-# ``average=True``.
+# By default, the connectivity over time function by default gives connectivity
+# for each epoch, but to visualise the results we want to average over epochs, which we
+# do in the function by setting ``average=True``.
 
-con_time_array = np.mean(con_time_array, axis=1)  # average over epochs
-foi = list(Freq_Bands.keys()).index("alpha")  # frequency of interest
-
-plot_con_matrix(con_time_array, n_con_methods)
+for con in con_time:
+    con_array = con.get_data()[..., foi]  # select frequency band of interest
+    con_method = Connectivity(
+        con_array, con.n_nodes, con.names, con.indices, con.method
+    )
+    plot_connectivity(
+        con_method, info=data_epoch.info, node_labels="names", vmin=0.0, vmax=1.0
+    )
 
 ###############################################################################
 # We see that the connectivity over time are not 1, since the signals were
@@ -270,13 +243,6 @@ data_epoch.plot(scalings=1, n_epochs=1)
 ###############################################################################
 # First we compute connectivity over trials.
 
-# Pre-allocatate memory for the connectivity matrices
-con_epochs_array = np.zeros(
-    (n_con_methods, n_channels, n_channels, n_freq_bands, n_times)
-)
-con_epochs_array[con_epochs_array == 0] = np.nan  # nan matrix
-
-# Compute connecitivty over trials
 con_epochs = spectral_connectivity_epochs(
     data_epoch,
     method=connectivity_methods,
@@ -288,27 +254,22 @@ con_epochs = spectral_connectivity_epochs(
     faverage=True,
 )
 
-# Get data as connectivity matrices
-for c in range(n_con_methods):
-    con_epochs_array[c] = con_epochs[c].get_data(output="dense")
-
-con_epochs_array = np.mean(con_epochs_array, axis=4)  # average over timepoints
-
-foi = list(Freq_Bands.keys()).index("alpha")  # frequency of interest
-
-plot_con_matrix(con_epochs_array, n_con_methods)
+for con in con_epochs:
+    con_array = con.get_data()
+    con_array = np.mean(con_array, axis=2)  # average over timepoints
+    con_array = con_array[..., foi]  # select frequency band of interest
+    con_method = Connectivity(
+        con_array, con.n_nodes, con.names, con.indices, con.method
+    )
+    plot_connectivity(
+        con_method, info=data_epoch.info, node_labels="names", vmin=0.0, vmax=1.0
+    )
 
 ###############################################################################
 # We see that connectivity over trials are not 1, since the phase differences
 # between two channels are not the same over trials.
 #
 # We will now compute connectivity over time.
-
-# Pre-allocatate memory for the connectivity matrices
-con_time_array = np.zeros(
-    (n_con_methods, n_epochs, n_channels, n_channels, n_freq_bands)
-)
-con_time_array[con_time_array == 0] = np.nan  # nan matrix
 
 con_time = spectral_connectivity_time(
     data_epoch,
@@ -318,16 +279,17 @@ con_time = spectral_connectivity_time(
     fmin=fmin,
     fmax=fmax,
     faverage=True,
+    average=True,
 )
 
-# Get data as connectivity matrices
-for c in range(n_con_methods):
-    con_time_array[c] = con_time[c].get_data(output="dense")
-
-con_time_array = np.mean(con_time_array, axis=1)  # average over epochs
-foi = list(Freq_Bands.keys()).index("alpha")  # frequency of interest
-
-plot_con_matrix(con_time_array, n_con_methods)
+for con in con_time:
+    con_array = con.get_data()[..., foi]  # select frequency band of interest
+    con_method = Connectivity(
+        con_array, con.n_nodes, con.names, con.indices, con.method
+    )
+    plot_connectivity(
+        con_method, info=data_epoch.info, node_labels="names", vmin=0.0, vmax=1.0
+    )
 
 ###############################################################################
 # We see that for case 2, the connectivity over time is approximately 1,
@@ -379,14 +341,10 @@ freqs = np.linspace(min_freq, max_freq, int((max_freq - min_freq) * 4 + 1))
 fmin = tuple([list(Freq_Bands.values())[f][0] for f in range(len(Freq_Bands))])
 fmax = tuple([list(Freq_Bands.values())[f][1] for f in range(len(Freq_Bands))])
 
-# We specify the connectivity measurements
-connectivity_methods = ["wpli"]
-n_con_methods = len(connectivity_methods)
-
 # Compute connectivity over trials
 con_epochs = spectral_connectivity_epochs(
     epochs,
-    method=connectivity_methods,
+    method="wpli",
     sfreq=sfreq,
     mode="cwt_morlet",
     cwt_freqs=freqs,
@@ -402,26 +360,24 @@ con_epochs = spectral_connectivity_epochs(
 # epochs and are looking at theta activity. This might make the connectivity
 # measurements more sensitive to noise.
 
-# Plot the global connectivity over time
-n_channels = epochs.info["nchan"]  # get number of channels
-times = epochs.times[epochs.times >= tmin]  # get the timepoints
-n_connections = (n_channels * n_channels - n_channels) / 2
+# Convert to TemporalConnectivity object for plotting over time
+con_epochs = TemporalConnectivity(
+    con_epochs.get_data()[:, 0, :],
+    con_epochs.times,
+    con_epochs.n_nodes,
+    con_epochs.names,
+    con_epochs.indices,
+    con_epochs.method,
+)
 
-# Get global avg connectivity over all connections
-con_epochs_raveled_array = con_epochs.get_data(output="raveled")
-global_con_epochs = np.sum(con_epochs_raveled_array, axis=0) / n_connections
-
-# Since there is only one freq band, we choose the first dimension
-global_con_epochs = global_con_epochs[0]
-
-fig = plt.figure()
-plt.plot(times, global_con_epochs)
-plt.xlabel("Time (s)")
-plt.ylabel("Global theta wPLI over trials")
+# Plot global connectivity by averaging results
+plot_temporal_connectivity(con_epochs, info=epochs.info, combine="mean", ci="sd")
 
 # Get the timepoint with highest global connectivity right after stimulus
-t_con_max = np.argmax(global_con_epochs[times <= 0.5])
-print(f"Global theta wPLI peaks {times[t_con_max]:.3f}s after stimulus")
+t_con_max = np.argmax(
+    np.mean(con_epochs.get_data(), axis=0)[np.array(con_epochs.times) <= 0.5]
+)
+print(f"Global theta wPLI peaks {con_epochs.times[t_con_max]:.3f}s after stimulus")
 
 ###############################################################################
 # We see that around the timing of the P1 evoked response, there is high theta
@@ -431,17 +387,17 @@ print(f"Global theta wPLI peaks {times[t_con_max]:.3f}s after stimulus")
 # and plot the sensor connectivity of the 20 highest connections
 
 # Plot the connectivity matrix at the timepoint with highest global wPLI
-con_epochs_matrix = con_epochs.get_data(output="dense")[:, :, 0, t_con_max]
-
-fig = plt.figure()
-im = plt.imshow(con_epochs_matrix)
-fig.colorbar(im, label="Connectivity")
-plt.ylabel("Channels")
-plt.xlabel("Channels")
-plt.show()
+max_con = Connectivity(
+    con_epochs.get_data()[:, t_con_max],
+    con_epochs.n_nodes,
+    con_epochs.names,
+    con_epochs.indices,
+    con_epochs.method,
+)
+plot_connectivity(max_con, info=epochs.info, node_labels="names")
 
 # Visualize top 20 connections in 3D
-plot_sensors_connectivity(epochs.info, con_epochs_matrix)
+plot_sensors_connectivity(epochs.info, max_con, n_con=20)
 
 ###############################################################################
 # Conclusions

--- a/examples/dpli_wpli_pli.py
+++ b/examples/dpli_wpli_pli.py
@@ -20,7 +20,8 @@ import mne
 import numpy as np
 from mne.datasets import sample
 
-from mne_connectivity import spectral_connectivity_epochs
+from mne_connectivity import Connectivity, spectral_connectivity_epochs
+from mne_connectivity.viz import plot_connectivity
 
 ###############################################################################
 # Background
@@ -342,44 +343,28 @@ sfreq = raw.info["sfreq"]  # the sampling frequency
 tmin = 0.0  # exclude the baseline period
 
 # Compute PLI, wPLI, and dPLI
-con_pli = spectral_connectivity_epochs(
-    epochs,
-    method="pli",
-    mode="multitaper",
-    sfreq=sfreq,
-    fmin=fmin,
-    fmax=fmax,
-    faverage=True,
-    tmin=tmin,
-    mt_adaptive=False,
-    n_jobs=1,
-)
-
-con_wpli = spectral_connectivity_epochs(
-    epochs,
-    method="wpli",
-    mode="multitaper",
-    sfreq=sfreq,
-    fmin=fmin,
-    fmax=fmax,
-    faverage=True,
-    tmin=tmin,
-    mt_adaptive=False,
-    n_jobs=1,
-)
-
-con_dpli = spectral_connectivity_epochs(
-    epochs,
-    method="dpli",
-    mode="multitaper",
-    sfreq=sfreq,
-    fmin=fmin,
-    fmax=fmax,
-    faverage=True,
-    tmin=tmin,
-    mt_adaptive=False,
-    n_jobs=1,
-)
+cons = dict()
+methods = ["pli", "wpli", "dpli"]
+for method in methods:
+    con = spectral_connectivity_epochs(
+        epochs,
+        method=method,
+        mode="multitaper",
+        sfreq=sfreq,
+        fmin=fmin,
+        fmax=fmax,
+        tmin=tmin,
+        mt_adaptive=False,
+        n_jobs=1,
+    )
+    con_data = con.get_data().mean(axis=-1)  # average across frequencies
+    cons[method] = Connectivity(
+        con_data,
+        n_nodes=con.n_nodes,
+        names=con.names,
+        indices=con.indices,
+        method=method,
+    )
 
 ###############################################################################
 # In this example, there is strong connectivity between sensors 190-200 and
@@ -395,22 +380,10 @@ con_dpli = spectral_connectivity_epochs(
 # against volume conduction effects decreasing the detected connectivity
 # strength, as was mentioned earlier.
 
-fig, axs = plt.subplots(1, 3, figsize=(14, 5), sharey=True)
-axs[0].imshow(con_pli.get_data("dense"), vmin=0, vmax=1)
-axs[0].set_title("PLI")
-axs[0].set_ylabel("Sensor 1")
-axs[0].set_xlabel("Sensor 2")
+# sphinx_gallery_multi_image_block = "single"
 
-axs[1].imshow(con_wpli.get_data("dense"), vmin=0, vmax=1)
-axs[1].set_title("wPLI")
-axs[1].set_xlabel("Sensor 2")
-
-im = axs[2].imshow(con_dpli.get_data("dense"), vmin=0, vmax=1)
-axs[2].set_title("dPLI")
-axs[2].set_xlabel("Sensor 2")
-
-fig.colorbar(im, ax=axs.ravel())
-plt.show()
+for con in cons.values():
+    plot_connectivity(con, info=epochs.info, vmin=0, vmax=1)
 
 ###############################################################################
 # Conclusions

--- a/examples/granger_causality.py
+++ b/examples/granger_causality.py
@@ -22,7 +22,8 @@ import numpy as np
 from matplotlib import pyplot as plt
 from mne.datasets.fieldtrip_cmc import data_path
 
-from mne_connectivity import spectral_connectivity_epochs
+from mne_connectivity import SpectralConnectivity, spectral_connectivity_epochs
+from mne_connectivity.viz import plot_spectral_connectivity
 
 ###############################################################################
 # Background
@@ -165,8 +166,8 @@ signals_b = [
     if ch_info["ch_name"][2] == "O"
 ]
 
-indices_ab = (np.array([signals_a]), np.array([signals_b]))  # A => B
-indices_ba = (np.array([signals_b]), np.array([signals_a]))  # B => A
+indices_ab = (np.array([signals_a]), np.array([signals_b]))  # A → B
+indices_ba = (np.array([signals_b]), np.array([signals_a]))  # B → A
 
 # compute Granger causality
 gc_ab = spectral_connectivity_epochs(
@@ -177,7 +178,7 @@ gc_ab = spectral_connectivity_epochs(
     fmax=30,
     rank=(np.array([5]), np.array([5])),
     gc_n_lags=20,
-)  # A => B
+)  # A → B
 gc_ba = spectral_connectivity_epochs(
     epochs,
     method=["gc"],
@@ -186,9 +187,8 @@ gc_ba = spectral_connectivity_epochs(
     fmax=30,
     rank=(np.array([5]), np.array([5])),
     gc_n_lags=20,
-)  # B => A
+)  # B → A
 freqs = gc_ab.freqs
-
 
 ###############################################################################
 # Plotting the results, we see that there is a flow of information from our
@@ -197,12 +197,8 @@ freqs = gc_ab.freqs
 
 # %%
 
-fig, axis = plt.subplots(1, 1)
-axis.plot(freqs, gc_ab.get_data()[0], linewidth=2)
-axis.set_xlabel("Frequency (Hz)")
-axis.set_ylabel("Connectivity (A.U.)")
-fig.suptitle("GC: [A => B]")
-
+fig, axes = plot_spectral_connectivity(gc_ab, info=epochs.info)
+axes[0].set_title("Granger causality: A → B")
 
 ###############################################################################
 # Drivers and receivers: analysing the net direction of information flow
@@ -223,15 +219,19 @@ fig.suptitle("GC: [A => B]")
 
 # %%
 
-net_gc = gc_ab.get_data() - gc_ba.get_data()  # [A => B] - [B => A]
+net_gc_data = gc_ab.get_data() - gc_ba.get_data()  # [A → B] - [B → A]
+net_gc = SpectralConnectivity(
+    data=net_gc_data,
+    freqs=freqs,
+    n_nodes=gc_ba.n_nodes,
+    names=gc_ab.names,
+    indices=indices_ab,
+    method="Net GC",
+)
 
-fig, axis = plt.subplots(1, 1)
-axis.plot((freqs[0], freqs[-1]), (0, 0), linewidth=2, linestyle="--", color="k")
-axis.plot(freqs, net_gc[0], linewidth=2)
-axis.set_xlabel("Frequency (Hz)")
-axis.set_ylabel("Connectivity (A.U.)")
-fig.suptitle("Net GC: [A => B] - [B => A]")
-
+fig, axes = plot_spectral_connectivity(net_gc, info=epochs.info)
+axes[0].plot((freqs[0], freqs[-1]), (0, 0), linewidth=2, linestyle="--", color="k")
+axes[0].set_title("Net Granger causality: A → B\n[A → B] - [B → A]")
 
 ###############################################################################
 # Improving the robustness of connectivity estimates with time-reversal
@@ -291,7 +291,7 @@ gc_tr_ab = spectral_connectivity_epochs(
     fmax=30,
     rank=(np.array([5]), np.array([5])),
     gc_n_lags=20,
-)  # TR[A => B]
+)  # TR[A → B]
 gc_tr_ba = spectral_connectivity_epochs(
     epochs,
     method=["gc_tr"],
@@ -300,13 +300,21 @@ gc_tr_ba = spectral_connectivity_epochs(
     fmax=30,
     rank=(np.array([5]), np.array([5])),
     gc_n_lags=20,
-)  # TR[B => A]
+)  # TR[B → A]
 
-# compute net GC on time-reversed signals (TR[A => B] - TR[B => A])
-net_gc_tr = gc_tr_ab.get_data() - gc_tr_ba.get_data()
+# compute net GC on time-reversed signals (TR[A → B] - TR[B → A])
+net_gc_tr_data = gc_tr_ab.get_data() - gc_tr_ba.get_data()
 
 # compute TRGC
-trgc = net_gc - net_gc_tr
+trgc_data = net_gc_data - net_gc_tr_data
+trgc = SpectralConnectivity(
+    data=trgc_data,
+    freqs=freqs,
+    n_nodes=gc_ba.n_nodes,
+    names=gc_ab.names,
+    indices=indices_ab,
+    method="TRGC",
+)
 
 ###############################################################################
 # Plotting the TRGC results reveals a very different picture compared to net
@@ -321,13 +329,11 @@ trgc = net_gc - net_gc_tr
 
 # %%
 
-fig, axis = plt.subplots(1, 1)
-axis.plot((freqs[0], freqs[-1]), (0, 0), linewidth=2, linestyle="--", color="k")
-axis.plot(freqs, trgc[0], linewidth=2)
-axis.set_xlabel("Frequency (Hz)")
-axis.set_ylabel("Connectivity (A.U.)")
-fig.suptitle("TRGC: net[A => B] - net time-reversed[A => B]")
-
+fig, axes = plot_spectral_connectivity(trgc, info=epochs.info)
+axes[0].plot((freqs[0], freqs[-1]), (0, 0), linewidth=2, linestyle="--", color="k")
+axes[0].set_title(
+    "Net time-reversed Granger causality: A → B\nnet[A → B] - net time-reversed[A → B]"
+)
 
 ###############################################################################
 # Controlling spectral smoothing with the number of lags
@@ -357,16 +363,15 @@ gc_ab_60 = spectral_connectivity_epochs(
     fmax=30,
     rank=(np.array([5]), np.array([5])),
     gc_n_lags=60,
-)  # A => B
+)  # A → B
 
 fig, axis = plt.subplots(1, 1)
 axis.plot(freqs, gc_ab.get_data()[0], linewidth=2, label="20 lags")
 axis.plot(freqs, gc_ab_60.get_data()[0], linewidth=2, label="60 lags")
 axis.set_xlabel("Frequency (Hz)")
 axis.set_ylabel("Connectivity (A.U.)")
+axis.set_title("Granger causality: A → B")
 axis.legend()
-fig.suptitle("GC: [A => B]")
-
 
 ###############################################################################
 # Handling high-dimensional data
@@ -421,7 +426,7 @@ spectral_connectivity_epochs(
     rank=None,
     gc_n_lags=20,
     verbose=False,
-)  # A => B
+)  # A → B
 
 ###############################################################################
 # Rigorous checks are implemented to identify any such instances which would

--- a/examples/mic_mim.py
+++ b/examples/mic_mim.py
@@ -26,7 +26,12 @@ from matplotlib import pyplot as plt
 from mne import EvokedArray, make_fixed_length_epochs
 from mne.datasets.fieldtrip_cmc import data_path
 
-from mne_connectivity import seed_target_indices, spectral_connectivity_epochs
+from mne_connectivity import (
+    SpectralConnectivity,
+    seed_target_indices,
+    spectral_connectivity_epochs,
+)
+from mne_connectivity.viz import plot_spectral_connectivity
 
 ###############################################################################
 # Background
@@ -106,11 +111,28 @@ target_names = [epochs.info["ch_names"][idx] for idx in targets]
 (mic, mim) = spectral_connectivity_epochs(
     epochs, method=["mic", "mim"], indices=multivar_indices, fmin=5, fmax=30, rank=None
 )
+mic = SpectralConnectivity(
+    data=np.abs(mic.get_data()),
+    freqs=mic.freqs,
+    n_nodes=mic.n_nodes,
+    names=mic.names,
+    indices=mic.indices,
+    method=mic.method,
+    patterns=mic.attrs["patterns"],
+)
 
 # bivariate imaginary part of coherency (for comparison)
 bivar_indices = seed_target_indices(seeds, targets)
 imcoh = spectral_connectivity_epochs(
     epochs, method="imcoh", indices=bivar_indices, fmin=5, fmax=30
+)
+imcoh = SpectralConnectivity(
+    data=np.abs(imcoh.get_data()),
+    freqs=imcoh.freqs,
+    n_nodes=imcoh.n_nodes,
+    names=imcoh.names,
+    indices=imcoh.indices,
+    method=imcoh.method,
 )
 
 ###############################################################################
@@ -120,12 +142,8 @@ imcoh = spectral_connectivity_epochs(
 # weaker peak around 27 Hz.
 
 # %%
-fig, axis = plt.subplots(1, 1)
-axis.plot(imcoh.freqs, np.mean(np.abs(imcoh.get_data()), axis=0), linewidth=2)
-axis.set_xlabel("Frequency (Hz)")
-axis.set_ylabel("Absolute connectivity (A.U.)")
-fig.suptitle("Imaginary part of coherency")
 
+plot_spectral_connectivity(imcoh, info=epochs.info, combine="mean", ci=95)
 
 ###############################################################################
 # Maximised imaginary part of coherency (MIC)
@@ -163,12 +181,7 @@ fig.suptitle("Imaginary part of coherency")
 
 # %%
 
-fig, axis = plt.subplots(1, 1)
-axis.plot(mic.freqs, np.abs(mic.get_data()[0]), linewidth=2)
-axis.set_xlabel("Frequency (Hz)")
-axis.set_ylabel("Absolute connectivity (A.U.)")
-fig.suptitle("Maximised imaginary part of coherency")
-
+plot_spectral_connectivity(mic, info=epochs.info)
 
 ###############################################################################
 # Furthermore, spatial patterns of connectivity can be constructed from the
@@ -215,24 +228,16 @@ target_pattern = EvokedArray(target_pattern[:, np.newaxis], target_info)
 
 # plot the patterns
 fig, axes = plt.subplots(1, 4)
-seed_pattern.plot_topomap(
+topomap_kwargs = dict(
     times=0,
     sensors="m.",
     units=dict(mag="A.U."),
     cbar_fmt="%.1E",
-    axes=axes[0:2],
     time_format="",
     show=False,
 )
-target_pattern.plot_topomap(
-    times=0,
-    sensors="m.",
-    units=dict(mag="A.U."),
-    cbar_fmt="%.1E",
-    axes=axes[2:],
-    time_format="",
-    show=False,
-)
+seed_pattern.plot_topomap(axes=axes[0:2], **topomap_kwargs)
+target_pattern.plot_topomap(axes=axes[2:], **topomap_kwargs)
 axes[0].set_position((0.1, 0.1, 0.35, 0.7))
 axes[1].set_position((0.4, 0.3, 0.02, 0.3))
 axes[2].set_position((0.5, 0.1, 0.35, 0.7))
@@ -292,11 +297,7 @@ plt.show()
 
 # %%
 
-fig, axis = plt.subplots(1, 1)
-axis.plot(mim.freqs, mim.get_data()[0], linewidth=2)
-axis.set_xlabel("Frequency (Hz)")
-axis.set_ylabel("Absolute connectivity (A.U.)")
-fig.suptitle("Multivariate interaction measure")
+plot_spectral_connectivity(mim, info=epochs.info)
 
 n_channels = len(seeds) + len(targets)
 normalised_mim = mim.get_data()[0] / n_channels
@@ -331,11 +332,7 @@ gim = spectral_connectivity_epochs(
     epochs, method="mim", indices=indices, fmin=5, fmax=30, rank=None, verbose=False
 )
 
-fig, axis = plt.subplots(1, 1)
-axis.plot(gim.freqs, gim.get_data()[0], linewidth=2)
-axis.set_xlabel("Frequency (Hz)")
-axis.set_ylabel("Connectivity (A.U.)")
-fig.suptitle("Global interaction measure")
+plot_spectral_connectivity(gim, info=epochs.info)
 
 n_channels = len(seeds) + len(targets)
 normalised_gim = gim.get_data()[0] / n_channels

--- a/examples/wsmi.py
+++ b/examples/wsmi.py
@@ -24,15 +24,16 @@ characteristic of conscious brain states.
 #
 # License: BSD (3-clause)
 
+# %%
+
 import matplotlib.pyplot as plt
 import mne
 import numpy as np
-import pandas as pd
-import seaborn as sns
 from matplotlib import colors
 from mne.datasets import sample
 
 from mne_connectivity import wsmi
+from mne_connectivity.viz import plot_connectivity
 
 ########################################################################################
 # Simulating Data with Different Connectivity Patterns
@@ -165,16 +166,7 @@ for i, j in zip(indices[0][:3], indices[1][:3]):  # First 3 pairs only
 
 # Now compute averaged connectivity for visualization
 conn_ave = wsmi(epochs, kernel=3, tau=1, average=True)
-# Get connectivity matrix for visualization
-conn_matrix = conn_ave.get_data("dense")
-conn_matrix += conn_matrix.T  # make matrix symmetric
-
-# Use pandas and seaborn for cleaner visualization
-df = pd.DataFrame(data=conn_matrix, index=names, columns=names)
-ax = sns.heatmap(df, annot=True, fmt="0.4f", cmap="viridis", vmin=0)
-ax.set_title("wSMI Connectivity Matrix\n(Higher values = stronger connectivity)")
-ax.tick_params(axis="x", labelrotation=45)
-ax.figure.tight_layout()
+plot_connectivity(conn_ave, info=epochs.info, node_labels="names")
 
 ########################################################################################
 # **Note**: Small negative values can occur for wSMI, reflecting estimator noise or a
@@ -372,36 +364,9 @@ print(f"Channels: {epochs_real.ch_names}")
 
 # Compute wSMI on real EEG data
 conn_real = wsmi(epochs_real, kernel=3, tau=1, average=True, verbose=False)
-conn_real_matrix = conn_real.get_data(output="dense")
-conn_real_matrix += conn_real_matrix.T  # make matrix symmetric
-conn_real_names = conn_real.attrs["node_names"]
 
 # Plot connectivity matrix
-fig, ax = plt.subplots(1, 1, figsize=(8, 6))
-im = ax.imshow(conn_real_matrix, cmap="viridis", vmin=0)
-ax.set_xticks(range(n_eeg))
-ax.set_yticks(range(n_eeg))
-ax.set_xticklabels(epochs_real.ch_names)
-ax.set_yticklabels(epochs_real.ch_names)
-
-# Add connectivity values
-for i in range(n_eeg):
-    for j in range(n_eeg):
-        text = ax.text(
-            j,
-            i,
-            f"{conn_real_matrix[i, j]:.3f}",
-            ha="center",
-            va="center",
-            color="black"
-            if conn_real_matrix[i, j] > conn_real_matrix.max() / 2
-            else "white",
-        )
-
-plt.colorbar(im, ax=ax, label="wSMI")
-plt.title("wSMI Connectivity: Real EEG Data\n(Visual stimulus epochs)")
-plt.tight_layout()
-plt.show()
+plot_connectivity(conn_real, info=epochs_real.info, node_labels="names")
 
 ########################################################################################
 # The connectivity matrix shows wSMI values between electrode pairs during visual

--- a/mne_connectivity/__init__.py
+++ b/mne_connectivity/__init__.py
@@ -41,4 +41,12 @@ from .utils import (
     seed_target_multivariate_indices,
 )
 from .vector_ar import select_order, vector_auto_regression
+from .viz import (
+    plot_connectivity,
+    plot_connectivity_circle,
+    plot_sensors_connectivity,
+    plot_spectral_connectivity,
+    plot_spectrotemporal_connectivity,
+    plot_temporal_connectivity,
+)
 from .wsmi import wsmi

--- a/mne_connectivity/base.py
+++ b/mne_connectivity/base.py
@@ -455,11 +455,9 @@ class BaseConnectivity(EpochMixin):
         metadata=None,
         **kwargs,
     ):
-        if isinstance(indices, str) and indices not in ["all", "symmetric"]:
-            raise ValueError(
-                'Indices can only be "all", "symmetric", or a list of tuples. '
-                f"It cannot be {indices}."
-            )
+        _validate_type(indices, (str, tuple), "indices")
+        if isinstance(indices, str):
+            _check_option("indices", indices, ["all", "lower", "upper"])
 
         # prepare metadata pandas dataframe and ensure metadata is a Pandas
         # DataFrame object
@@ -594,10 +592,6 @@ class BaseConnectivity(EpochMixin):
 
         # get the number of estimated nodes
         self._get_num_connections(data)
-        if self.is_epoched:
-            data_len = data.shape[1]
-        else:
-            data_len = data.shape[0]
 
         if isinstance(indices, tuple):
             # check that the indices passed in are of the same length
@@ -607,20 +601,31 @@ class BaseConnectivity(EpochMixin):
                     f"are right now {len(indices[0])} and {len(indices[1])}."
                 )
             # indices length should match the data length
-            if len(indices[0]) != data_len:
+            if len(indices[0]) != self.n_estimated_nodes:
                 raise ValueError(
                     f"The number of indices, {len(indices[0])} should match the "
-                    f"raveled data length passed in of {data_len}."
+                    f"raveled data length passed in of {self.n_estimated_nodes}."
                 )
 
-        elif indices == "symmetric":
-            expected_len = ((n_nodes + 1) * n_nodes) // 2
-            if data_len != expected_len:
+        elif indices in ["lower", "upper"]:
+            expected_len = n_nodes * (n_nodes - 1) // 2
+            if self.n_estimated_nodes != expected_len:
                 raise ValueError(
-                    'If "indices" is "symmetric", then '
-                    f"connectivity data should be the upper-triangular part of the "
-                    f"matrix. There are {data_len} estimated connections. But there "
-                    f"should be {expected_len} estimated connections."
+                    "If `indices` is 'lower' or 'upper', then connectivity data should "
+                    "be the lower- or upper-triangular part of the connectivity "
+                    f"matrix, respectively. Expected {expected_len} connections from "
+                    f"the {n_nodes} nodes, but got {self.n_estimated_nodes} "
+                    "connections."
+                )
+
+        else:  # indices = "all"
+            expected_len = n_nodes**2
+            if self.n_estimated_nodes != expected_len:
+                raise ValueError(
+                    "If `indices` is 'all', then connectivity data should be the full "
+                    f"connectivity matrix. Expected {expected_len} connections from "
+                    f"the {n_nodes} nodes, but got {self.n_estimated_nodes} "
+                    "connections."
                 )
 
     def copy(self):
@@ -686,10 +691,11 @@ class BaseConnectivity(EpochMixin):
 
         Returns
         -------
-        indices : ``'all'`` | ``'symmetric'`` | tuple of list
-            Either ``'all'`` for all-to-all connectivity, ``'symmetric'`` for symmetric
-            connectivity, or a tuple of lists representing the node-to-nodes that
-            connectivity was computed for.
+        indices : ``'all'`` | ``'lower'`` | ``'upper'`` | tuple of list
+            Either ``'all'`` for all-to-all connectivity, ``'lower'`` for
+            lower-triangular connectivity, ``'upper'`` for upper-triangular
+            connectivity, or a tuple of lists representing the seed and target nodes
+            that connectivity was computed between.
         """
         return self.attrs["indices"]
 
@@ -723,7 +729,7 @@ class BaseConnectivity(EpochMixin):
         #     size += self.metadata.memory_usage(index=True).sum()
         return size
 
-    def get_data(self, output="compact"):
+    def get_data(self, output="compact", missing="raise"):
         """Get connectivity data as a numpy array.
 
         Parameters
@@ -732,11 +738,17 @@ class BaseConnectivity(EpochMixin):
             How to format the output:
 
             - ``'raveled'`` will represent each connectivity matrix as a
-              ``(..., n_nodes_in * n_nodes_out, ...)`` array
+              ``(..., n_nodes_in * n_nodes_out, ...)`` array.
             - ``'dense'`` will return each connectivity matrix as a ``(..., n_nodes_in,
-              n_nodes_out, ...)`` array
-            - ``'compact'`` (default) will return ``'raveled'`` if ``indices`` were
-              defined as a tuple of arrays, or ``'dense'`` if ``indices='all'``
+              n_nodes_out, ...)`` array.
+            - ``'compact'`` (default) will return ``'raveled'`` if ``indices`` is
+              a tuple of arrays, or ``'dense'`` if ``indices is ``'all'``, ``'lower'``,
+              or ``'upper'``.
+        missing : ``'raise'`` | float
+            How to handle missing values in the dense connectivity matrix when these
+            cannot be filled in (see notes for more information). If ``'raise'``, an
+            error is raised. If a float, the missing values are filled with that float.
+            Ignored if ``output='raveled'``. Default is ``'raise'``.
 
         Returns
         -------
@@ -750,6 +762,31 @@ class BaseConnectivity(EpochMixin):
 
         Notes
         -----
+        **Handling missing values for dense outputs**
+
+        If ``indices`` is not ``'all'`` and ``output='dense'``, there may be missing
+        values from the full connectivity matrix that need to be filled in. There are
+        four cases to consider:
+
+        1. When ``indices`` is ``'lower'`` or ``'upper'``, there will be missing values.
+           If ``method`` is a connectivity method available in MNE-Connectivity, and the
+           the missing values can be inferred based on the existing ones, this will be
+           handled automatically.
+
+        2. When ``indices`` is ``'lower'`` or ``'upper'`` and ``method`` is not
+           recognised by MNE-Connectivity, or it is recognised and the missing values
+           cannot be inferred from the existing ones, the behaviour is determined by the
+           ``missing`` parameter.
+
+        3. When ``indices`` is a tuple and ``indices`` represents a subset of the full
+           connectivity matrix, the missing values will not be inferred, and the
+           behaviour is determined by the ``missing`` parameter.
+
+        4. When ``indices`` is a tuple and ``indices`` represents the full connectivity
+           matrix, there are no missing values to fill in.
+
+        **Handling dense outputs for multivariate connectivity**
+
         Because multivariate connectivity data can involve multiple channels per
         connection, it is not possible to represent the data in a dense matrix form
         where each row/column represent a single channel.
@@ -784,7 +821,7 @@ class BaseConnectivity(EpochMixin):
         multivariate_nodes = None
 
         if output == "compact":
-            if self.indices in ["all", "symmetric"]:
+            if self.indices in ["all", "lower", "upper"]:
                 output = "dense"
             else:
                 output = "raveled"

--- a/mne_connectivity/base.py
+++ b/mne_connectivity/base.py
@@ -20,6 +20,7 @@ from mne.utils import (
 
 from mne_connectivity.utils import (
     _check_if_multivariate_indices,
+    _get_full_connectivity,
     _get_unique_multivariate_nodes_and_indices,
     _prepare_xarray_mne_data_structures,
     fill_doc,
@@ -818,6 +819,12 @@ class BaseConnectivity(EpochMixin):
         ``[[0, 1], [2, 3], [4, 5]]``.
         """
         _check_option("output", output, ["raveled", "dense", "compact"])
+        _validate_type(missing, (str, "numeric"), "missing")
+        if isinstance(missing, str):
+            _check_option("missing", missing, ["raise"])
+        else:
+            missing = float(missing)
+
         multivariate_nodes = None
 
         if output == "compact":
@@ -842,48 +849,19 @@ class BaseConnectivity(EpochMixin):
             else:
                 indices, n_nodes = self.indices, self.n_nodes
 
-            # get the new shape of the data array
+            # Move epochs from first dimension temporarily for easier reshaping
+            data = self._data
             if self.is_epoched:
-                new_shape = [self.n_epochs]
-            else:
-                new_shape = []
+                data = np.moveaxis(data, 0, -1)
 
-            # handle the case where model order is defined in VAR connectivity
-            # and thus appends the connectivity matrices side by side, so the
-            # shape is N x N * lags
-            new_shape.extend([n_nodes, n_nodes])
-            if "components" in self.dims:
-                new_shape.append(len(self.coords["components"]))
-            if "freqs" in self.dims:
-                new_shape.append(len(self.coords["freqs"]))
-            if "times" in self.dims:
-                new_shape.append(len(self.coords["times"]))
+            # Get connectivity as a square matrix, with missing values filled
+            data = _get_full_connectivity(
+                data, indices, n_nodes, self.method, missing=missing
+            )
 
-            if isinstance(indices, tuple) or indices == "symmetric":
-                if np.iscomplexobj(self._data):
-                    fill_value = np.nan + 1j * np.nan
-                else:
-                    fill_value = np.nan
-                data = np.full(new_shape, fill_value=fill_value, dtype=self._data.dtype)
-
-            if isinstance(indices, tuple):
-                # handle things differently if indices is defined
-                row_idx, col_idx = indices
-                if self.is_epoched:
-                    data[:, row_idx, col_idx, ...] = self._data
-                else:
-                    data[row_idx, col_idx, ...] = self._data
-            elif indices == "symmetric":
-                # get the upper/lower triangular indices
-                row_triu_inds, col_triu_inds = np.triu_indices(n_nodes, k=0)
-                if self.is_epoched:
-                    data[:, row_triu_inds, col_triu_inds, ...] = self._data
-                    data[:, col_triu_inds, row_triu_inds, ...] = self._data
-                else:
-                    data[row_triu_inds, col_triu_inds, ...] = self._data
-                    data[col_triu_inds, row_triu_inds, ...] = self._data
-            else:
-                data = self._data.reshape(new_shape)
+            # Move epochs back to first dimension if needed
+            if self.is_epoched:
+                data = np.moveaxis(data, -1, 0)
 
         if multivariate_nodes is not None:
             return data, multivariate_nodes

--- a/mne_connectivity/base.py
+++ b/mne_connectivity/base.py
@@ -402,8 +402,10 @@ class BaseConnectivity(EpochMixin):
     connectivity computing functions.
 
     Connectivity data is anything that represents "connections" between nodes as a
-    ``(N, N)`` array. It can be symmetric, or asymmetric (if it is symmetric, storage
-    optimization will occur).
+    ``(N, N)`` array. It can be symmetric, or asymmetric. If it is symmetric (or
+    asymmetric, but the missing (e.g., upper-triangular) elements can be determined
+    based on the existing (e.g., lower-triangular) elements), we can optimise memory
+    demand for storage.
 
     Parameters
     ----------
@@ -422,23 +424,26 @@ class BaseConnectivity(EpochMixin):
     Notes
     -----
     Connectivity data can be generally represented as a square matrix with values
-    intending the connectivity function value between two nodes. We optimize storage of
-    symmetric connectivity data and allow support for computing connectivity data on a
-    subset of nodes. We store connectivity data as a raveled ``(n_estimated_nodes,
-    ...)`` where ``n_estimated_nodes`` can be ``n_nodes_in * n_nodes_out`` if a full
-    connectivity structure is computed, or a subset of the nodes (equal to the length of
-    the indices passed in).
+    intending the connectivity function value between two nodes. We store connectivity
+    data as a raveled ``(n_estimated_nodes, ...)`` array, where ``n_estimated_nodes``
+    can be ``n_nodes_in * n_nodes_out`` if a full connectivity structure is computed, or
+    a subset of the nodes (equal to the length of the indices passed in).
 
     Since we store connectivity data as a raveled array, one can easily optimize the
-    storage of "symmetric" connectivity data. One can use numpy to convert a full
-    all-to-all connectivity into an upper triangular portion, and set
-    ``indices='symmetric'``. This would reduce the RAM needed in half.
+    storage of "symmetric" connectivity data by storing only the lower-triangular (or
+    upper-triangular) elements, and filling these in when the user requests the full
+    connectivity matrix. How to fill in the missing values is determined based on the
+    ``method`` parameter.
 
     The underlying data structure is an :class:`xarray.DataArray`, with a similar API to
     ``xarray``. We provide support for storing connectivity data in a subset of nodes.
     Thus the underlying data structure instead of a ``(n_nodes_in, n_nodes_out)`` 2D
     array would be a ``(n_nodes_in * n_nodes_out,)`` raveled 1D array. This allows us to
-    optimize storage also for symmetric connectivity.
+    optimize storage also for "symmetric" connectivity.
+
+    Storage optimisation will not occur for multivariate connectivity, as computing
+    connectivity in the same lower-/upper-triangular manner for "symmetric" methods does
+    not transfer.
     """
 
     # whether or not the connectivity occurs over epochs
@@ -458,7 +463,7 @@ class BaseConnectivity(EpochMixin):
     ):
         _validate_type(indices, (str, tuple), "indices")
         if isinstance(indices, str):
-            _check_option("indices", indices, ["all", "lower", "upper"], " as a string")
+            _check_option("indices", indices, ["all", "lower", "upper"], "as a string")
 
         # prepare metadata pandas dataframe and ensure metadata is a Pandas
         # DataFrame object

--- a/mne_connectivity/base.py
+++ b/mne_connectivity/base.py
@@ -458,7 +458,7 @@ class BaseConnectivity(EpochMixin):
     ):
         _validate_type(indices, (str, tuple), "indices")
         if isinstance(indices, str):
-            _check_option("indices", indices, ["all", "lower", "upper"])
+            _check_option("indices", indices, ["all", "lower", "upper"], " as a string")
 
         # prepare metadata pandas dataframe and ensure metadata is a Pandas
         # DataFrame object
@@ -821,7 +821,7 @@ class BaseConnectivity(EpochMixin):
         _check_option("output", output, ["raveled", "dense", "compact"])
         _validate_type(missing, (str, "numeric"), "missing")
         if isinstance(missing, str):
-            _check_option("missing", missing, ["raise"])
+            _check_option("missing", missing, ["raise"], " as a string")
         else:
             missing = float(missing)
 

--- a/mne_connectivity/base.py
+++ b/mne_connectivity/base.py
@@ -766,24 +766,23 @@ class BaseConnectivity(EpochMixin):
         **Handling missing values for dense outputs**
 
         If ``indices`` is not ``'all'`` and ``output='dense'``, there may be missing
-        values from the full connectivity matrix that need to be filled in. There are
-        four cases to consider:
+        values from the full connectivity matrix that need to be filled in:
 
-        1. When ``indices`` is ``'lower'`` or ``'upper'``, there will be missing values.
-           If ``method`` is a connectivity method available in MNE-Connectivity, and the
-           the missing values can be inferred based on the existing ones, this will be
-           handled automatically.
+        1. When ``indices`` is ``'lower'`` or ``'upper'``, there will be missing values:
 
-        2. When ``indices`` is ``'lower'`` or ``'upper'`` and ``method`` is not
-           recognised by MNE-Connectivity, or it is recognised and the missing values
-           cannot be inferred from the existing ones, the behaviour is determined by the
-           ``missing`` parameter.
+           a. If ``missing`` is not a float (default) and ``method`` is a connectivity
+              method where the missing values can be inferred based on the existing
+              ones, the missing values are filled in automatically.
+           b. If ``missing`` is not a float (default) and ``method`` is not a
+              connectivity method where the missing values can be inferred based on the
+              existing ones, an error is raised.
+           c. If ``missing`` is a float, the missing values are filled in using this.
 
-        3. When ``indices`` is a tuple and ``indices`` represents a subset of the full
+        2. When ``indices`` is a tuple and ``indices`` represents a subset of the full
            connectivity matrix, the missing values will not be inferred, and the
            behaviour is determined by the ``missing`` parameter.
 
-        4. When ``indices`` is a tuple and ``indices`` represents the full connectivity
+        3. When ``indices`` is a tuple and ``indices`` represents the full connectivity
            matrix, there are no missing values to fill in.
 
         **Handling dense outputs for multivariate connectivity**

--- a/mne_connectivity/base.py
+++ b/mne_connectivity/base.py
@@ -472,6 +472,19 @@ class BaseConnectivity(EpochMixin):
         self.metadata = metadata
 
         # check the incoming data structure
+        if "components" in kwargs:
+            bad_indices = None
+            if not isinstance(indices, tuple):
+                bad_indices = f"'{indices}'"  # must be a str
+            elif not _check_if_multivariate_indices(indices):
+                bad_indices = "a tuple of non-nested arrays"  # must be non-nested
+            if bad_indices:
+                raise ValueError(
+                    "`components` are present in `kwargs`, which is a term reserved "
+                    "for multivariate connectivity methods. However, `indices` does "
+                    "not match the format for multivariate methods. Expected a tuple "
+                    f"of nested arrays, got {bad_indices}."
+                )
         self._check_data_consistency(data, indices=indices, n_nodes=n_nodes)
         self._prepare_xarray(
             data,

--- a/mne_connectivity/base.py
+++ b/mne_connectivity/base.py
@@ -461,7 +461,7 @@ class BaseConnectivity(EpochMixin):
         metadata=None,
         **kwargs,
     ):
-        _validate_type(indices, (str, tuple), "indices")
+        _validate_type(indices, (str, tuple), "`indices`")
         if isinstance(indices, str):
             _check_option("indices", indices, ["all", "lower", "upper"], "as a string")
 
@@ -823,9 +823,9 @@ class BaseConnectivity(EpochMixin):
         ``[[0, 1], [2, 3], [4, 5]]``.
         """
         _check_option("output", output, ["raveled", "dense", "compact"])
-        _validate_type(missing, (str, "numeric"), "missing")
+        _validate_type(missing, (str, "numeric"), "`missing`")
         if isinstance(missing, str):
-            _check_option("missing", missing, ["raise"], " as a string")
+            _check_option("missing", missing, ["raise"], "as a string")
         else:
             missing = float(missing)
 

--- a/mne_connectivity/conftest.py
+++ b/mne_connectivity/conftest.py
@@ -7,8 +7,22 @@ import os
 import warnings
 from contextlib import contextmanager, suppress
 
+import numpy as np
 import pytest
+from mne import EpochsArray, create_info
 from mne.utils import _check_qt_version
+
+
+@pytest.fixture()
+def data_make_full():
+    """Create random data for _make_<method>_full tests."""
+    # Simulate random data
+    rng = np.random.default_rng(42)
+    n_epochs, n_channels, n_times = 4, 3, 50
+    sfreq = 100.0
+    data = rng.standard_normal((n_epochs, n_channels, n_times))
+    info = create_info(ch_names=n_channels, sfreq=sfreq, ch_types="eeg")
+    return EpochsArray(data, info=info)
 
 
 def has_pyvista():

--- a/mne_connectivity/effective.py
+++ b/mne_connectivity/effective.py
@@ -5,7 +5,7 @@
 import copy
 
 import numpy as np
-from mne.utils import _check_option, _validate_type, logger, verbose
+from mne.utils import logger, verbose
 
 from .base import (
     EpochSpectralConnectivity,
@@ -21,7 +21,7 @@ from .utils import fill_doc
 def phase_slope_index(
     data,
     names=None,
-    indices="all",
+    indices="lower",
     sfreq=None,
     *,
     mode="multitaper",
@@ -172,10 +172,6 @@ def phase_slope_index(
     ----------
     .. footbibliography::
     """  # noqa: E501
-    _validate_type(indices, (tuple, str), "indices")
-    if isinstance(indices, str):
-        _check_option("indices", indices, ["all"], " as a string")
-
     logger.info("Estimating phase slope index (PSI)")
 
     # estimate the coherency
@@ -273,7 +269,7 @@ def phase_slope_index(
 def phase_slope_index_time(
     data,
     freqs=None,
-    indices=None,
+    indices="lower",
     sfreq=None,
     *,
     mode="cwt_morlet",
@@ -500,7 +496,8 @@ def phase_slope_index_time(
 def _compute_psi(cohy, freqs, bands, freq_dim):
     """Compute Phase Slope Index (PSI) from coherency data."""
     # Allocate space for output
-    out_shape = list(cohy.shape)
+    data = cohy.get_data("raveled")
+    out_shape = list(data.shape)
     out_shape[freq_dim] = len(bands)
     psi = np.zeros(out_shape, dtype=np.float64)
 
@@ -523,9 +520,7 @@ def _compute_psi(cohy, freqs, bands, freq_dim):
         for fi, fj in zip(freq_idx, freq_idx[1:]):
             idx_fi[freq_dim] = fi
             idx_fj[freq_dim] = fj
-            acc += (
-                np.conj(cohy.get_data()[tuple(idx_fi)]) * cohy.get_data()[tuple(idx_fj)]
-            )
+            acc += np.conj(data[tuple(idx_fi)]) * data[tuple(idx_fj)]
 
         idx_fi[freq_dim] = band_idx
         psi[tuple(idx_fi)] = np.imag(acc)

--- a/mne_connectivity/effective.py
+++ b/mne_connectivity/effective.py
@@ -85,15 +85,11 @@ def phase_slope_index(
            Storing multitaper weights in :class:`mne.time_frequency.EpochsTFR` objects
            requires ``mne >= 1.10``.
     %(names)s
-    indices : tuple of array_like | ``'all'``
-        Two array-likes with indices of connections for which to compute connectivity.
-        If ``'all'``, all connections are computed. See notes of
-        :func:`~mne_connectivity.spectral_connectivity_epochs` for details. Default is
-        ``'all'``.
+    %(indices_with_str_only_bivar)s
     sfreq : float | None
         The sampling frequency. Required if ``data`` is not an :class:`mne.Epochs`,
-            :class:`mne.time_frequency.EpochsSpectrum`, or
-            :class:`mne.time_frequency.EpochsTFR` object.
+        :class:`mne.time_frequency.EpochsSpectrum`, or
+        :class:`mne.time_frequency.EpochsTFR` object.
     mode : ``'multitaper'`` | ``'fourier'`` | ``'cwt_morlet'``
         Spectrum estimation mode. Ignored if ``data`` is an
         :class:`mne.time_frequency.EpochsSpectrum` or
@@ -158,7 +154,7 @@ def phase_slope_index(
         - ``(n_cons, n_bands)`` for ``'multitaper'`` or ``'fourier'`` modes
         - ``(n_cons, n_bands, n_times)`` for ``'cwt_morlet'`` mode
         - ``n_cons = n_signals ** 2`` when ``indices=''all''``
-        - ``n_cons = len(indices[0])`` when ``indices`` is supplied
+        - ``n_cons = len(indices[0])`` when ``indices`` is supplied as a tuple of arrays
         - ``n_bands`` is the number of frequency bands defined by ``fmin`` and ``fmax``
 
     See Also
@@ -167,6 +163,11 @@ def phase_slope_index(
     mne_connectivity.phase_slope_index_time
     mne_connectivity.SpectralConnectivity
     mne_connectivity.SpectroTemporalConnectivity
+
+    Notes
+    -----
+    %(tri_indices_efficiency_note)s
+    %(tuple_bivar_indices_note)s
 
     References
     ----------
@@ -266,6 +267,7 @@ def phase_slope_index(
 
 
 @verbose
+@fill_doc
 def phase_slope_index_time(
     data,
     freqs=None,
@@ -327,9 +329,7 @@ def phase_slope_index_time(
         ``data`` is an array-like or :class:`mne.Epochs` object, the frequencies must
         be specified. If ``data`` is an :class:`mne.time_frequency.EpochsTFR` object,
         ``data.freqs`` is used and this parameter is ignored.
-    indices : tuple of array_like | None
-        Two array-likes with indices of connections for which to compute connectivity.
-        If ``None`` (default), all connections are computed.
+    %(indices_with_str_only_bivar)s
     sfreq : float | None
         The sampling frequency. Required if ``data`` is not an :class:`mne.Epochs` or
         :class:`mne.time_frequency.EpochsTFR` object.
@@ -399,8 +399,8 @@ def phase_slope_index_time(
 
         - The epoch dimension is present when ``average=False``, and absent when
           ``average=True``.
-        - When ``indices`` is ``None``, ``n_cons = n_signals ** 2``
-        - When ``indices`` is specified, ``n_con = len(indices[0])``
+        - ``n_cons = n_signals ** 2`` when ``indices=''all''``
+        - ``n_cons = len(indices[0])`` when ``indices`` is supplied as a tuple of arrays
         - ``n_bands`` is the number of frequency bands defined by ``fmin`` and ``fmax``
 
     See Also
@@ -412,6 +412,9 @@ def phase_slope_index_time(
 
     Notes
     -----
+    %(tri_indices_efficiency_note)s
+    %(tuple_bivar_indices_note)s
+
     .. versionadded:: 0.8
 
     References

--- a/mne_connectivity/effective.py
+++ b/mne_connectivity/effective.py
@@ -5,7 +5,7 @@
 import copy
 
 import numpy as np
-from mne.utils import logger, verbose
+from mne.utils import _check_option, _validate_type, logger, verbose
 
 from .base import (
     EpochSpectralConnectivity,
@@ -21,7 +21,7 @@ from .utils import fill_doc
 def phase_slope_index(
     data,
     names=None,
-    indices=None,
+    indices="all",
     sfreq=None,
     *,
     mode="multitaper",
@@ -85,10 +85,11 @@ def phase_slope_index(
            Storing multitaper weights in :class:`mne.time_frequency.EpochsTFR` objects
            requires ``mne >= 1.10``.
     %(names)s
-    indices : tuple of array_like | None
+    indices : tuple of array_like | ``'all'``
         Two array-likes with indices of connections for which to compute connectivity.
-        If ``None``, all connections are computed. See Notes of
-        :func:`~mne_connectivity.spectral_connectivity_epochs` for details.
+        If ``'all'``, all connections are computed. See notes of
+        :func:`~mne_connectivity.spectral_connectivity_epochs` for details. Default is
+        ``'all'``.
     sfreq : float | None
         The sampling frequency. Required if ``data`` is not an :class:`mne.Epochs`,
             :class:`mne.time_frequency.EpochsSpectrum`, or
@@ -156,7 +157,7 @@ def phase_slope_index(
 
         - ``(n_cons, n_bands)`` for ``'multitaper'`` or ``'fourier'`` modes
         - ``(n_cons, n_bands, n_times)`` for ``'cwt_morlet'`` mode
-        - ``n_cons = n_signals ** 2`` when ``indices=None``
+        - ``n_cons = n_signals ** 2`` when ``indices=''all''``
         - ``n_cons = len(indices[0])`` when ``indices`` is supplied
         - ``n_bands`` is the number of frequency bands defined by ``fmin`` and ``fmax``
 
@@ -171,6 +172,10 @@ def phase_slope_index(
     ----------
     .. footbibliography::
     """  # noqa: E501
+    _validate_type(indices, (tuple, str), "indices")
+    if isinstance(indices, str):
+        _check_option("indices", indices, ["all"], "if a string")
+
     logger.info("Estimating phase slope index (PSI)")
 
     # estimate the coherency

--- a/mne_connectivity/effective.py
+++ b/mne_connectivity/effective.py
@@ -174,7 +174,7 @@ def phase_slope_index(
     """  # noqa: E501
     _validate_type(indices, (tuple, str), "indices")
     if isinstance(indices, str):
-        _check_option("indices", indices, ["all"], "if a string")
+        _check_option("indices", indices, ["all"], " as a string")
 
     logger.info("Estimating phase slope index (PSI)")
 

--- a/mne_connectivity/effective.py
+++ b/mne_connectivity/effective.py
@@ -43,7 +43,7 @@ def phase_slope_index(
 
     The PSI is an effective connectivity measure, i.e., a measure which can give an
     indication of the direction of the information flow (causality). For two time
-    series, and one computes the PSI between the first and the second time series as
+    series, one computes the PSI between the first and the second time series as
     follows::
 
         indices = (np.array([0]), np.array([1]))
@@ -153,7 +153,7 @@ def phase_slope_index(
 
         - ``(n_cons, n_bands)`` for ``'multitaper'`` or ``'fourier'`` modes
         - ``(n_cons, n_bands, n_times)`` for ``'cwt_morlet'`` mode
-        - ``n_cons = n_signals ** 2`` when ``indices=''all''``
+        - ``n_cons = n_signals ** 2`` when ``indices='all'``
         - ``n_cons = len(indices[0])`` when ``indices`` is supplied as a tuple of arrays
         - ``n_bands`` is the number of frequency bands defined by ``fmin`` and ``fmax``
 
@@ -399,7 +399,7 @@ def phase_slope_index_time(
 
         - The epoch dimension is present when ``average=False``, and absent when
           ``average=True``.
-        - ``n_cons = n_signals ** 2`` when ``indices=''all''``
+        - ``n_cons = n_signals ** 2`` when ``indices='all'``
         - ``n_cons = len(indices[0])`` when ``indices`` is supplied as a tuple of arrays
         - ``n_bands`` is the number of frequency bands defined by ``fmin`` and ``fmax``
 

--- a/mne_connectivity/envelope.py
+++ b/mne_connectivity/envelope.py
@@ -206,17 +206,17 @@ def envelope_correlation(
     # create time axis
     corr = corr[..., np.newaxis]
 
-    # only get the upper-triu indices
-    triu_inds = np.triu_indices(n_nodes, k=0)
-    raveled_triu_inds = np.ravel_multi_index(triu_inds, dims=(n_nodes, n_nodes))
-    corr = corr[:, raveled_triu_inds, ...]
+    # only get the lower-triangular indices
+    tril_inds = np.tril_indices(n_nodes, k=-1)
+    raveled_tril_inds = np.ravel_multi_index(tril_inds, dims=(n_nodes, n_nodes))
+    corr = corr[:, raveled_tril_inds, ...]
 
     conn = EpochTemporalConnectivity(
         data=corr,
         names=names,
         times=times,
         method="envelope correlation",
-        indices="symmetric",
+        indices="lower",
         n_epochs_used=n_epochs,
         n_nodes=n_nodes,
         events=events,

--- a/mne_connectivity/envelope.py
+++ b/mne_connectivity/envelope.py
@@ -50,9 +50,8 @@ def envelope_correlation(
     Returns
     -------
     corr : instance of EpochTemporalConnectivity
-        The pairwise orthogonal envelope correlations. This matrix is symmetric. The
-        array will have three dimensions, the first of which is ``n_epochs``. The data
-        shape is ``(n_epochs, (n_nodes + 1) * n_nodes / 2)``.
+        The pairwise orthogonal envelope correlations. The lower-triangular part of the
+        full matrix is returned.
 
     See Also
     --------

--- a/mne_connectivity/spectral/epochs.py
+++ b/mne_connectivity/spectral/epochs.py
@@ -255,28 +255,21 @@ def _prepare_connectivity(
         logger.info("    connectivity scores will be averaged for each band")
 
     # Sort indices
-    multivariate_con = any(
-        this_method in _multivariate_methods for this_method in method
-    )
-
-    if indices is None:
-        if multivariate_con:
-            if any(this_method in _gc_methods for this_method in method):
-                raise ValueError(
-                    "indices must be specified when computing Granger causality, as "
-                    "all-to-all connectivity is not supported"
-                )
-            logger.info("using all indices for multivariate connectivity")
-            # indices expected to be a masked array, even if not ragged
-            indices_use = (picks[np.newaxis, :], picks[np.newaxis, :])
-            indices_use = np.ma.masked_array(indices_use, mask=False, fill_value=-1)
+    if not isinstance(indices, tuple):
+        # Can only be bivariate connectivity
+        if indices == "all":
+            logger.info("Computing all connections for full connectivity matrix")
+            # Only compute tril, then transform to full matrix later
+            indices_use = np.tril_indices(n_good_signals, k=-1)
         else:
-            logger.info("only using indices for lower-triangular matrix")
-            # only compute r for lower-triangular region
-            indices_use = np.tril_indices(n_good_signals, -1)
-            indices_use = tuple(picks[ind] for ind in indices_use)
+            logger.info(f"Computing connections for {indices}-triangular matrix")
+            if indices == "upper":
+                indices_use = np.triu_indices(n_good_signals, k=1)
+            else:  # "lower"
+                indices_use = np.tril_indices(n_good_signals, k=-1)
+        indices_use = tuple(picks[ind] for ind in indices_use)
     else:
-        if multivariate_con:
+        if any(this_method in _multivariate_methods for this_method in method):
             # pad ragged indices and mask the invalid entries
             indices_use = _check_multivariate_indices(indices, n_signals)
             if any(this_method in _gc_methods for this_method in method):
@@ -771,7 +764,7 @@ def spectral_connectivity_epochs(
     data,
     names=None,
     method="coh",
-    indices=None,
+    indices="lower",
     sfreq=None,
     *,
     mode="multitaper",
@@ -853,14 +846,16 @@ def spectral_connectivity_epochs(
 
         Multivariate methods (``['cacoh', 'mic', 'mim', 'gc', 'gc_tr']``) cannot be
         called with the other methods.
-    indices : tuple of array_like | None
+    indices : tuple of array_like | ``'lower'`` | ``'upper'`` | ``'all'``
         Two array-likes with indices of connections for which to compute connectivity.
         If a bivariate method is called, each array for the seeds and targets should
         contain the channel indices for each bivariate connection. If a multivariate
-        method is called, each array for the seeds and targets should consist of nested
-        arrays containing the channel indices for each multivariate connection. If
-        ``None``, connections between all channels are computed, unless a Granger
-        causality method is called, in which case an error is raised.
+        method is called, a tuple must be provided, and each array for the seeds and
+        targets should consist of nested  arrays containing the channel indices for each
+        multivariate connection. If ``'lower'``, compute lower-triangular part of
+        connectivity matrix. If ``'upper'``, compute upper-triangular part of
+        connectivity matrix. If ``'all'``, compute all connections. Default is
+        ``'lower'``.
     sfreq : float | None
         The sampling frequency. Required if ``data`` is an array-like.
     mode : ``'multitaper'`` | ``'fourier'`` | ``'cwt_morlet'``
@@ -958,10 +953,10 @@ def spectral_connectivity_epochs(
         - ``(n_cons, n_freqs, n_times)`` for ``'cwt_morlet'`` mode
         - ``(n_cons, n_comps, n_freqs[, n_times])`` for valid multivariate methods if
           ``n_components > 1``
-        - ``n_cons = n_signals ** 2`` for bivariate methods with ``indices=None``
-        - ``n_cons = 1`` for multivariate methods with ``indices=None``
-        - ``n_cons = len(indices[0])`` for bivariate and multivariate methods when
-          ``indices`` is supplied
+        - ``n_cons = n_signals ** 2`` for methods with ``indices='all'``
+        - ``n_cons = n_signals * (n_signals - 1) / 2`` for methods with
+          ``indices='lower'`` or ``indices='upper'``
+        - ``n_cons = len(indices[0])`` when ``indices`` is a tuple of array-likes
 
     See Also
     --------
@@ -1007,12 +1002,10 @@ def spectral_connectivity_epochs(
     In this case ``con.get_data().shape = (3, n_freqs)``. The connectivity scores are in
     the same order as defined indices.
 
-    For multivariate methods, this is handled differently. If ``indices`` is ``None``,
-    connectivity between all signals will be computed and a single connectivity spectrum
-    will be returned (this is not possible if a Granger causality method is called). If
-    ``indices`` is specified, seed and target indices for each connection should be
-    specified as nested array-likes. For example, to compute the connectivity between
-    signals (0, 1) -> (2, 3) and (0, 1) -> (4, 5), indices should be specified as::
+    For multivariate methods, this is handled differently. If ``indices`` is specified,
+    seed and target indices for each connection should be specified as nested
+    array-likes. For example, to compute the connectivity between signals (0, 1) ->
+    (2, 3) and (0, 1) -> (4, 5), indices should be specified as::
 
         indices = (np.array([[0, 1], [0, 1]]),  # seeds
                    np.array([[2, 3], [4, 5]]))  # targets
@@ -1177,6 +1170,16 @@ def spectral_connectivity_epochs(
     else:
         multivariate_con = False
 
+    # Check indices
+    _validate_type(indices, (tuple, str), "indices")
+    if isinstance(indices, str):
+        _check_option("indices", indices, ("lower", "upper", "all"), " as a string")
+    if multivariate_con and not isinstance(indices, tuple):
+        raise TypeError(
+            "`indices` must be a tuple of array-likes for multivariate connectivity "
+            f"methods, got {indices}."
+        )
+
     # handle connectivity estimators
     (con_method_types, n_methods, accumulate_psd) = _check_estimators(method)
 
@@ -1323,7 +1326,7 @@ def spectral_connectivity_epochs(
                 gc_n_lags = None
 
             # make sure padded indices are stored in the connectivity object
-            if multivariate_con and indices is not None:
+            if multivariate_con:
                 # create a copy so that `indices_use` can be modified
                 indices = (indices_use[0].copy(), indices_use[1].copy())
 
@@ -1552,36 +1555,26 @@ def spectral_connectivity_epochs(
         freqs_used = freqs_bands
         freqs_used = [[np.min(band), np.max(band)] for band in freqs_used]
 
-    if indices is None:
-        if not multivariate_con:
-            # return all-to-all connectivity matrices raveled into a 1D array
-            logger.info("    assembling connectivity matrix")
-            con_flat = con
-            con = list()
-            for this_con_flat in con_flat:
-                this_con = np.zeros(
-                    (n_signals, n_signals) + this_con_flat.shape[1:],
-                    dtype=this_con_flat.dtype,
-                )
-                this_con[indices_use] = this_con_flat
+    if not isinstance(indices, tuple):
+        # return all-to-all connectivity matrices raveled into a 1D array
+        logger.info("    assembling connectivity matrix")
+        con_flat = con
+        con = list()
+        for this_con_flat in con_flat:
+            fill = np.nan
+            if np.iscomplexobj(this_con_flat):
+                fill = fill + 1j * fill
+            this_con = np.full(
+                (n_signals, n_signals) + this_con_flat.shape[1:],
+                fill,
+                dtype=this_con_flat.dtype,
+            )
+            this_con[indices_use] = this_con_flat
 
-                # ravel 2D connectivity into a 1D array
-                # while keeping other dimensions
-                this_con = this_con.reshape((n_signals**2,) + this_con_flat.shape[1:])
-                con.append(this_con)
-        elif n_signals != n_good_signals:
-            # add missing bads to the multivariate patterns
-            patterns_full = list()
-            for this_patterns in patterns:
-                if this_patterns is not None:
-                    this_patterns_full = np.zeros(
-                        (2, n_cons, n_signals) + this_patterns.shape[3:]
-                    )
-                    this_patterns_full[:, :, sig_idx] = this_patterns
-                else:
-                    this_patterns_full = None
-                patterns_full.append(this_patterns_full)
-            patterns = patterns_full
+            # ravel 2D connectivity into a 1D array
+            # while keeping other dimensions
+            this_con = this_con.reshape((n_signals**2,) + this_con_flat.shape[1:])
+            con.append(this_con)
 
     # number of nodes in the original data
     n_nodes = n_signals

--- a/mne_connectivity/spectral/epochs.py
+++ b/mne_connectivity/spectral/epochs.py
@@ -38,7 +38,13 @@ from mne.utils import (
 )
 
 from ..base import SpectralConnectivity, SpectroTemporalConnectivity
-from ..utils import _check_multivariate_indices, check_indices, fill_doc
+from ..utils import (
+    _CAN_SYMMETRISE,
+    _check_multivariate_indices,
+    _make_square,
+    check_indices,
+    fill_doc,
+)
 from .epochs_bivariate import _CON_METHOD_MAP_BIVARIATE
 from .epochs_multivariate import (
     _CON_METHOD_MAP_MULTIVARIATE,
@@ -1555,25 +1561,40 @@ def spectral_connectivity_epochs(
         freqs_used = freqs_bands
         freqs_used = [[np.min(band), np.max(band)] for band in freqs_used]
 
-    if not isinstance(indices, tuple):
-        # return all-to-all connectivity matrices raveled into a 1D array
-        logger.info("    assembling connectivity matrix")
+    # Make full connectivity matrix from lower-triangular part
+    if indices == "all":
+        for method_idx in range(n_methods):
+            this_con = _make_square(con[method_idx], "lower", n_good_signals)
+            this_con = _CAN_SYMMETRISE[method[method_idx]](this_con, "lower")
+            con[method_idx] = this_con.reshape((-1,) + this_con.shape[2:])
+
+    # Fill entries for bad channels
+    if not isinstance(indices, tuple) and n_signals != n_good_signals:
+        # Bad channels were excluded, need to create full (n_nodes x n_nodes) matrix and
+        # fill only the good channel entries
         con_flat = con
         con = list()
         for this_con_flat in con_flat:
+            if indices == "all":
+                out_indices = np.indices((n_signals, n_signals))
+            elif indices == "lower":
+                out_indices = np.tril_indices(n_signals, k=-1)
+            else:  # "upper"
+                out_indices = np.triu_indices(n_signals, k=1)
+
+            out_indices = np.ravel_multi_index(out_indices, (n_signals, n_signals))
+            good_indices = np.ravel_multi_index(indices_use, (n_signals, n_signals))
+            insert_indices = np.searchsorted(out_indices, good_indices)
+
             fill = np.nan
             if np.iscomplexobj(this_con_flat):
                 fill = fill + 1j * fill
             this_con = np.full(
-                (n_signals, n_signals) + this_con_flat.shape[1:],
+                (len(out_indices),) + this_con_flat.shape[1:],
                 fill,
                 dtype=this_con_flat.dtype,
             )
-            this_con[indices_use] = this_con_flat
-
-            # ravel 2D connectivity into a 1D array
-            # while keeping other dimensions
-            this_con = this_con.reshape((n_signals**2,) + this_con_flat.shape[1:])
+            this_con[insert_indices] = this_con_flat
             con.append(this_con)
 
     # number of nodes in the original data

--- a/mne_connectivity/spectral/epochs.py
+++ b/mne_connectivity/spectral/epochs.py
@@ -1181,7 +1181,7 @@ def spectral_connectivity_epochs(
     if isinstance(indices, str):
         _check_option("indices", indices, ("lower", "upper", "all"), " as a string")
     if multivariate_con and not isinstance(indices, tuple):
-        raise TypeError(
+        raise ValueError(
             "`indices` must be a tuple of array-likes for multivariate connectivity "
             f"methods, got {indices}."
         )

--- a/mne_connectivity/spectral/epochs.py
+++ b/mne_connectivity/spectral/epochs.py
@@ -39,7 +39,7 @@ from mne.utils import (
 
 from ..base import SpectralConnectivity, SpectroTemporalConnectivity
 from ..utils import (
-    _CAN_SYMMETRISE,
+    _CAN_FILL_MISSING,
     _check_multivariate_indices,
     _make_square,
     check_indices,
@@ -1532,7 +1532,7 @@ def spectral_connectivity_epochs(
     if indices == "all":
         for method_idx in range(n_methods):
             this_con = _make_square(con[method_idx], "lower", n_good_signals)
-            this_con = _CAN_SYMMETRISE[method[method_idx]](this_con, "lower")
+            this_con = _CAN_FILL_MISSING[method[method_idx]](this_con, "lower")
             con[method_idx] = this_con.reshape((-1,) + this_con.shape[2:])
 
     # Fill entries for bad channels

--- a/mne_connectivity/spectral/epochs.py
+++ b/mne_connectivity/spectral/epochs.py
@@ -987,11 +987,11 @@ def spectral_connectivity_epochs(
     :class:`mne.time_frequency.EpochsSpectrum` or :class:`mne.time_frequency.EpochsTFR`
     objects.
 
-    By default, the connectivity between all signals is computed (only connections
-    corresponding to the lower-triangular part of the connectivity matrix). If one is
-    only interested in the connectivity between some signals, the ``indices`` parameter
-    can be used. For example, to compute the connectivity between the signal with index
-    0 and signals "2, 3, 4" (a total of 3 connections) one can use the following::
+    By default, the connectivity corresponding to the lower-triangular part of the
+    connectivity matrix is computed. If one is only interested in the connectivity
+    between some signals, the ``indices`` parameter can be used. For example, to compute
+    the connectivity between the signal with index 0 and signals "2, 3, 4" (a total of 3
+    connections) one can use the following::
 
         indices = (np.array([0, 0, 0]),    # row indices
                    np.array([2, 3, 4]))    # col indices
@@ -1002,10 +1002,10 @@ def spectral_connectivity_epochs(
     In this case ``con.get_data().shape = (3, n_freqs)``. The connectivity scores are in
     the same order as defined indices.
 
-    For multivariate methods, this is handled differently. If ``indices`` is specified,
-    seed and target indices for each connection should be specified as nested
-    array-likes. For example, to compute the connectivity between signals (0, 1) ->
-    (2, 3) and (0, 1) -> (4, 5), indices should be specified as::
+    For multivariate methods, this is handled differently. ``indices`` must be specified
+    as a tuple, where seed and target indices for each connection should be specified as
+    nested array-likes. For example, to compute the connectivity between signals (0, 1)
+    -> (2, 3) and (0, 1) -> (4, 5), indices should be specified as::
 
         indices = (np.array([[0, 1], [0, 1]]),  # seeds
                    np.array([[2, 3], [4, 5]]))  # targets
@@ -1194,7 +1194,7 @@ def spectral_connectivity_epochs(
     is_tfr_con = False
     if isinstance(data, BaseEpochs | EpochsSpectrum | EpochsTFR):
         # Find good channels
-        if indices is None:
+        if not isinstance(indices, tuple):
             picks = _picks_to_idx(data.info, picks="all", exclude="bads")
 
         names = data.ch_names

--- a/mne_connectivity/spectral/epochs.py
+++ b/mne_connectivity/spectral/epochs.py
@@ -852,16 +852,7 @@ def spectral_connectivity_epochs(
 
         Multivariate methods (``['cacoh', 'mic', 'mim', 'gc', 'gc_tr']``) cannot be
         called with the other methods.
-    indices : tuple of array_like | ``'lower'`` | ``'upper'`` | ``'all'``
-        Two array-likes with indices of connections for which to compute connectivity.
-        If a bivariate method is called, each array for the seeds and targets should
-        contain the channel indices for each bivariate connection. If a multivariate
-        method is called, a tuple must be provided, and each array for the seeds and
-        targets should consist of nested  arrays containing the channel indices for each
-        multivariate connection. If ``'lower'``, compute lower-triangular part of
-        connectivity matrix. If ``'upper'``, compute upper-triangular part of
-        connectivity matrix. If ``'all'``, compute all connections. Default is
-        ``'lower'``.
+    %(indices_with_str_with_multivar)s
     sfreq : float | None
         The sampling frequency. Required if ``data`` is an array-like.
     mode : ``'multitaper'`` | ``'fourier'`` | ``'cwt_morlet'``
@@ -992,33 +983,9 @@ def spectral_connectivity_epochs(
     multitaper, or Morlet coefficients can also be passed in as data in the form of
     :class:`mne.time_frequency.EpochsSpectrum` or :class:`mne.time_frequency.EpochsTFR`
     objects.
-
-    By default, the connectivity corresponding to the lower-triangular part of the
-    connectivity matrix is computed. If one is only interested in the connectivity
-    between some signals, the ``indices`` parameter can be used. For example, to compute
-    the connectivity between the signal with index 0 and signals "2, 3, 4" (a total of 3
-    connections) one can use the following::
-
-        indices = (np.array([0, 0, 0]),    # row indices
-                   np.array([2, 3, 4]))    # col indices
-
-        con = spectral_connectivity_epochs(data, method='coh',
-                                           indices=indices, ...)
-
-    In this case ``con.get_data().shape = (3, n_freqs)``. The connectivity scores are in
-    the same order as defined indices.
-
-    For multivariate methods, this is handled differently. ``indices`` must be specified
-    as a tuple, where seed and target indices for each connection should be specified as
-    nested array-likes. For example, to compute the connectivity between signals (0, 1)
-    -> (2, 3) and (0, 1) -> (4, 5), indices should be specified as::
-
-        indices = (np.array([[0, 1], [0, 1]]),  # seeds
-                   np.array([[2, 3], [4, 5]]))  # targets
-
-    More information on working with multivariate indices and handling connections where
-    the number of seeds and targets are not equal can be found in the
-    :doc:`../auto_examples/handling_ragged_arrays` example.
+    %(tri_indices_efficiency_note)s
+    %(tuple_bivar_indices_note)s
+    %(tuple_multivar_indices_note)s
 
     **Supported Connectivity Measures**
 

--- a/mne_connectivity/spectral/epochs.py
+++ b/mne_connectivity/spectral/epochs.py
@@ -1576,7 +1576,9 @@ def spectral_connectivity_epochs(
         con = list()
         for this_con_flat in con_flat:
             if indices == "all":
-                out_indices = np.indices((n_signals, n_signals))
+                out_indices = np.unravel_index(
+                    np.arange(n_signals**2), (n_signals, n_signals)
+                )
             elif indices == "lower":
                 out_indices = np.tril_indices(n_signals, k=-1)
             else:  # "upper"

--- a/mne_connectivity/spectral/epochs.py
+++ b/mne_connectivity/spectral/epochs.py
@@ -1144,9 +1144,9 @@ def spectral_connectivity_epochs(
         multivariate_con = False
 
     # Check indices
-    _validate_type(indices, (tuple, str), "indices")
+    _validate_type(indices, (tuple, str), "`indices`")
     if isinstance(indices, str):
-        _check_option("indices", indices, ("lower", "upper", "all"), " as a string")
+        _check_option("indices", indices, ("lower", "upper", "all"), "as a string")
     if multivariate_con and not isinstance(indices, tuple):
         raise ValueError(
             "`indices` must be a tuple of array-likes for multivariate connectivity "

--- a/mne_connectivity/spectral/tests/test_spectral.py
+++ b/mne_connectivity/spectral/tests/test_spectral.py
@@ -635,7 +635,6 @@ def test_spectral_connectivity_epochs_multivariate(method, n_components):
     sfreq = 100.0  # Hz
     n_seeds = 3
     n_targets = 4
-    n_signals = n_seeds + n_targets
     fstart = 15  # Hz
     fend = 20  # Hz
     n_epochs = 60
@@ -714,16 +713,6 @@ def test_spectral_connectivity_epochs_multivariate(method, n_components):
         assert np.all(trgc[0, freqs_con] > upper_t)
         # checks that TRGC is ~ 0 for other frequencies
         assert np.allclose(trgc[0, freqs_noise].mean(), 0, atol=lower_t)
-
-    # check all-to-all conn. computed for CaCoh/MIC/MIM when no indices given
-    if method in ["cacoh", "mic", "mim"]:
-        con = spectral_connectivity_epochs(
-            data, method=method, mode=mode, indices="lower", gc_n_lags=gc_n_lags
-        )
-        assert con.indices is None
-        assert con.n_nodes == n_signals
-        if method in ["cacoh", "mic"]:
-            assert np.array(con.attrs["patterns"]).shape[2] == n_signals
 
     # check ragged indices padded correctly
     ragged_indices = ([[0]], [[1, 2]])
@@ -944,11 +933,17 @@ def test_multivar_spectral_connectivity_epochs_error_catch(method, mode):
             data, method=method, indices=repeated_indices, gc_n_lags=10, **conn_kwargs
         )
 
+    # check no indices caught
+    with pytest.raises(ValueError, match="`indices` must be a tuple of array-likes"):
+        spectral_connectivity_epochs(
+            data, method=method, indices="lower", **conn_kwargs
+        )
+
     # check mixed methods caught
     with pytest.raises(ValueError, match="bivariate and multivariate connectivity"):
         if isinstance(method, str):
             mixed_methods = [method, "coh"]
-        elif isinstance(method, list):
+        else:
             mixed_methods = [*method, "coh"]
         spectral_connectivity_epochs(
             data, method=mixed_methods, indices=indices, **conn_kwargs
@@ -1050,12 +1045,6 @@ def test_multivar_spectral_connectivity_epochs_error_catch(method, mode):
                 fmax=frange[1],
                 gc_n_lags=n_lags,
                 **conn_kwargs,
-            )
-
-        # check no indices caught
-        with pytest.raises(ValueError, match="indices must be specified"):
-            spectral_connectivity_epochs(
-                data, method=method, indices="lower", **conn_kwargs
             )
 
         # check intersecting indices caught
@@ -1268,7 +1257,7 @@ def test_spectral_connectivity_freq_decim():
         con_decim = spectral_connectivity_epochs(data, fdecim=fdecim)
         assert (
             len(con_decim.freqs)
-            == len(con_decim.get_data("raveled")[1])  # freqs dim
+            == con_decim.get_data("raveled").shape[1]  # freqs dim
             == len(con_original.freqs) // fdecim
         )
 
@@ -1385,8 +1374,11 @@ def test_spectral_connectivity_time_phaselocked(method, mode, data_option):
         # CaCoh within set of signals will always be 1, so need to specify
         # distinct seeds and targets
         indices = ([[0, 1]], [[2, 3]])
+    elif method in ["mic", "mim"]:
+        # Manually specify pseudo-all-to-all indices for other multivariate methods
+        indices = ([np.arange(n_channels)], [np.arange(n_channels)])
     else:
-        indices = None
+        indices = "lower"
 
     # the frequency band should contain the frequency at which there is a
     # hypothesized "connection"
@@ -1407,7 +1399,7 @@ def test_spectral_connectivity_time_phaselocked(method, mode, data_option):
         average=method not in ["cohy", "cacoh", "mic"],
         sm_times=0,
     )
-    con_matrix = con.get_data()
+    con_matrix = con.get_data("raveled")
 
     # Cohy/CaCoh/MIC values can be pos. and neg., so must be averaged after taking
     # the absolute values for the test to work
@@ -1417,20 +1409,21 @@ def test_spectral_connectivity_time_phaselocked(method, mode, data_option):
             assert con.shape == (n_epochs, 1, len(con.freqs))
         else:
             assert con.shape == (1, len(con.freqs))
-    else:  #  Cohy values are complex, so take abs before validation of properties
+    else:  # Cohy values are complex, so take abs before validation of properties
         if method == "cohy":
             con_matrix = np.abs(con_matrix).mean(axis=0)
-            assert con.shape == (n_epochs, n_channels**2, len(con.freqs))
+            assert con.shape == (
+                n_epochs,
+                n_channels * (n_channels - 1) // 2,
+                len(con.freqs),
+            )
         else:
-            assert con.shape == (n_channels**2, len(con.freqs))
-        con_matrix = np.reshape(con_matrix, (n_channels, n_channels))[
-            np.tril_indices(n_channels, -1)
-        ]
+            assert con.shape == (n_channels * (n_channels - 1) // 2, len(con.freqs))
 
     if data_option == "sync":
         # signals are perfectly phase-locked, connectivity matrix should be
         # a matrix of ones
-        assert np.allclose(con_matrix, np.ones(con_matrix.shape), atol=0.01)
+        assert np.allclose(con_matrix, 1.0, atol=0.01)
     if data_option == "random":
         # signals are random, all connectivity values should be small
         # 0.5 is picked rather arbitrarily such that the obsolete wrong
@@ -1561,6 +1554,7 @@ def test_spectral_connectivity_time_freqs(method, freqs, mode):
         data,
         freqs,
         method=method,
+        indices="lower",
         mode=mode,
         sfreq=sfreq,
         fmin=np.min(freqs),
@@ -1570,15 +1564,14 @@ def test_spectral_connectivity_time_freqs(method, freqs, mode):
         average=method != "cohy",  # don't average complex values of cohy
         sm_times=0,
     )
-    assert con.shape[-2:] == (n_channels**2, len(con.freqs))
-    con_matrix = con.get_data("dense")[..., 0]
+    assert con.shape[-2:] == (n_channels * (n_channels - 1) // 2, len(con.freqs))
+    con_matrix = con.get_data("raveled")[..., 0]
     if method == "cohy":  # complex-valued → real, then average epochs
         con_matrix = np.abs(con_matrix)
         con_matrix = con_matrix.mean(axis=0)
 
-    # signals are perfectly phase-locked, connectivity matrix should be
-    # a lower triangular matrix of ones
-    assert np.allclose(con_matrix, np.tril(np.ones(con_matrix.shape), k=-1), atol=0.01)
+    # signals are perfectly phase-locked, connectivity matrix should be all ones
+    assert np.allclose(con_matrix, 1.0, atol=0.01)
 
 
 @pytest.mark.parametrize("method", ["coh", "imcoh", "cohy", "plv", "pli", "wpli"])
@@ -1615,15 +1608,9 @@ def test_spectral_connectivity_time_resolved(method, mode):
 
     # run connectivity estimation
     con = spectral_connectivity_time(
-        data, freqs, sfreq=sfreq, method=method, mode=mode, n_cycles=5
+        data, freqs, sfreq=sfreq, method=method, indices="lower", mode=mode, n_cycles=5
     )
-    assert con.shape == (n_epochs, n_signals**2, len(con.freqs))
-    assert con.get_data(output="dense").shape == (
-        n_epochs,
-        n_signals,
-        n_signals,
-        len(con.freqs),
-    )
+    assert con.shape == (n_epochs, n_signals * (n_signals - 1) // 2, len(con.freqs))
 
     # test the simulated signal
     triu_inds = np.vstack(np.triu_indices(n_signals, k=1)).T
@@ -1698,12 +1685,13 @@ def test_spectral_connectivity_time_padding(method, mode, padding):
         freqs,
         sfreq=sfreq,
         method=method,
+        indices="lower",
         mode=mode,
         n_cycles=5,
         padding=padding,
     )
 
-    assert con.shape == (n_epochs, n_signals**2, len(con.freqs))
+    assert con.shape == (n_epochs, n_signals * (n_signals - 1) // 2, len(con.freqs))
     assert con.get_data(output="dense").shape == (
         n_epochs,
         n_signals,
@@ -1953,7 +1941,6 @@ def test_multivar_spectral_connectivity_time_error_catch(method, mode):
     """Test error catching for time-resolved multivar. connectivity methods."""
     n_seeds = 2  # do not change!
     n_targets = 2  # do not change!
-    n_signals = n_seeds + n_targets
     data = make_signals_in_freq_bands(
         n_seeds=n_seeds,
         n_targets=n_targets,
@@ -1987,6 +1974,12 @@ def test_multivar_spectral_connectivity_time_error_catch(method, mode):
         repeated_indices = ([[0, 1, 1]], [[2, 2, 3]])
         spectral_connectivity_time(
             data, freqs, method=method, mode=mode, indices=repeated_indices
+        )
+
+    # check no indices caught
+    with pytest.raises(ValueError, match="`indices` must be a tuple of array-likes"):
+        spectral_connectivity_time(
+            data, freqs, method=method, mode=mode, indices="lower"
         )
 
     # check mixed methods caught
@@ -2046,23 +2039,7 @@ def test_multivar_spectral_connectivity_time_error_catch(method, mode):
             n_components=2,
         )
 
-    # check all-to-all conn. computed for CaCoh/MIC/MIM when no indices given
-    if method in ["cacoh", "mic", "mim"]:
-        con = spectral_connectivity_time(
-            data, freqs, method=method, indices=None, mode=mode
-        )
-        assert con.indices is None
-        assert con.n_nodes == n_signals
-        if method in ["cacoh", "mic"]:
-            assert np.array(con.attrs["patterns"]).shape[3] == n_signals
-
     if method in ["gc", "gc_tr"]:
-        # check no indices caught
-        with pytest.raises(ValueError, match="indices must be specified"):
-            spectral_connectivity_time(
-                data, freqs, method=method, mode=mode, indices="lower"
-            )
-
         # check intersecting indices caught
         bad_indices = ([[0, 1]], [[0, 2]])
         with pytest.raises(
@@ -2218,8 +2195,7 @@ def test_spectral_connectivity_indices_roundtrip_io(tmp_path, method, indices):
 
 
 @pytest.mark.parametrize("method", ["cacoh", "mic", "mim", _gc, _gc_tr])
-@pytest.mark.parametrize("indices", [None, ([[0, 1]], [[2, 3]])])
-def test_multivar_spectral_connectivity_indices_roundtrip_io(tmp_path, method, indices):
+def test_multivar_spectral_connectivity_indices_roundtrip_io(tmp_path, method):
     """Test that indices values and type is maintained after saving.
 
     If `indices` is None, `indices` in the returned connectivity object should
@@ -2235,7 +2211,7 @@ def test_multivar_spectral_connectivity_indices_roundtrip_io(tmp_path, method, i
         sfreq=100,
         rng_seed=0,
     )
-
+    indices = ([[0, 1]], [[2, 3]])
     freqs = np.arange(10, 31)
     tmp_file = os.path.join(tmp_path, "foo_mvc.nc")
 

--- a/mne_connectivity/spectral/tests/test_spectral.py
+++ b/mne_connectivity/spectral/tests/test_spectral.py
@@ -153,7 +153,7 @@ def test_spectral_connectivity_parallel(method, mode, tmp_path):
             data,
             method=method,
             mode=mode,
-            indices=None,
+            indices="lower",
             mt_adaptive=adaptive,
             mt_low_bias=True,
             mt_bandwidth=mt_bandwidth,
@@ -263,7 +263,7 @@ def test_spectral_connectivity(method, mode):
             data,
             method=method,
             mode=mode,
-            indices=None,
+            indices="lower",
             sfreq=sfreq,
             fmin=5.0,
             mt_adaptive=adaptive,
@@ -718,7 +718,7 @@ def test_spectral_connectivity_epochs_multivariate(method, n_components):
     # check all-to-all conn. computed for CaCoh/MIC/MIM when no indices given
     if method in ["cacoh", "mic", "mim"]:
         con = spectral_connectivity_epochs(
-            data, method=method, mode=mode, indices=None, gc_n_lags=gc_n_lags
+            data, method=method, mode=mode, indices="lower", gc_n_lags=gc_n_lags
         )
         assert con.indices is None
         assert con.n_nodes == n_signals
@@ -1055,7 +1055,7 @@ def test_multivar_spectral_connectivity_epochs_error_catch(method, mode):
         # check no indices caught
         with pytest.raises(ValueError, match="indices must be specified"):
             spectral_connectivity_epochs(
-                data, method=method, indices=None, **conn_kwargs
+                data, method=method, indices="lower", **conn_kwargs
             )
 
         # check intersecting indices caught
@@ -1172,13 +1172,13 @@ def test_multivar_spectral_connectivity_flipped_indices():
 @pytest.mark.parametrize(
     "conn_func", [spectral_connectivity_epochs, spectral_connectivity_time]
 )
-@pytest.mark.parametrize("method", ["coh", "cacoh"])
 @pytest.mark.parametrize("picks", [None, "all", "goods"])
 @pytest.mark.parametrize("data_as_spectra", [False, True])
-def test_spectral_connectivity_bad_channels(conn_func, method, picks, data_as_spectra):
+def test_spectral_connectivity_bad_channels(conn_func, picks, data_as_spectra):
     """Test spectral_connectivity_epochs bad channels handling.
 
-    Important to test indices handling with both bivariate and multivariate methods.
+    Don't need to test with multivariate connectivity when indices must always be
+    specified as a tuple.
     """
     # Simulate data
     rng = np.random.default_rng(0)
@@ -1206,12 +1206,10 @@ def test_spectral_connectivity_bad_channels(conn_func, method, picks, data_as_sp
             indices = (np.array([1, 2, 2]), np.array([0, 0, 1]))
         else:  # ("goods") explicit bad exclusion
             indices = (np.array([2]), np.array([0]))
-        if method != "coh":  # multivariate indices must be nested
-            indices = tuple([[i] for i in ind] for ind in indices)
         n_cons = len(indices[0])
     else:
-        indices = None  # implicit bad exclusion
-        n_cons = n_channels**2 if method == "coh" else 1
+        indices = "lower"  # implicit bad exclusion
+        n_cons = n_channels * (n_channels - 1) // 2
 
     # Compute connectivity
     conn_kwargs = dict()
@@ -1221,36 +1219,33 @@ def test_spectral_connectivity_bad_channels(conn_func, method, picks, data_as_sp
     else:
         conn_kwargs["freqs"] = con_freqs
         conn_kwargs["average"] = True
-    con = conn_func(data, method=method, indices=indices, **conn_kwargs)
+    con = conn_func(data, method="coh", indices=indices, **conn_kwargs)
     n_freqs = len(con.freqs)
 
     # Check connectivity object properties
     assert con.n_nodes == n_channels
     assert con.names == data.ch_names
 
-    # Check dense shape same regardless of indices (not for multivariate connectivity)
-    if method == "coh":
-        assert con.get_data("dense").shape == (n_channels, n_channels, n_freqs)
+    # Check dense shape same regardless of indices
+    missing = np.nan if indices != "lower" else "raise"
+    assert con.get_data("dense", missing=missing).shape == (
+        n_channels,
+        n_channels,
+        n_freqs,
+    )
 
     # Check raveled shape and contents depends on indices
-    raveled_data = np.abs(con.get_data("raveled"))  # abs for CaCoh
+    raveled_data = con.get_data("raveled")
     assert raveled_data.shape == (n_cons, n_freqs)  # n_cons depends on picks
     if picks is not None:
-        # with "all" channels used, bads entries are present and are non-zero
+        # with "all" channels used, bads entries are present and are not NaN
         # with "goods" channels used, bads entries are non-existent
-        # in both cases, all entries are non-zero
-        assert_array_less(0, raveled_data)
-        if method != "coh":  # check shape of patterns (1 channel per connection)
-            assert np.shape(con.attrs["patterns"]) == (2, n_cons, 1, n_freqs)
-    else:  # indices=None → all-to-all connectivity
-        if method == "coh":  # bads entries present, but filled with zeros
-            assert_array_equal(raveled_data[[3, 7]], 0)  # bads indices
-            # (use np.ravel_multi_index to find dense array indices in raveled array)
-        else:  # only good channs used for single multivar connection (so all non-zero)
-            assert_array_less(0, raveled_data)
-            # but we can check shape (all chans) and entries (bads=zeros) of patterns
-            assert np.shape(con.attrs["patterns"]) == (2, n_cons, n_channels, n_freqs)
-            assert_array_equal(0, np.array(con.attrs["patterns"])[:, :, 1, :])
+        # in both cases, all entries are not NaN
+        assert not np.any(np.isnan(raveled_data))
+    else:  # indices="lower"
+        # bads entries present, but filled with NaNs
+        assert_array_equal(raveled_data[[0, 2]], np.nan)  # bads indices
+        # (use np.ravel_multi_index to find dense array indices in raveled array)
 
 
 def test_spectral_connectivity_freq_decim():
@@ -2065,7 +2060,7 @@ def test_multivar_spectral_connectivity_time_error_catch(method, mode):
         # check no indices caught
         with pytest.raises(ValueError, match="indices must be specified"):
             spectral_connectivity_time(
-                data, freqs, method=method, mode=mode, indices=None
+                data, freqs, method=method, mode=mode, indices="lower"
             )
 
         # check intersecting indices caught
@@ -2185,14 +2180,9 @@ def test_multivar_save_load(tmp_path):
 @pytest.mark.parametrize(
     "method", ["coh", "imcoh", "cohy", "plv", "pli", "wpli", "ciplv"]
 )
-@pytest.mark.parametrize("indices", [None, ([0, 1], [2, 3])])
+@pytest.mark.parametrize("indices", ["lower", "all", "upper", ([0, 1], [2, 3])])
 def test_spectral_connectivity_indices_roundtrip_io(tmp_path, method, indices):
-    """Test that indices values and type is maintained after saving.
-
-    If `indices` is None, `indices` in the returned connectivity object should
-    be None, otherwise, `indices` should be a tuple. The type of `indices` and
-    its values should be retained after saving and reloading.
-    """
+    """Test that indices values and type is maintained after saving."""
     epochs = make_signals_in_freq_bands(
         n_seeds=2,
         n_targets=2,
@@ -2216,7 +2206,7 @@ def test_spectral_connectivity_indices_roundtrip_io(tmp_path, method, indices):
         con.save(tmp_file)
         read_con = read_connectivity(tmp_file)
 
-        if indices is not None:
+        if isinstance(indices, tuple):
             # check indices of same type (tuples)
             assert isinstance(con.indices, tuple) and isinstance(
                 read_con.indices, tuple
@@ -2224,7 +2214,7 @@ def test_spectral_connectivity_indices_roundtrip_io(tmp_path, method, indices):
             # check indices have same values
             assert np.all(np.array(con.indices) == np.array(read_con.indices))
         else:
-            assert con.indices is None and read_con.indices is None
+            assert con.indices == indices and read_con.indices == indices
 
 
 @pytest.mark.parametrize("method", ["cacoh", "mic", "mim", _gc, _gc_tr])

--- a/mne_connectivity/spectral/tests/test_spectral.py
+++ b/mne_connectivity/spectral/tests/test_spectral.py
@@ -1576,91 +1576,30 @@ def test_spectral_connectivity_time_freqs(method, freqs, mode):
 
 @pytest.mark.parametrize("method", ["coh", "imcoh", "cohy", "plv", "pli", "wpli"])
 @pytest.mark.parametrize("mode", ["cwt_morlet", "multitaper"])
-def test_spectral_connectivity_time_resolved(method, mode):
-    """Test time-resolved spectral connectivity."""
-    sfreq = 50.0
-    n_signals = 3
-    n_epochs = 2
-    n_times = 1000
-    trans_bandwidth = 2.0
-    tmin = 0.0
-    tmax = (n_times - 1) / sfreq
-    # 5Hz..15Hz
-    fstart, fend = 5.0, 15.0
-    # TODO: Replace with `make_signals_in_freq_bands` after tweaking tolerances in tests
-    data, _ = create_test_dataset(
-        sfreq,
-        n_signals=n_signals,
-        n_epochs=n_epochs,
-        n_times=n_times,
-        tmin=tmin,
-        tmax=tmax,
-        fstart=fstart,
-        fend=fend,
-        trans_bandwidth=trans_bandwidth,
-    )
-    ch_names = np.arange(n_signals).astype(str).tolist()
-    info = create_info(ch_names=ch_names, sfreq=sfreq, ch_types="eeg")
-    data = EpochsArray(data, info)
-
-    # define some frequencies for tfr
-    freqs = np.arange(3, 20.5, 1)
-
-    # run connectivity estimation
-    con = spectral_connectivity_time(
-        data, freqs, sfreq=sfreq, method=method, indices="lower", mode=mode, n_cycles=5
-    )
-    assert con.shape == (n_epochs, n_signals * (n_signals - 1) // 2, len(con.freqs))
-
-    # test the simulated signal
-    triu_inds = np.vstack(np.triu_indices(n_signals, k=1)).T
-
-    # average over frequencies
-    conn_data = con.get_data(output="dense")
-    if method in ["imcoh", "cohy"]:
-        # for imcoh: positive/negative real → positive real
-        # for cohy: complex-valued → positive real
-        conn_data = np.abs(conn_data)
-    conn_data = conn_data.mean(axis=-1)
-
-    # the indices at which there is a correlation should be greater
-    # then the rest of the components
-    for epoch_idx in range(n_epochs):
-        high_conn_val = conn_data[epoch_idx, 0, 1]
-        assert all(
-            high_conn_val >= conn_data[epoch_idx, idx, jdx] for idx, jdx in triu_inds
-        )
-
-
-@pytest.mark.parametrize("method", ["coh", "imcoh", "cohy", "plv", "pli", "wpli"])
-@pytest.mark.parametrize("mode", ["cwt_morlet", "multitaper"])
 @pytest.mark.parametrize("padding", [0, 1, 5])
 def test_spectral_connectivity_time_padding(method, mode, padding):
     """Test time-resolved spectral connectivity with padding."""
-    sfreq = 50.0
-    n_signals = 3
     n_epochs = 2
-    n_times = 300
-    trans_bandwidth = 2.0
-    tmin = 0.0
-    tmax = (n_times - 1) / sfreq
-    # 5Hz..15Hz
-    fstart, fend = 5.0, 15.0
-    # TODO: Replace with `make_signals_in_freq_bands` after tweaking tolerances in tests
-    data, _ = create_test_dataset(
-        sfreq,
-        n_signals=n_signals,
+    data = make_signals_in_freq_bands(
+        n_seeds=1,
+        n_targets=1,
+        freq_band=(5.0, 15.0),
         n_epochs=n_epochs,
-        n_times=n_times,
-        tmin=tmin,
-        tmax=tmax,
-        fstart=fstart,
-        fend=fend,
-        trans_bandwidth=trans_bandwidth,
+        duration=6.0,
+        sfreq=50.0,
+        trans_bandwidth=2.0,
+        snr=0.7,
+        connection_delay=0.05,
+        rng_seed=44,
     )
-    ch_names = np.arange(n_signals).astype(str).tolist()
-    info = create_info(ch_names=ch_names, sfreq=sfreq, ch_types="eeg")
-    data = EpochsArray(data, info)
+    rng = np.random.default_rng(42)
+    noise_data = rng.standard_normal((n_epochs, 1, data.get_data().shape[-1]))
+    noise_info = create_info(
+        ch_names=["noise"], sfreq=data.info["sfreq"], ch_types="eeg"
+    )
+    noise = EpochsArray(noise_data, noise_info)
+    data.add_channels([noise])
+    n_signals = data.info["nchan"]
 
     # define some frequencies for tfr
     freqs = np.arange(3, 20.5, 1)
@@ -1671,19 +1610,12 @@ def test_spectral_connectivity_time_padding(method, mode, padding):
             ValueError, match="Padding cannot be larger than half of data length"
         ):
             con = spectral_connectivity_time(
-                data,
-                freqs,
-                sfreq=sfreq,
-                method=method,
-                mode=mode,
-                n_cycles=5,
-                padding=padding,
+                data, freqs, method=method, mode=mode, n_cycles=5, padding=padding
             )
         return
     con = spectral_connectivity_time(
         data,
         freqs,
-        sfreq=sfreq,
         method=method,
         indices="lower",
         mode=mode,
@@ -1699,9 +1631,6 @@ def test_spectral_connectivity_time_padding(method, mode, padding):
         len(con.freqs),
     )
 
-    # test the simulated signal
-    triu_inds = np.vstack(np.triu_indices(n_signals, k=1)).T
-
     # average over frequencies
     conn_data = con.get_data(output="dense")
     if method in ["imcoh", "cohy"]:
@@ -1712,10 +1641,11 @@ def test_spectral_connectivity_time_padding(method, mode, padding):
 
     # the indices at which there is a correlation should be greater
     # then the rest of the components
+    noise_cons = ([0, 2], [1, 2])
     for epoch_idx in range(n_epochs):
         high_conn_val = conn_data[epoch_idx, 0, 1]
         assert all(
-            high_conn_val >= conn_data[epoch_idx, idx, jdx] for idx, jdx in triu_inds
+            high_conn_val >= conn_data[epoch_idx, idx, jdx] for idx, jdx in noise_cons
         )
 
 

--- a/mne_connectivity/spectral/time.py
+++ b/mne_connectivity/spectral/time.py
@@ -775,7 +775,9 @@ def spectral_connectivity_time(
         conn = dict()
         for m in method:
             if indices == "all":
-                out_indices = np.indices((n_signals, n_signals))
+                out_indices = np.unravel_index(
+                    np.arange(n_signals**2), (n_signals, n_signals)
+                )
             elif indices == "lower":
                 out_indices = np.tril_indices(n_signals, k=-1)
             else:  # "upper"

--- a/mne_connectivity/spectral/time.py
+++ b/mne_connectivity/spectral/time.py
@@ -439,7 +439,7 @@ def spectral_connectivity_time(
     if isinstance(indices, str):
         _check_option("indices", indices, ("lower", "upper", "all"), " as a string")
     if multivariate_con and not isinstance(indices, tuple):
-        raise TypeError(
+        raise ValueError(
             "`indices` must be a tuple of array-likes for multivariate connectivity "
             f"methods, got {indices}."
         )

--- a/mne_connectivity/spectral/time.py
+++ b/mne_connectivity/spectral/time.py
@@ -122,16 +122,7 @@ def spectral_connectivity_time(
     average : bool
         Average connectivity scores over epochs. If ``True``, output will be an instance
         of :class:`SpectralConnectivity`, otherwise :class:`EpochSpectralConnectivity`.
-    indices : tuple of array_like | ``'lower'`` | ``'upper'`` | ``'all'``
-        Two array-likes with indices of connections for which to compute connectivity.
-        If a bivariate method is called, each array for the seeds and targets should
-        contain the channel indices for each bivariate connection. If a multivariate
-        method is called, a tuple must be provided, and each array for the seeds and
-        targets should consist of nested  arrays containing the channel indices for each
-        multivariate connection. If ``'lower'``, compute lower-triangular part of
-        connectivity matrix. If ``'upper'``, compute upper-triangular part of
-        connectivity matrix. If ``'all'``, compute all connections. Default is
-        ``'lower'``.
+    %(indices_with_str_with_multivar)s
     sfreq : float | None
         The sampling frequency. Required if ``data`` is not an :class:`mne.Epochs` or
         :class:`mne.time_frequency.EpochsTFR` object.
@@ -260,33 +251,9 @@ def spectral_connectivity_time(
 
     Complex multitaper, or Morlet coefficients can also be passed in as data in the form
     of :class:`mne.time_frequency.EpochsTFR` objects.
-
-    By default, the connectivity corresponding to the lower-triangular part of the
-    connectivity matrix is computed. If one is only interested in the connectivity
-    between some signals, the ``indices`` parameter can be used. For example, to compute
-    the connectivity between the signal with index 0 and signals "2, 3, 4" (a total of 3
-    connections) one can use the following::
-
-        indices = (np.array([0, 0, 0]),    # row indices
-                   np.array([2, 3, 4]))    # col indices
-
-        con = spectral_connectivity_time(data, method='coh',
-                                         indices=indices, ...)
-
-    In this case ``con.get_data().shape = (3, n_freqs)``. The connectivity scores are in
-    the same order as defined indices.
-
-    For multivariate methods, this is handled differently. ``indices`` must be specified
-    as a tuple, where seed and target indices for each connection should be specified as
-    nested array-likes. For example, to compute the connectivity between signals (0, 1)
-    -> (2, 3) and (0, 1) -> (4, 5), indices should be specified as::
-
-        indices = (np.array([[0, 1], [0, 1]]),  # seeds
-                   np.array([[2, 3], [4, 5]]))  # targets
-
-    More information on working with multivariate indices and handling connections where
-    the number of seeds and targets are not equal can be found in the
-    :doc:`../auto_examples/handling_ragged_arrays` example.
+    %(tri_indices_efficiency_note)s
+    %(tuple_bivar_indices_note)s
+    %(tuple_multivar_indices_note)s
 
     **Supported Connectivity Measures**
 

--- a/mne_connectivity/spectral/time.py
+++ b/mne_connectivity/spectral/time.py
@@ -402,9 +402,9 @@ def spectral_connectivity_time(
         multivariate_con = False
 
     # Check indices
-    _validate_type(indices, (tuple, str), "indices")
+    _validate_type(indices, (tuple, str), "`indices`")
     if isinstance(indices, str):
-        _check_option("indices", indices, ("lower", "upper", "all"), " as a string")
+        _check_option("indices", indices, ("lower", "upper", "all"), "as a string")
     if multivariate_con and not isinstance(indices, tuple):
         raise ValueError(
             "`indices` must be a tuple of array-likes for multivariate connectivity "

--- a/mne_connectivity/spectral/time.py
+++ b/mne_connectivity/spectral/time.py
@@ -42,7 +42,7 @@ def spectral_connectivity_time(
     freqs=None,
     method="coh",
     average=False,
-    indices=None,
+    indices="lower",
     sfreq=None,
     *,
     fmin=None,
@@ -116,14 +116,16 @@ def spectral_connectivity_time(
     average : bool
         Average connectivity scores over epochs. If ``True``, output will be an instance
         of :class:`SpectralConnectivity`, otherwise :class:`EpochSpectralConnectivity`.
-    indices : tuple of array_like | None
+    indices : tuple of array_like | ``'lower'`` | ``'upper'`` | ``'all'``
         Two array-likes with indices of connections for which to compute connectivity.
         If a bivariate method is called, each array for the seeds and targets should
-        contain the channel indices for the each bivariate connection. If a multivariate
-        method is called, each array for the seeds and targets should consist of nested
-        arrays containing the channel indices for each multivariate connection. If
-        ``None``, connections between all channels are computed, unless a Granger
-        causality method is called, in which case an error is raised.
+        contain the channel indices for each bivariate connection. If a multivariate
+        method is called, a tuple must be provided, and each array for the seeds and
+        targets should consist of nested  arrays containing the channel indices for each
+        multivariate connection. If ``'lower'``, compute lower-triangular part of
+        connectivity matrix. If ``'upper'``, compute upper-triangular part of
+        connectivity matrix. If ``'all'``, compute all connections. Default is
+        ``'lower'``.
     sfreq : float | None
         The sampling frequency. Required if ``data`` is not an :class:`mne.Epochs` or
         :class:`mne.time_frequency.EpochsTFR` object.
@@ -253,11 +255,11 @@ def spectral_connectivity_time(
     Complex multitaper, or Morlet coefficients can also be passed in as data in the form
     of :class:`mne.time_frequency.EpochsTFR` objects.
 
-    By default, the connectivity between all signals is computed (only connections
-    corresponding to the lower-triangular part of the connectivity matrix). If one is
-    only interested in the connectivity between some signals, the ``indices`` parameter
-    can be used. For example, to compute the connectivity between the signal with index
-    0 and signals "2, 3, 4" (a total of 3 connections) one can use the following::
+    By default, the connectivity corresponding to the lower-triangular part of the
+    connectivity matrix is computed. If one is only interested in the connectivity
+    between some signals, the ``indices`` parameter can be used. For example, to compute
+    the connectivity between the signal with index 0 and signals "2, 3, 4" (a total of 3
+    connections) one can use the following::
 
         indices = (np.array([0, 0, 0]),    # row indices
                    np.array([2, 3, 4]))    # col indices
@@ -268,12 +270,10 @@ def spectral_connectivity_time(
     In this case ``con.get_data().shape = (3, n_freqs)``. The connectivity scores are in
     the same order as defined indices.
 
-    For multivariate methods, this is handled differently. If ``indices`` is ``None``,
-    connectivity between all signals will be computed and a single connectivity spectrum
-    will be returned (this is not possible if a Granger causality method is called). If
-    ``indices`` is specified, seed and target indices for each connection should be
-    specified as nested array-likes. For example, to compute the connectivity between
-    signals (0, 1) -> (2, 3) and (0, 1) -> (4, 5), indices should be specified as::
+    For multivariate methods, this is handled differently. ``indices`` must be specified
+    as a tuple, where seed and target indices for each connection should be specified as
+    nested array-likes. For example, to compute the connectivity between signals (0, 1)
+    -> (2, 3) and (0, 1) -> (4, 5), indices should be specified as::
 
         indices = (np.array([[0, 1], [0, 1]]),  # seeds
                    np.array([[2, 3], [4, 5]]))  # targets
@@ -405,6 +405,39 @@ def spectral_connectivity_time(
     events = None
     event_id = None
     picks = None
+
+    # Check that method is a list
+    if isinstance(method, str):
+        method = [method]
+    # validate methods
+    bad_methods = [meth for meth in method if meth not in _CON_METHOD_MAP_TIME]
+    if len(bad_methods) > 0:
+        raise ValueError(
+            f"Connectivity method(s) not recognized: {bad_methods}. Valid methods are "
+            f"{list(_CON_METHOD_MAP_TIME.keys())}"
+        )
+
+    # Check if multivariate methods are used
+    if any(this_method in _multivariate_methods for this_method in method):
+        if not all(this_method in _multivariate_methods for this_method in method):
+            raise ValueError(
+                "bivariate and multivariate connectivity methods cannot be used in the "
+                "same function call"
+            )
+        multivariate_con = True
+    else:
+        multivariate_con = False
+
+    # Check indices
+    _validate_type(indices, (tuple, str), "indices")
+    if isinstance(indices, str):
+        _check_option("indices", indices, ("lower", "upper", "all"), " as a string")
+    if multivariate_con and not isinstance(indices, tuple):
+        raise TypeError(
+            "`indices` must be a tuple of array-likes for multivariate connectivity "
+            f"methods, got {indices}."
+        )
+
     # extract data from Epochs object
     _validate_type(
         data,
@@ -420,7 +453,7 @@ def spectral_connectivity_time(
     spectrum_computed = False
     if isinstance(data, BaseEpochs | EpochsTFR):
         # Find good channels
-        if indices is None:
+        if not isinstance(indices, tuple):
             picks = _picks_to_idx(data.info, picks="all", exclude="bads")
 
         names = data.ch_names
@@ -491,17 +524,6 @@ def spectral_connectivity_time(
         n_good_signals = n_signals
         picks = np.arange(n_good_signals)
 
-    # check that method is a list
-    if isinstance(method, str):
-        method = [method]
-    # validate methods
-    bad_methods = [meth for meth in method if meth not in _CON_METHOD_MAP_TIME]
-    if len(bad_methods) > 0:
-        raise ValueError(
-            f"Connectivity method(s) not recognized: {bad_methods}. Valid methods are "
-            f"{list(_CON_METHOD_MAP_TIME.keys())}"
-        )
-
     # defaults for fmin and fmax
     if fmin is None:
         fmin = np.min(freqs)
@@ -527,16 +549,6 @@ def spectral_connectivity_time(
     if fdecim < 1:
         raise ValueError("`fdecim` must be >= 1")
 
-    if any(this_method in _multivariate_methods for this_method in method):
-        if not all(this_method in _multivariate_methods for this_method in method):
-            raise ValueError(
-                "bivariate and multivariate connectivity methods cannot be used in the "
-                "same function call"
-            )
-        multivariate_con = True
-    else:
-        multivariate_con = False
-
     # convert kernel width in time to samples
     if isinstance(sm_times, int | float):
         sm_times = int(np.round(sm_times * sfreq))
@@ -554,21 +566,19 @@ def spectral_connectivity_time(
     kernel = _create_kernel(sm_times, sm_freqs, kernel=sm_kernel)
 
     # get indices of pairs of (group) regions
-    if indices is None:
-        if multivariate_con:
-            if any(this_method in _gc_methods for this_method in method):
-                raise ValueError(
-                    "indices must be specified when computing Granger causality, as "
-                    "all-to-all connectivity is not supported"
-                )
-            logger.info("using all indices for multivariate connectivity")
-            # indices expected to be a masked array, even if not ragged
-            indices_use = (picks[np.newaxis, :], picks[np.newaxis, :])
-            indices_use = np.ma.masked_array(indices_use, mask=False, fill_value=-1)
-        else:
-            logger.info("only using indices for lower-triangular matrix")
+    if not isinstance(indices, tuple):
+        # Can only be bivariate connectivity
+        if indices == "all":
+            logger.info("Computing all connections for full connectivity matrix")
+            # Only compute tril, then transform to full matrix later
             indices_use = np.tril_indices(n_good_signals, k=-1)
-            indices_use = tuple(picks[ind] for ind in indices_use)
+        else:
+            logger.info(f"Computing connections for {indices}-triangular matrix")
+            if indices == "upper":
+                indices_use = np.triu_indices(n_good_signals, k=1)
+            else:  # "lower"
+                indices_use = np.tril_indices(n_good_signals, k=-1)
+        indices_use = tuple(picks[ind] for ind in indices_use)
     else:
         if multivariate_con:
             # pad ragged indices and mask the invalid entries
@@ -742,37 +752,28 @@ def spectral_connectivity_time(
             # convert to [seeds/targets x epochs x cons x [comps] x channels x freqs]
             conn_patterns[m] = np.moveaxis(conn_patterns[m], 1, 0)
 
-    if indices is None:
-        if not multivariate_con:
-            # return all-to-all connectivity matrices raveled into a 1D array
-            conn_flat = conn
-            conn = dict()
-            for m in method:
-                this_conn = np.zeros(
-                    (n_epochs, n_signals, n_signals) + conn_flat[m].shape[2:],
-                    dtype=conn_flat[m].dtype,
+    if not isinstance(indices, tuple):
+        # return all-to-all connectivity matrices raveled into a 1D array
+        conn_flat = conn
+        conn = dict()
+        for m in method:
+            fill = np.nan
+            if np.iscomplexobj(conn_flat[m]):
+                fill = fill + 1j * fill
+            this_conn = np.full(
+                (n_epochs, n_signals, n_signals) + conn_flat[m].shape[2:],
+                fill,
+                dtype=conn_flat[m].dtype,
+            )
+            this_conn[:, source_idx, target_idx] = conn_flat[m]
+            this_conn = this_conn.reshape(
+                (
+                    n_epochs,
+                    n_signals**2,
                 )
-                this_conn[:, source_idx, target_idx] = conn_flat[m]
-                this_conn = this_conn.reshape(
-                    (
-                        n_epochs,
-                        n_signals**2,
-                    )
-                    + conn_flat[m].shape[2:]
-                )
-                conn[m] = this_conn
-        elif n_signals != n_good_signals:
-            # add missing bads to the multivariate patterns
-            patterns_full = dict()
-            for m in method:
-                if conn_patterns[m] is not None:
-                    patterns_full[m] = np.zeros(
-                        (2, n_epochs, n_cons, n_signals, n_freqs)
-                    )
-                    patterns_full[m][..., picks, :] = conn_patterns[m]
-                else:
-                    patterns_full[m] = None
-            conn_patterns = patterns_full
+                + conn_flat[m].shape[2:]
+            )
+            conn[m] = this_conn
 
     # create the connectivity containers
     out = []

--- a/mne_connectivity/spectral/time.py
+++ b/mne_connectivity/spectral/time.py
@@ -22,7 +22,7 @@ from mne.utils import _check_option, _validate_type, logger, verbose
 
 from ..base import EpochSpectralConnectivity, SpectralConnectivity
 from ..utils import (
-    _CAN_SYMMETRISE,
+    _CAN_FILL_MISSING,
     _check_multivariate_indices,
     _make_square,
     check_indices,
@@ -730,7 +730,7 @@ def spectral_connectivity_time(
         for m in method:
             this_con = np.moveaxis(conn[m], 0, -1)  # move epochs to last axis
             this_con = _make_square(this_con, "lower", n_good_signals)
-            this_con = _CAN_SYMMETRISE[m](this_con, "lower")
+            this_con = _CAN_FILL_MISSING[m](this_con, "lower")
             this_con = this_con.reshape((-1,) + this_con.shape[2:])
             conn[m] = np.moveaxis(this_con, -1, 0)  # move epochs back to first axis
 

--- a/mne_connectivity/spectral/time.py
+++ b/mne_connectivity/spectral/time.py
@@ -21,7 +21,13 @@ from mne.time_frequency import (
 from mne.utils import _check_option, _validate_type, logger, verbose
 
 from ..base import EpochSpectralConnectivity, SpectralConnectivity
-from ..utils import _check_multivariate_indices, check_indices, fill_doc
+from ..utils import (
+    _CAN_SYMMETRISE,
+    _check_multivariate_indices,
+    _make_square,
+    check_indices,
+    fill_doc,
+)
 from .epochs import _compute_freq_mask
 from .epochs_multivariate import (
     _CON_METHOD_MAP_MULTIVARIATE,
@@ -752,28 +758,47 @@ def spectral_connectivity_time(
             # convert to [seeds/targets x epochs x cons x [comps] x channels x freqs]
             conn_patterns[m] = np.moveaxis(conn_patterns[m], 1, 0)
 
-    if not isinstance(indices, tuple):
-        # return all-to-all connectivity matrices raveled into a 1D array
+    # Make full connectivity matrix from lower-triangular part
+    if indices == "all":
+        for m in method:
+            this_con = np.moveaxis(conn[m], 0, -1)  # move epochs to last axis
+            this_con = _make_square(this_con, "lower", n_good_signals)
+            this_con = _CAN_SYMMETRISE[m](this_con, "lower")
+            this_con = this_con.reshape((-1,) + this_con.shape[2:])
+            conn[m] = np.moveaxis(this_con, -1, 0)  # move epochs back to first axis
+
+    # Fill entries for bad channels
+    if not isinstance(indices, tuple) and n_signals != n_good_signals:
+        # Bad channels were excluded, need to create full (n_nodes x n_nodes) matrix and
+        # fill only the good channel entries
         conn_flat = conn
         conn = dict()
         for m in method:
+            if indices == "all":
+                out_indices = np.indices((n_signals, n_signals))
+            elif indices == "lower":
+                out_indices = np.tril_indices(n_signals, k=-1)
+            else:  # "upper"
+                out_indices = np.triu_indices(n_signals, k=1)
+
+            out_indices = np.ravel_multi_index(out_indices, (n_signals, n_signals))
+            good_indices = np.ravel_multi_index(indices_use, (n_signals, n_signals))
+            insert_indices = np.searchsorted(out_indices, good_indices)
+
             fill = np.nan
             if np.iscomplexobj(conn_flat[m]):
                 fill = fill + 1j * fill
-            this_conn = np.full(
-                (n_epochs, n_signals, n_signals) + conn_flat[m].shape[2:],
+            this_con = np.full(
+                (
+                    conn_flat[m].shape[0],
+                    len(out_indices),
+                )
+                + conn_flat[m].shape[2:],
                 fill,
                 dtype=conn_flat[m].dtype,
             )
-            this_conn[:, source_idx, target_idx] = conn_flat[m]
-            this_conn = this_conn.reshape(
-                (
-                    n_epochs,
-                    n_signals**2,
-                )
-                + conn_flat[m].shape[2:]
-            )
-            conn[m] = this_conn
+            this_con[:, insert_indices] = conn_flat[m]
+            conn[m] = this_con
 
     # create the connectivity containers
     out = []

--- a/mne_connectivity/tests/test_connectivity.py
+++ b/mne_connectivity/tests/test_connectivity.py
@@ -3,6 +3,7 @@
 # License: BSD (3-clause)
 
 import os
+from functools import partial
 
 import numpy as np
 import pandas as pd
@@ -11,7 +12,7 @@ from mne import create_info, make_fixed_length_epochs
 from mne.annotations import Annotations
 from mne.epochs import BaseEpochs
 from mne.io import RawArray
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_allclose, assert_array_equal
 
 from mne_connectivity import (
     Connectivity,
@@ -23,11 +24,13 @@ from mne_connectivity import (
     SpectroTemporalConnectivity,
     TemporalConnectivity,
     envelope_correlation,
+    phase_slope_index,
+    read_connectivity,
+    spectral_connectivity_epochs,
+    spectral_connectivity_time,
     vector_auto_regression,
+    wsmi,
 )
-from mne_connectivity.effective import phase_slope_index
-from mne_connectivity.io import read_connectivity
-from mne_connectivity.spectral import spectral_connectivity_epochs
 
 
 def _make_test_epochs():
@@ -231,6 +234,89 @@ def test_connectivity_containers(conn_cls, n_components):
             for idx in range(len(dense_shape))
         ]
     )
+
+
+# Time-resolved CIPLV can involve division by zero on diagonal
+@pytest.mark.filterwarnings("ignore:divide by zero encountered in divide")
+@pytest.mark.parametrize("kind", ["epochs", "time"])
+def test_make_spec_conn_full(data_make_full, kind):
+    """Test that filling missing values in spectral conn methods works correctly.
+
+    For some methods, diagonal can be spurious depending on sample size, so we ignore it
+    for those methods.
+    """
+    n_channels = data_make_full.info["nchan"]
+    methods = ("coh", "cohy", "imcoh", "plv", "ciplv", "pli", "wpli")
+    ignore_diag_methods = ("pli", "wpli", "pli2_unbiased", "dpli", "wpli2_debiased")
+
+    # Get spectral coeffs
+    if kind == "epochs":
+        coeffs = data_make_full.compute_psd(method="welch", output="complex")
+        methods += ("ppc", "pli2_unbiased", "dpli", "wpli2_debiased")
+        conn_func = spectral_connectivity_epochs
+    else:  # kind == "time"
+        coeffs = data_make_full.compute_tfr(
+            method="morlet", freqs=np.arange(15, 20), n_cycles=3, output="complex"
+        )
+        ignore_diag_methods += ("ciplv",)  # Can have inf diag
+        conn_func = partial(spectral_connectivity_time, average=True)
+
+    # Compute connectivity
+    lower = conn_func(coeffs, method=methods, indices="lower")
+    upper = conn_func(coeffs, method=methods, indices="upper")
+    indices_all = np.unravel_index(np.arange(n_channels**2), (n_channels, n_channels))
+    full = conn_func(coeffs, method=methods, indices=indices_all)
+
+    # Check results are equivalent
+    for this_lower, this_upper, this_full in zip(lower, upper, full, strict=True):
+        lower_data = this_lower.get_data()
+        upper_data = this_upper.get_data()
+        full_data = this_full.get_data("dense")
+        assert_allclose(lower_data, upper_data, atol=1e-6)
+        if this_lower.method in ignore_diag_methods:
+            lower_data[np.diag_indices(n_channels)] = 0.0
+            full_data[np.diag_indices(n_channels)] = 0.0
+        assert_allclose(lower_data, full_data, atol=1e-6)
+
+
+@pytest.mark.parametrize("kind", ["epochs", "time"])
+def test_make_psi_full(data_make_full, kind):
+    """Test that filling missing values in PSI data works correctly."""
+    n_channels = data_make_full.info["nchan"]
+
+    # Get spectral coeffs
+    if kind == "epochs":
+        coeffs = data_make_full.compute_psd(method="welch", output="complex")
+    else:  # kind == "time"
+        coeffs = data_make_full.compute_tfr(
+            method="morlet", freqs=np.arange(15, 20), n_cycles=3, output="complex"
+        )
+
+    # Compute connectivity
+    lower = phase_slope_index(coeffs, indices="lower")
+    upper = phase_slope_index(coeffs, indices="upper")
+    indices_all = np.unravel_index(np.arange(n_channels**2), (n_channels, n_channels))
+    full = phase_slope_index(coeffs, indices=indices_all)
+
+    # Check results are equivalent
+    assert_allclose(lower.get_data(), upper.get_data(), atol=1e-6)
+    assert_allclose(lower.get_data(), full.get_data("dense"), atol=1e-6)
+
+
+@pytest.mark.parametrize("weighted", [True, False])
+def test_make_smi_full(data_make_full, weighted):
+    """Test that filling missing values in SMI data works correctly."""
+    n_channels = data_make_full.info["nchan"]
+
+    # Compute connectivity
+    lower = wsmi(data_make_full, kernel=3, tau=1, indices="lower", weighted=weighted)
+    upper = wsmi(data_make_full, kernel=3, tau=1, indices="upper", weighted=weighted)
+    indices_all = np.unravel_index(np.arange(n_channels**2), (n_channels, n_channels))
+    full = wsmi(data_make_full, kernel=3, tau=1, indices=indices_all, weighted=weighted)
+
+    # Check results are equivalent
+    assert_allclose(lower.get_data(), upper.get_data(), atol=1e-6)
+    assert_allclose(lower.get_data(), full.get_data("dense"), atol=1e-6)
 
 
 def test_get_multivariate_data():

--- a/mne_connectivity/tests/test_connectivity.py
+++ b/mne_connectivity/tests/test_connectivity.py
@@ -59,7 +59,7 @@ def _make_test_epochs():
 
 
 def _prep_correct_connectivity_input(
-    conn_cls, n_nodes=3, symmetric=False, n_epochs=4, indices=None, n_components=0
+    conn_cls, n_nodes=3, tril=False, n_epochs=4, indices=None, n_components=0
 ):
     correct_numpy_shape = []
 
@@ -68,8 +68,8 @@ def _prep_correct_connectivity_input(
         correct_numpy_shape.append(n_epochs)
 
     if indices is None:
-        if symmetric:
-            correct_numpy_shape.append((n_nodes + 1) * n_nodes // 2)
+        if tril:
+            correct_numpy_shape.append((n_nodes - 1) * n_nodes // 2)
         else:
             correct_numpy_shape.append(n_nodes**2)
     else:
@@ -131,7 +131,7 @@ def test_connectivity_containers(conn_cls, n_components):
     correct_numpy_shape, extra_kwargs = _prep_correct_connectivity_input(
         conn_cls,
         n_nodes=n_nodes,
-        symmetric=False,
+        tril=False,
         n_epochs=n_epochs,
         n_components=n_components,
     )
@@ -149,10 +149,13 @@ def test_connectivity_containers(conn_cls, n_components):
         conn_cls(
             data=correct_numpy_input, indices=bad_indices, n_nodes=2, **extra_kwargs
         )
-    with pytest.raises(ValueError, match="Indices can only be"):
+    with pytest.raises(ValueError, match="Invalid value for the 'indices' parameter"):
         conn_cls(data=correct_numpy_input, indices="square", n_nodes=2, **extra_kwargs)
 
-    conn = conn_cls(data=correct_numpy_input, n_nodes=3, **extra_kwargs)
+    # test connectivity instantiation with 'all's
+    conn = conn_cls(data=correct_numpy_input, n_nodes=3, indices="all", **extra_kwargs)
+    with pytest.raises(ValueError, match="If `indices` is 'all'"):
+        conn_cls(data=correct_numpy_input, n_nodes=2, indices="all", **extra_kwargs)
 
     # test that get_data works as intended
     with pytest.raises(ValueError, match="Invalid value for the 'output' parameter"):
@@ -187,7 +190,7 @@ def test_connectivity_containers(conn_cls, n_components):
     # test connectivity instantiation with indices
     indices = ([0, 1], [1, 0])
     indexed_numpy_shape, index_kwargs = _prep_correct_connectivity_input(
-        conn_cls, n_nodes=n_nodes, symmetric=False, n_epochs=n_epochs, indices=indices
+        conn_cls, n_nodes=n_nodes, tril=False, n_epochs=n_epochs, indices=indices
     )
     indexed_numpy_input = np.ones(indexed_numpy_shape)
     conn2 = conn_cls(
@@ -205,23 +208,44 @@ def test_connectivity_containers(conn_cls, n_components):
     with pytest.raises(ValueError, match="The number of indices"):
         conn_cls(data=correct_numpy_input, n_nodes=3, indices=indices, **extra_kwargs)
 
-    # test symmetric input
+    # test lower-/upper-triangular input
     correct_numpy_shape, extra_kwargs = _prep_correct_connectivity_input(
-        conn_cls, n_nodes=3, symmetric=True
+        conn_cls, n_nodes=3, tril=True
     )
     correct_numpy_input = np.ones(correct_numpy_shape)
 
-    with pytest.raises(ValueError, match='If "indices" is "symmetric"'):
-        conn_cls(
-            data=correct_numpy_input, n_nodes=2, indices="symmetric", **extra_kwargs
+    for indices in ["lower", "upper"]:
+        with pytest.raises(ValueError, match="If `indices` is 'lower' or 'upper'"):
+            conn_cls(
+                data=correct_numpy_input, n_nodes=2, indices=indices, **extra_kwargs
+            )
+        tri_conn = conn_cls(
+            data=correct_numpy_input,
+            n_nodes=n_nodes,
+            indices=indices,
+            method="coh",  # use a method where we can auto-fill missing values
+            **extra_kwargs,
         )
-    symm_conn = conn_cls(
-        data=correct_numpy_input, n_nodes=n_nodes, indices="symmetric", **extra_kwargs
-    )
-    assert symm_conn.n_nodes == n_nodes
+        assert tri_conn.n_nodes == n_nodes
+
+        # test that conversion to dense maps properly
+        dense_out = tri_conn.get_data(missing=np.nan)
+        if conn_cls.is_epoched:
+            dense_out = np.moveaxis(dense_out, 0, -1)  # move epochs for indexing
+            correct_numpy_input = np.moveaxis(correct_numpy_input, 0, -1)
+        tril_inds = np.tril_indices(n_nodes, k=-1)
+        triu_inds = np.triu_indices(n_nodes, k=1)
+        if indices == "lower":
+            assert_array_equal(dense_out[tril_inds], correct_numpy_input)
+            assert_array_equal(dense_out[triu_inds], np.nan)
+        else:
+            assert_array_equal(dense_out[triu_inds], correct_numpy_input)
+            assert_array_equal(dense_out[tril_inds], np.nan)
+        if conn_cls.is_epoched:
+            correct_numpy_input = np.moveaxis(correct_numpy_input, -1, 0)
 
     # raveled shape should be the same
-    assert_array_equal(symm_conn.get_data(output="raveled").shape, correct_numpy_shape)
+    assert_array_equal(tri_conn.get_data(output="raveled").shape, correct_numpy_shape)
 
     # should be ([n_epochs], n_nodes, n_nodes, ...) dense shape
     dense_shape = []
@@ -230,10 +254,48 @@ def test_connectivity_containers(conn_cls, n_components):
     dense_shape.extend([n_nodes, n_nodes])
     assert all(
         [
-            symm_conn.get_data(output="dense").shape[idx] == dense_shape[idx]
+            tri_conn.get_data(output="dense").shape[idx] == dense_shape[idx]
             for idx in range(len(dense_shape))
         ]
     )
+
+
+@pytest.mark.parametrize("indices", ["lower", "upper"])
+def test_make_unknown_method_full(indices):
+    """Test that filling missing values in unknown methods errors."""
+    n_nodes = 3
+    correct_numpy_shape, extra_kwargs = _prep_correct_connectivity_input(
+        Connectivity, n_nodes=n_nodes, tril=True
+    )
+    correct_numpy_input = np.ones(correct_numpy_shape)
+    con = Connectivity(
+        data=correct_numpy_input, n_nodes=n_nodes, indices=indices, **extra_kwargs
+    )
+
+    with pytest.raises(ValueError, match="Cannot fill missing values for connectivity"):
+        con.get_data()
+
+
+def test_make_full_with_indices():
+    """Test filling missing values in connectivity data with tuple indices."""
+    n_nodes = 3
+    correct_numpy_input = np.arange(n_nodes**2)
+
+    # Check that connectivity data with explicit all-to-all indices works
+    indices = np.unravel_index(np.arange(n_nodes**2), (n_nodes, n_nodes))
+    con_ind = Connectivity(data=correct_numpy_input, n_nodes=n_nodes, indices=indices)
+    con_all = Connectivity(data=correct_numpy_input, n_nodes=n_nodes, indices="all")
+    assert_array_equal(con_ind.get_data("dense"), con_all.get_data())
+
+    # Check that non-all-to-all indices errors when trying to fill missing values
+    non_all_indices = ([0, 1], [1, 0])
+    con_non_all = Connectivity(
+        data=np.arange(len(non_all_indices[0])),
+        n_nodes=n_nodes,
+        indices=non_all_indices,
+    )
+    with pytest.raises(ValueError, match="Cannot fill missing values for connectivity"):
+        con_non_all.get_data("dense")
 
 
 # Time-resolved CIPLV can involve division by zero on diagonal

--- a/mne_connectivity/tests/test_connectivity.py
+++ b/mne_connectivity/tests/test_connectivity.py
@@ -158,9 +158,6 @@ def test_connectivity_containers(conn_cls, n_components):
         conn_cls(data=correct_numpy_input, n_nodes=2, indices="all", **extra_kwargs)
 
     # test that get_data works as intended
-    with pytest.raises(ValueError, match="Invalid value for the 'output' parameter"):
-        conn.get_data(output="blah")
-
     assert conn.shape == tuple(correct_numpy_shape)
     assert conn.get_data(output="raveled").shape == tuple(correct_numpy_shape)
     assert conn.get_data(output="dense").ndim == len(correct_numpy_shape) + 1
@@ -260,6 +257,98 @@ def test_connectivity_containers(conn_cls, n_components):
     )
 
 
+def test_get_multivariate_data():
+    """Test that get_data() works properly with multivariate data."""
+    indices = (
+        np.array([[0, 1], [0, 1], [2, 3]]),
+        np.array([[2, 3], [4, 5], [4, 5]]),
+    )  # should map to upper-triangular elements
+
+    # Find individual channels and nodes (sets of channels) in the data
+    chans, nodes = set(), set()
+    for seed, target in zip(*indices):
+        for ch in seed:
+            chans.add(ch)
+        for ch in target:
+            chans.add(ch)
+        nodes.add(tuple(seed))
+        nodes.add(tuple(target))
+
+    data = np.arange(len(indices[0]), dtype=np.float64)
+    con = Connectivity(data=data, indices=indices, n_nodes=len(chans))
+
+    # Check no manipulation is performed for raveled output
+    matrix = con.get_data(output="raveled")
+    assert isinstance(matrix, np.ndarray)  # just data expected
+    assert_array_equal(data, matrix)
+
+    # Check that output gets mapped to new space for dense output
+    out = con.get_data(output="dense", missing=np.nan)
+    assert isinstance(out, tuple)  # data and multivariate_nodes expected
+    assert len(out) == 2
+    matrix, multivariate_nodes = out
+    assert isinstance(matrix, np.ndarray)
+    assert isinstance(multivariate_nodes, tuple)
+    assert np.all(isinstance(ind, np.ndarray) for ind in multivariate_nodes)
+    assert set(tuple(ind) for ind in multivariate_nodes) == nodes
+    triu_indices = np.triu_indices(len(nodes), k=1)
+    # TODO VERSION: use [*triu_indices] when Py3.10 dropped
+    assert_array_equal(matrix[triu_indices[0], triu_indices[1]], data)
+
+
+def test_get_data_error_catch():
+    """Test that bad calls are caught for get_data()."""
+    n_nodes = 3
+    con = Connectivity(
+        data=np.arange(n_nodes**2),
+        n_nodes=n_nodes,
+        indices="all",
+        method="coh",  # use known method that support filling missing values
+    )
+
+    # Check bad output is caught
+    with pytest.raises(ValueError, match="Invalid value for the 'output' parameter"):
+        con.get_data(output="square")
+
+    # Check bad missing is caught
+    with pytest.raises(
+        TypeError, match="`missing` must be an instance of str or numeric"
+    ):
+        con.get_data(missing=True)
+    with pytest.raises(ValueError, match="Invalid value for the 'missing' parameter"):
+        con.get_data(missing="warn")
+
+    # Check that non-all-to-all indices errors when trying to fill missing values
+    non_all_indices = ([0, 1], [1, 0])
+    con_non_all = Connectivity(
+        data=np.arange(len(non_all_indices[0])),
+        n_nodes=n_nodes,
+        indices=non_all_indices,
+    )
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Cannot fill missing values for connectivity data when indices are "
+            "specified"
+        ),
+    ):
+        con_non_all.get_data("dense")
+
+    # Check that unknown method errors when trying to fill missing values
+    for indices in ["lower", "upper"]:
+        con_bad_meth = Connectivity(
+            data=np.arange(n_nodes * (n_nodes - 1) // 2),
+            n_nodes=n_nodes,
+            indices=indices,
+            method="who_knows",
+        )
+        with pytest.raises(
+            ValueError,
+            match="Cannot fill missing values for connectivity data for the method",
+        ):
+            con_bad_meth.get_data()
+
+
 @pytest.mark.parametrize("indices", ["lower", "upper"])
 def test_make_unknown_method_full(indices):
     """Test that filling missing values in unknown methods errors."""
@@ -286,16 +375,6 @@ def test_make_full_with_indices():
     con_ind = Connectivity(data=correct_numpy_input, n_nodes=n_nodes, indices=indices)
     con_all = Connectivity(data=correct_numpy_input, n_nodes=n_nodes, indices="all")
     assert_array_equal(con_ind.get_data("dense"), con_all.get_data())
-
-    # Check that non-all-to-all indices errors when trying to fill missing values
-    non_all_indices = ([0, 1], [1, 0])
-    con_non_all = Connectivity(
-        data=np.arange(len(non_all_indices[0])),
-        n_nodes=n_nodes,
-        indices=non_all_indices,
-    )
-    with pytest.raises(ValueError, match="Cannot fill missing values for connectivity"):
-        con_non_all.get_data("dense")
 
 
 # Time-resolved CIPLV can involve division by zero on diagonal
@@ -379,44 +458,6 @@ def test_make_smi_full(data_make_full, weighted):
     # Check results are equivalent
     assert_allclose(lower.get_data(), upper.get_data(), atol=1e-6)
     assert_allclose(lower.get_data(), full.get_data("dense"), atol=1e-6)
-
-
-def test_get_multivariate_data():
-    """Test that get_data works properly with multivariate data."""
-    indices = (
-        np.array([[0, 1], [0, 1], [2, 3]]),
-        np.array([[2, 3], [4, 5], [4, 5]]),
-    )  # should map to upper-triangular elements
-
-    # Find individual channels and nodes (sets of channels) in the data
-    chans, nodes = set(), set()
-    for seed, target in zip(*indices):
-        for ch in seed:
-            chans.add(ch)
-        for ch in target:
-            chans.add(ch)
-        nodes.add(tuple(seed))
-        nodes.add(tuple(target))
-
-    data = np.arange(len(indices[0]), dtype=np.float64)
-    con = Connectivity(data=data, indices=indices, n_nodes=len(chans))
-
-    # Check no manipulation is performed for raveled output
-    matrix = con.get_data(output="raveled")
-    assert isinstance(matrix, np.ndarray)  # just data expected
-    assert_array_equal(data, matrix)
-
-    # Check that output gets mapped to new space for dense output
-    out = con.get_data(output="dense", missing=np.nan)
-    assert isinstance(out, tuple)  # data and multivariate_nodes expected
-    assert len(out) == 2
-    matrix, multivariate_nodes = out
-    assert isinstance(matrix, np.ndarray)
-    assert isinstance(multivariate_nodes, tuple)
-    assert np.all(isinstance(ind, np.ndarray) for ind in multivariate_nodes)
-    triu_indices = np.triu_indices(len(nodes), k=1)
-    # TODO VERSION: use [*triu_indices] when Py3.10 dropped
-    assert_array_equal(matrix[triu_indices[0], triu_indices[1]], data)
 
 
 @pytest.mark.parametrize(

--- a/mne_connectivity/tests/test_connectivity.py
+++ b/mne_connectivity/tests/test_connectivity.py
@@ -259,7 +259,7 @@ def test_get_multivariate_data():
     assert_array_equal(data, matrix)
 
     # Check that output gets mapped to new space for dense output
-    out = con.get_data(output="dense")
+    out = con.get_data(output="dense", missing=np.nan)
     assert isinstance(out, tuple)  # data and multivariate_nodes expected
     assert len(out) == 2
     matrix, multivariate_nodes = out
@@ -454,19 +454,23 @@ def test_metadata_handling(func, tmpdir, epochs):
         assert metadata.empty
 
 
-@pytest.mark.parametrize("indices", ["all", "symmetric", "tril"])
-def test_get_data_complex(indices):
+@pytest.mark.parametrize("indices", ["all", "lower", "upper"])
+@pytest.mark.parametrize(
+    ["output", "missing"],
+    [["raveled", "raise"], ["dense", "raise"], ["dense", np.nan]],
+)
+def test_get_data_complex(indices, output, missing):
     """Test that get_data works properly with complex data."""
     n_nodes = 3
     data = np.ones((n_nodes * n_nodes), dtype=np.complex128)
-    if indices == "symmetric":
-        triu_inds = np.triu_indices(n_nodes, k=0)
+    if indices == "lower":
+        tril_inds = np.tril_indices(n_nodes, k=-1)
+        data = data[np.ravel_multi_index(tril_inds, (n_nodes, n_nodes))]
+    if indices == "upper":
+        triu_inds = np.triu_indices(n_nodes, k=1)
         data = data[np.ravel_multi_index(triu_inds, (n_nodes, n_nodes))]
-    if indices == "tril":
-        indices = np.tril_indices(n_nodes, k=-1)
-        data = data[np.ravel_multi_index(indices, (n_nodes, n_nodes))]
 
-    conn = Connectivity(data=data, indices=indices, n_nodes=n_nodes)
-    for output in ["raveled", "dense"]:
-        out_data = conn.get_data(output=output)
-        assert np.iscomplexobj(out_data)
+    # use known method so missing values can be filled for dense when default missing
+    conn = Connectivity(data=data, indices=indices, n_nodes=n_nodes, method="coh")
+    out_data = conn.get_data(output=output, missing=missing)
+    assert np.iscomplexobj(out_data)

--- a/mne_connectivity/tests/test_connectivity.py
+++ b/mne_connectivity/tests/test_connectivity.py
@@ -112,8 +112,7 @@ def _prep_correct_connectivity_input(
         EpochSpectroTemporalConnectivity,
     ],
 )
-@pytest.mark.parametrize("n_components", [0, 2])
-def test_connectivity_containers(conn_cls, n_components):
+def test_connectivity_containers(conn_cls):
     """Test connectivity classes."""
     n_epochs = 4
     n_nodes = 3
@@ -129,11 +128,7 @@ def test_connectivity_containers(conn_cls, n_components):
         bad_numpy_input = np.zeros((3, 3, 3, 4, 5, 6))
 
     correct_numpy_shape, extra_kwargs = _prep_correct_connectivity_input(
-        conn_cls,
-        n_nodes=n_nodes,
-        tril=False,
-        n_epochs=n_epochs,
-        n_components=n_components,
+        conn_cls, n_nodes=n_nodes, tril=False, n_epochs=n_epochs
     )
 
     correct_numpy_input = np.ones(correct_numpy_shape)
@@ -257,8 +252,21 @@ def test_connectivity_containers(conn_cls, n_components):
     )
 
 
-def test_get_multivariate_data():
-    """Test that get_data() works properly with multivariate data."""
+@pytest.mark.parametrize(
+    "conn_cls",
+    [
+        Connectivity,
+        EpochConnectivity,
+        SpectralConnectivity,
+        TemporalConnectivity,
+        SpectroTemporalConnectivity,
+        EpochTemporalConnectivity,
+        EpochSpectralConnectivity,
+        EpochSpectroTemporalConnectivity,
+    ],
+)
+def test_connectivity_containers_multivariate(conn_cls):
+    """Test that connectivity containers work properly with multivariate data."""
     indices = (
         np.array([[0, 1], [0, 1], [2, 3]]),
         np.array([[2, 3], [4, 5], [4, 5]]),
@@ -274,8 +282,12 @@ def test_get_multivariate_data():
         nodes.add(tuple(seed))
         nodes.add(tuple(target))
 
-    data = np.arange(len(indices[0]), dtype=np.float64)
-    con = Connectivity(data=data, indices=indices, n_nodes=len(chans))
+    # Create connectivity container
+    correct_numpy_shape, index_kwargs = _prep_correct_connectivity_input(
+        conn_cls, n_nodes=len(chans), indices=indices, n_components=2
+    )
+    data = np.ones(correct_numpy_shape, dtype=np.float64)
+    con = conn_cls(data=data, indices=indices, n_nodes=len(chans), **index_kwargs)
 
     # Check no manipulation is performed for raveled output
     matrix = con.get_data(output="raveled")
@@ -293,7 +305,10 @@ def test_get_multivariate_data():
     assert set(tuple(ind) for ind in multivariate_nodes) == nodes
     triu_indices = np.triu_indices(len(nodes), k=1)
     # TODO VERSION: use [*triu_indices] when Py3.10 dropped
-    assert_array_equal(matrix[triu_indices[0], triu_indices[1]], data)
+    if conn_cls.is_epoched:
+        assert_array_equal(matrix[:, triu_indices[0], triu_indices[1]], data)
+    else:
+        assert_array_equal(matrix[triu_indices[0], triu_indices[1]], data)
 
 
 def test_get_data_error_catch():

--- a/mne_connectivity/tests/test_envelope.py
+++ b/mne_connectivity/tests/test_envelope.py
@@ -35,7 +35,7 @@ def _compute_corrs_orig(data):
                 # Estimate correlation
                 corr[ii, jj] += np.abs(np.corrcoef(x_mag, y_orth_x_mag)[0, 1])
     corr = (corr + corr.T) / (2.0 * n_epochs)
-    corr.flat[:: n_labels + 1] = 0.0
+    corr.flat[:: n_labels + 1] = 1.0
     return corr
 
 
@@ -72,18 +72,18 @@ def test_envelope_correlation():
     data_hilbert = hilbert(data, axis=-1)
     corr_orig = _compute_corrs_orig(data_hilbert)
     assert (0 <= corr_orig).all()
-    assert (corr_orig < 1).all()
+    assert (corr_orig <= 1).all()
 
-    # upper triangular indices to access the "corr_orig"
-    triu_inds = np.triu_indices(n_signals, k=0)
-    raveled_triu_inds = np.ravel_multi_index(triu_inds, dims=(n_signals, n_signals))
-    condensed_n_estimates = len(raveled_triu_inds)
+    # lower triangular indices to access the "corr_orig"
+    tril_inds = np.tril_indices(n_signals, k=-1)
+    raveled_tril_inds = np.ravel_multi_index(tril_inds, dims=(n_signals, n_signals))
+    condensed_n_estimates = len(raveled_tril_inds)
 
     # using complex data
     corr = envelope_correlation(data_hilbert)
     assert_allclose(
         np.mean(corr.get_data(output="raveled"), axis=0).squeeze(),
-        corr_orig.flatten()[raveled_triu_inds],
+        corr_orig.flatten()[raveled_tril_inds],
     )
 
     # do Hilbert internally, and don't combine
@@ -149,7 +149,7 @@ def test_envelope_correlation():
         ],
         float,
     )
-    ft_vals[np.isnan(ft_vals)] = 0
+    ft_vals[np.isnan(ft_vals)] = 1.0
     corr_log = envelope_correlation(data, log=True, absolute=False)
     assert_allclose(corr_log.get_data(output="dense").squeeze(), ft_vals)
 

--- a/mne_connectivity/tests/test_wsmi.py
+++ b/mne_connectivity/tests/test_wsmi.py
@@ -55,9 +55,6 @@ def test_wsmi_input_output_validation():
     with pytest.raises(ValueError, match="Index.*is out of range"):
         wsmi(epochs, kernel=3, tau=1, indices=(np.array([0]), np.array([5])))
 
-    with pytest.raises(ValueError, match="Self-connectivity not supported"):
-        wsmi(epochs, kernel=3, tau=1, indices=(np.array([0]), np.array([0])))
-
     # Test with different channel types
     with pytest.warns(RuntimeWarning, match="The unit for channel"):
         epochs.set_channel_types({"0": "eeg", "1": "mag", "2": "grad"})
@@ -684,8 +681,8 @@ def test_wsmi_bad_channels(picks):
             indices = (np.array([2]), np.array([0]))
         n_cons = len(indices[0])
     else:
-        indices = None  # implicit bad exclusion
-        n_cons = n_channels**2
+        indices = "lower"  # implicit bad exclusion
+        n_cons = n_channels * (n_channels - 1) // 2
 
     # Compute connectivity
     con = wsmi(data, kernel=3, tau=1, indices=indices, average=True)
@@ -695,17 +692,18 @@ def test_wsmi_bad_channels(picks):
     assert con.names == data.ch_names
 
     # Check dense shape same regardless of indices
-    assert con.get_data("dense").shape == (n_channels, n_channels)
+    missing = np.nan if indices != "lower" else "raise"
+    assert con.get_data("dense", missing=missing).shape == (n_channels, n_channels)
 
     # Check raveled shape and contents depends on indices
     raveled_data = con.get_data("raveled")
     assert raveled_data.shape == (n_cons,)  # n_cons depends on picks
     if picks is not None:
-        # with "all" channels used, bads entries are present and are non-zero
+        # with "all" channels used, bads entries are present and are not NaN
         # with "goods" channels used, bads entries are non-existent
-        # in both cases, all entries are non-zero
-        assert_array_less(0, raveled_data)
-    else:  # indices=None → all-to-all connectivity
-        # bads entries present, but filled with zeros
-        assert_array_equal(raveled_data[[3, 7]], 0)  # bads indices
+        # in both cases, all entries are not NaN
+        assert not np.any(np.isnan(raveled_data))
+    else:  # indices="lower"
+        # bads entries present, but filled with NaNs
+        assert_array_equal(raveled_data[[0, 2]], np.nan)  # bads indices
         # (use np.ravel_multi_index to find dense array indices in raveled array)

--- a/mne_connectivity/utils/__init__.py
+++ b/mne_connectivity/utils/__init__.py
@@ -1,5 +1,5 @@
 from .docs import fill_doc
-from .transform_to_full import _CAN_SYMMETRISE, _get_full_connectivity, _make_square
+from .transform_to_full import _CAN_FILL_MISSING, _get_full_connectivity, _make_square
 from .utils import (
     _check_if_multivariate_indices,
     _check_multivariate_indices,

--- a/mne_connectivity/utils/__init__.py
+++ b/mne_connectivity/utils/__init__.py
@@ -1,4 +1,5 @@
 from .docs import fill_doc
+from .transform_to_full import _get_full_connectivity
 from .utils import (
     _check_if_multivariate_indices,
     _check_multivariate_indices,

--- a/mne_connectivity/utils/__init__.py
+++ b/mne_connectivity/utils/__init__.py
@@ -1,5 +1,5 @@
 from .docs import fill_doc
-from .transform_to_full import _get_full_connectivity
+from .transform_to_full import _CAN_SYMMETRISE, _get_full_connectivity, _make_square
 from .utils import (
     _check_if_multivariate_indices,
     _check_multivariate_indices,

--- a/mne_connectivity/utils/docs.py
+++ b/mne_connectivity/utils/docs.py
@@ -4,11 +4,7 @@
 #
 # License: BSD (3-clause)
 
-try:  # 1.0+
-    from mne.utils.docs import _indentcount_lines
-except ImportError:
-    from mne.externals.doccer import indentcount_lines as _indentcount_lines  # noqa
-
+from mne.utils.docs import _indentcount_lines
 
 ##############################################################################
 # Define our standard documentation entries
@@ -169,6 +165,243 @@ random_state : None | int | instance of ~numpy.random.RandomState
     :class:`numpy.random.RandomState`. If ``None``, the seed will be obtained from the
     operating system (see :class:`numpy.random.RandomState` for details). Default is
     ``None``.
+"""
+
+# Visualisation
+docdict["viz_info"] = """
+info : mne.Info | None
+    The :class:`mne.Info` object with information about the sensors and methods of
+    measurement. Used to split the figures by channel types and identify bad channels.
+    If ``None`` (default), all channels are assumed to be good ``'misc'`` channels.
+"""
+
+docdict["viz_picks"] = """
+picks : str | array_like | slice | None
+    Channels to include in the plot. Connections involving these channels will be
+    included, based on ``selection``. Slices and lists of integers will be interpreted
+    as channel indices. In lists, channel type strings (e.g., ``['meg', 'eeg']``) will
+    pick channels of those types, channel name strings (e.g.,
+    ``['MEG0111', 'MEG2623']``) will pick the given channels. Can also be the string
+    values ``'all'`` to pick all channels, or ``'data'`` to pick data channels. None
+    (default) will pick any good channels. Note that channels in ``info['bads']`` will
+    be included if their names or indices are explicitly provided.
+"""
+
+viz_selection_template = """
+selection : ``'seeds'`` | ``'targets'`` | ``'both'``
+    What the ``picks`` parameter will be applied to. If ``'seeds'``, only connections
+    within the seed channels matchinng ``picks`` will be included. If ``'targets'``,
+    only connections within the target channels matching ``picks`` will be included. If
+    ``'both'``, connections will be included if either the seed or target channels match
+    ``picks``. Ignored if ``picks`` is ``None``.{}
+"""
+docdict["viz_selection"] = viz_selection_template.format("")
+docdict["viz_selection_line"] = docdict["viz_selection"].format(
+    " This also controls the channels which can be selected in the interactive circle "
+    "plot."
+)
+
+docdict["viz_exclude"] = """
+exclude : list of str | ``'bads'``
+    Channel names to exclude from plotting. All connections involving these channels
+    will be excluded. If ``'bads'`` (default), channels in ``info['bads']`` are
+    excluded.
+"""
+
+viz_combine_template = """
+combine : ``'mean'`` | callable | None
+    How to aggregate across connections. ``'mean'`` uses :func:`numpy.mean`. If
+    :func:`callable`, it must operate on an array of shape {} and return an array of
+    shape {}. If ``None``, plot {}. Defaults to {}.
+"""
+docdict["viz_combine_line_spectral"] = viz_combine_template.format(
+    "``(n_connections, n_freqs)``",
+    "``(n_freqs,)``",
+    "each connection individually",
+    "``None``",
+)
+docdict["viz_combine_line_temporal"] = viz_combine_template.format(
+    "``(n_connections, n_times)``",
+    "``(n_times,)``",
+    "each connection individually",
+    "``None``",
+)
+docdict["viz_combine_image_spectrotemporal"] = viz_combine_template.format(
+    "``(n_connections, n_freqs, n_times)``",
+    "``(n_freqs, n_times)``",
+    "one figure per connection",
+    "``'mean'``",
+)
+
+docdict["viz_ci"] = """
+ci : float | ``'sd'`` | ``'range'`` | None
+    Type of confidence band drawn around the aggregated data when ``combine`` is not
+    ``None``. If ``'sd'`` (default) the band spans ±1 the standard deviation across
+    connections. If ``'range'`` the band spans the range across connections at each bin.
+    If a float, it indicates the (bootstrapped) confidence interval to display, and must
+    satisfy ``0 < ci <= 100``. If ``None``, no band is drawn.
+"""
+
+docdict["viz_tmin_tmax"] = """
+tmin, tmax : float | None
+    First and last times to plot, in seconds. If ``None`` take the first/last time
+    in the data, respectively. Default is ``None``.
+"""
+
+docdict["viz_fmin_fmax"] = """
+fmin, fmax : float | None
+    First and last frequencies to plot, in Hz. If ``None`` take the first/last frequency
+    in the data, respectively. Default is ``None``.
+"""
+
+docdict["viz_colors_line"] = """
+colors : ``'auto'`` | ``'global'`` | ``'relative'``
+    How to color the connections. If ``'global'``, the same colormap is used across all
+    connections. This is recommended if the connectivity indices do not correspond to
+    a full or symmetric matrix. If ``'relative'``, the connections for each channel
+    span the full colormap. This is recommended if the connectivity indices correspond
+    to a full or symmetric matrix. If ``'auto'`` (default), the coloring is set to
+    ``'relative'`` if the connectivity indices correspond to a lower-triangular matrix
+    and ``interactive`` is ``True``, or ``'global'`` otherwise.
+"""
+
+docdict["viz_cmap_line"] = """
+cmap : str | matplotlib.colors.Colormap
+    Colormap to use for coloring the connections. If a str, must be a recognised
+    Matplotlib colormap name. Default is ``'turbo'``.
+"""
+
+docdict["viz_yscale_image"] = """
+yscale : ``'linear'`` | ``'log'`` | ``'auto'``
+    The scale of the y-axis (frequencies). ``'linear'`` gives a linear y-axis. ``'log'``
+    gives a log-spaced y-axis. ``'auto'`` (default) detects if frequencies are
+    log-spaced, and if so, sets the y-axis to ``'log'``, otherwise is ``'linear'``.
+    Default is ``'auto'``.
+"""
+
+docdict["viz_node_aliases"] = """
+node_aliases : dict | None
+    Mapping of node indices to node names. Keys should be seed or target indices
+    found in ``con.indices``, that is, integers for bivariate connectivity, and arrays
+    of integers for multivariate connectivity. If ``None`` and plotting results for
+    bivariate connectivity, node names will be taken from ``con.names``. If ``None``
+    and plotting results for multivariate connectivity, node names will be generated
+    as ``'node {idx}'``, where ``idx`` is the order of the node in the unique set of
+    indices, as determined by ``np.unique([*con.indices[0], *con.indices[1]])``.
+"""
+
+docdict["viz_vmin_vmax"] = """
+vmin, vmax : float | None
+    Lower and upper bounds of the colormap, respectively. If both entries are ``None``
+    and there are both positive and negative values in the data, the bounds are set at ±
+    the maximum absolute value of the data (yielding a colormap with midpoint at 0). If
+    both entries are ``None`` and the data is all positive or all negative, the bounds
+    are set at the min/max of the data, respectively. Providing ``None`` for just one
+    entry will set the corresponding boundary at the min/max of the data. Defaults to
+    ``None``.
+"""
+
+docdict["viz_cnorm"] = """
+cnorm : matplotlib.colors.Normalize | None
+    How to normalize the colormap. If ``None`` (default), standard linear normalization
+    is performed. If not ``None``, ``vmin`` and ``vmax`` will be ignored. See
+    :ref:`Matplotlib docs <matplotlib:colormapnorms>` for more details on colormap
+    normalization.
+"""
+
+docdict["viz_cbar"] = """
+colorbar : bool
+    Whether to display a colorbar for each figure. Defaults to ``True``.
+"""
+
+docdict["viz_cmap"] = """
+cmap : str | matplotlib.colors.Colormap | None
+    The colormap to use for coloring the connectivity values. If a str, must be a valid
+    Matplotlib colormap name.If ``None`` (default), ``'RdBu_r'`` is used for data that
+    has positive and negative values, ``Reds`` is used for data that is all positive,
+    and ``Blues_r`` is used for data that is all negative.
+"""
+
+docdict["viz_node_labels_matrix"] = """
+node_labels : ``'ticks'`` | ``'names'`` | None
+    How to label the nodes in the matrix along the x- and y-axes. If ``'ticks'``
+    (default), the indices of the nodes are shown at evenly spaced intervals. Note that
+    for many nodes, not all may have labels. If ``'names'``, each node's name is shown.
+    Note that for many nodes, this can lead to overlapping labels. If ``None``, no
+    labels are shown.
+"""
+
+docdict["viz_mask"] = """
+mask : numpy.ndarray | None
+    An array of boolean values, of the same shape as the data. Data that corresponds to
+    ``False`` entries in the mask are plotted differently, as determined by
+    ``mask_style``, ``mask_alpha``, and ``mask_cmap``. Useful for, e.g., highlighting
+    areas of statistical significance. Default is ``None``, for no masking.
+"""
+
+docdict["viz_mask_style"] = """
+mask_style : None | ``'contour'`` | ``'mask'`` | ``'both'``
+    How to distinguish the masked/unmasked regions of the plot. If ``'contour'``, a line
+    is drawn around the areas where ``mask`` is True. If ``'mask'``, areas where
+    ``mask`` is ``False`` will be (partially) transparent, as determined by
+    ``mask_alpha``. If ``'both'``, both a contour and transparency are used. Default is
+    ``None``, which is silently ignored if ``mask`` is ``None``, and is interpreted like
+    ``'both'`` otherwise.
+"""
+
+docdict["viz_mask_cmap"] = """
+mask_cmap : matplotlib.colors.Colormap | str | None
+    Colormap to use for masked areas of the plot. If a str, must be a valid Matplotlib
+    colormap name. If ``None``, ``cmap`` is used for both masked and unmasked areas.
+    Ignored if mask is ``None``. Default is ``'Greys'``.
+"""
+
+docdict["viz_mask_alpha"] = """
+mask_alpha : float
+    Relative opacity of the masked region versus the unmasked region, given as a float
+    between 0 and 1 (0 means masked areas are not visible at all). Defaults to ``0.1``.
+"""
+
+docdict["viz_highlight"] = """
+highlight : array_like of float, shape (2,) | array_like of float, shape (n, 2) | None
+    Segments of the data to highlight by means of a light-yellow background color. The
+    data periods to highlight must be specified as array-like objects in the form of
+    ``(start, end)`` in the units of the data. Multiple periods can be specified by
+    passing an array-like object of individual periods (e.g., for 3 periods, the shape
+    of the passed object would be ``(3, 2)``. If ``None`` (default), no highlighting is
+    applied.
+"""
+
+docdict["viz_interactive"] = """
+interactive : bool
+    Whether to make the plot interactive. This enables functionality like clicking on
+    a connection to show its name. Defaults to ``True``.
+"""
+
+docdict["viz_show"] = """
+show : bool
+    Whether to show the figure(s). Defaults to ``True``.
+"""
+
+docdict["viz_figures"] = """
+fig : instance of matplotlib.figure.Figure | list of instance of matplotlib.figure.Figure
+    The figure(s) containing the connectivity plot(s). One figure is returned per
+    channel types in the seeds and targets.
+"""  # noqa E501
+
+docdict["viz_components_note"] = """
+Plotting for multivariate connectivity is handled by treating each component of the
+multivariate connections as a separate connection. The names of the nodes are
+differentiated by the addition of the component number to the node name, e.g.,
+``'node 0 (0)', 'node 0 (1)', ...``.
+"""
+
+docdict["viz_circle_line_note"] = """
+The circle plot acts as an overview of the channels and their connections in the line
+plot. If ``interactive`` is ``True``, left-clicking on a channel in the circle plot will
+show the connections only for that channel (the exact behaviour is determined by
+``selection``). Right-click to return to the original view. The circle plot is not shown
+if the plotted connections correspond to only a single node in the figure.
 """
 
 # Decoding initialisation
@@ -512,5 +745,5 @@ def fill_doc(f):
     except (TypeError, ValueError, KeyError) as exp:
         funcname = f.__name__
         funcname = docstring.split("\n")[0] if funcname is None else funcname
-        raise RuntimeError(f"Error documenting {funcname}:\n{str(exp)}")
+        raise RuntimeError(f"Error documenting {funcname}:\n{exp}")
     return f

--- a/mne_connectivity/utils/docs.py
+++ b/mne_connectivity/utils/docs.py
@@ -172,6 +172,7 @@ indices : tuple of array_like | ``'lower'`` | ``'upper'`` | ``'all'``
     If ``'upper'``, connectivity represents the upper-triangular part of the
     connectivity matrix.
     If ``'all'``, connectivity represents all connections.
+    Indices for multivarate methods should only be specified as a tuple of arrays.
 """
 
 docdict["freqs"] = """

--- a/mne_connectivity/utils/docs.py
+++ b/mne_connectivity/utils/docs.py
@@ -4,6 +4,8 @@
 #
 # License: BSD (3-clause)
 
+from functools import partial
+
 from mne.utils.docs import _indentcount_lines
 
 ##############################################################################
@@ -27,14 +29,34 @@ names : array_like | None
     of names, then it must be equal in length to ``n_nodes``.
 """
 
-docdict["indices"] = """
-indices : tuple of array_like | ``'all'`` | ``'symmetric'`` | None
-    The indices of relevant connectivity data. If ``'all'`` (default), then data is
-    connectivity between all nodes. If ``'symmetric'``, then data is symmetric
-    connectivity between all nodes. If a tuple, then contains two array-likes where the
-    first array represents the "in nodes" (seeds), and the second array represents the
-    "out nodes" (targets).
+indices_base = """
+indices : tuple of array_like{other_types}
+    The indices of channels to compute connectivity between. If a tuple, then must
+    contain two array-likes, where the first array represents the channel indices of the
+    seeds, and the second array represents the channel indices of the targets.
+    {multivar_indices}
+    See the notes section for more information.
+    {other_types_description}
+    {default}
 """
+multivar_indices_extra = (
+    "For multivariate methods, the seed and target indices should consist of nested "
+    "arrays containing the channel indices for each multivariate connection."
+)
+indices_with_str = partial(
+    indices_base.format,
+    other_types=" | ``'lower'`` | ``'upper'`` | ``'all'``",
+    other_types_description=(
+        "If ``'lower'``, compute the lower-triangular part of the connectivity matrix. "
+        "If ``'upper'``, compute the upper-triangular part of the connectivity matrix. "
+        "If ``'all'``, compute all connections."
+    ),
+    default="Default is ``'lower'``.",
+)
+docdict["indices_with_str_only_bivar"] = indices_with_str(multivar_indices="")
+docdict["indices_with_str_with_multivar"] = indices_with_str(
+    multivar_indices=multivar_indices_extra
+)
 
 docdict["n_nodes"] = """
 n_nodes : int
@@ -103,7 +125,55 @@ docdict["wpli2_debiased"] = "'wpli2_debiased' : Debiased estimator of squared WP
 docdict["gc"] = "'gc' : State-space Granger Causality (GC)"
 docdict["gc_tr"] = "'gc_tr' : State-space GC on time-reversed signals"
 
+docdict["tri_indices_efficiency_note"] = """
+If connectivity for all possible connections is desired, we can save time and memory by
+only computing and storing the lower- (or upper-) triangular part of the connectivity
+matrix. When the full set of connectivity values is needed, the missing values can be
+inferred based on what has been computed. See the notes section of the
+:meth:`~Connectivity.get_data` method in the connectivity containers for more
+information.
+"""
+
+docdict["tuple_bivar_indices_note"] = """
+If one is only interested in the connectivity between some signals, the ``indices``
+parameter can be specified as a tuple of array-likes. For example, to compute the
+connectivity between the signal with index 0 and the signals with indices 2, 3, and 4 (a
+total of 3 connections) one can use the following::
+
+    indices = (np.array([0, 0, 0]),  # seed indices
+               np.array([2, 3, 4]))  # target indices
+"""
+
+docdict["tuple_multivar_indices_note"] = """
+For multivariate methods, ``indices`` must be specified as a tuple, where the seed and
+target indices for each connection are nested array-likes. For example, to compute the
+connectivity between signals (0, 1) → (2, 3) and (0, 1) → (4, 5), ``indices`` should be
+specified as::
+
+    indices = (np.array([[0, 1], [0, 1]]),  # seeds
+               np.array([[2, 3], [4, 5]]))  # targets
+
+More information on working with multivariate indices and handling connections where the
+number of seeds and targets are not equal can be found in the
+:doc:`../auto_examples/handling_ragged_arrays` example.
+"""
+
 # Downstream container variables
+docdict["indices"] = """
+indices : tuple of array_like | ``'lower'`` | ``'upper'`` | ``'all'``
+    The indices of channels connectivity was computed between.
+    If a tuple, then contains two array-likes, where the first array represents the
+    channel indices of the seeds, and the second array represents the channel indices of
+    the targets.
+    For multivariate methods, the seed and target indices should consist of nested
+    arrays containing the channel indices for each multivariate connection.
+    If ``'lower'``, connectivity represents the lower-triangular part of the
+    connectivity matrix.
+    If ``'upper'``, connectivity represents the upper-triangular part of the
+    connectivity matrix.
+    If ``'all'``, connectivity represents all connections.
+"""
+
 docdict["freqs"] = """
 freqs : list | array
     The frequencies at which the connectivity data is computed over. If the frequencies

--- a/mne_connectivity/utils/docs.py
+++ b/mne_connectivity/utils/docs.py
@@ -454,18 +454,38 @@ show : bool
     Whether to show the figure(s). Defaults to ``True``.
 """
 
-docdict["viz_figures"] = """
+viz_figures_base = """
 fig : instance of matplotlib.figure.Figure | list of instance of matplotlib.figure.Figure
-    The figure(s) containing the connectivity plot(s). One figure is returned per
-    channel types in the seeds and targets.
+    The figure(s) containing the connectivity plot(s).{}
 """  # noqa E501
 
-docdict["viz_components_note"] = """
-Plotting for multivariate connectivity is handled by treating each component of the
-multivariate connections as a separate connection. The names of the nodes are
-differentiated by the addition of the component number to the node name, e.g.,
-``'node 0 (0)', 'node 0 (1)', ...``.
+docdict["viz_figure_image"] = viz_figures_base.format(
+    " One figure is returned per connection."
+)
+
+docdict["viz_figures_line"] = viz_figures_base.format(
+    " One figure is returned per channel types in the seeds and targets."
+)
+
+docdict["viz_figures_matrix"] = viz_figures_base.format(
+    " One figure is returned per channel types in the seeds and targets. For "
+    "multivariate connectivity with multiple components, one figure is also returned "
+    "per component."
+)
+
+viz_components_note_base = """
+Plotting for multivariate connectivity with multiple components is handled by treating
+each component of the multivariate connections as a separate connection.{}
 """
+
+docdict["viz_components_extra_con_note"] = viz_components_note_base.format(
+    " The names of the nodes are differentiated by the addition of the component "
+    "number to the node name, e.g., ``'node 0 (0)', 'node 0 (1)', ...``."
+)
+
+docdict["viz_components_extra_fig_note"] = viz_components_note_base.format(
+    " The connections for each component are plotted on a separate figure."
+)
 
 docdict["viz_circle_line_note"] = """
 The circle plot acts as an overview of the channels and their connections in the line

--- a/mne_connectivity/utils/transform_to_full.py
+++ b/mne_connectivity/utils/transform_to_full.py
@@ -29,12 +29,12 @@ def _get_full_connectivity(data, indices, n_nodes, method, missing):
         return _make_square(data, indices, n_nodes)
 
     # Check if we can infer missing entries in the data for the method
-    if method not in _CAN_SYMMETRISE:
+    if method not in _CAN_FILL_MISSING:
         raise ValueError(
             f"Cannot fill missing values for connectivity data for the method {method}."
         )
     data = _make_square(data, indices, n_nodes)
-    return _CAN_SYMMETRISE[method](data, indices)
+    return _CAN_FILL_MISSING[method](data, indices)
 
 
 def _make_square(data, indices, n_nodes, fill=0.0):
@@ -58,8 +58,8 @@ def _make_square(data, indices, n_nodes, fill=0.0):
     return square_matrix
 
 
-def _make_symmetric(data, indices, diag, transpose_extra=None):
-    """Make the connectivity data symmetric."""
+def _make_full(data, indices, diag, transpose_extra=None):
+    """Fill missing values in the connectivity data."""
     assert indices in ("lower", "upper"), (
         "Expected indices to be 'lower' or 'upper' for symmetrisation, got "
         f"{indices}. Please contact the MNE-Connectivity developers."
@@ -79,75 +79,45 @@ def _make_symmetric(data, indices, diag, transpose_extra=None):
     return data
 
 
-def _symmetrise_coh(data, indices):
-    """Symmetrise coherence data."""
-    return _make_symmetric(data, indices, diag=1.0)
+def _transpose_zero_diag(data, indices):
+    """Fill missing values by transposing, with zeros on the diagonal."""
+    return _make_full(data, indices, diag=0.0)
 
 
-def _symmetrise_cohy(data, indices):
-    """Symmetrise coherency data."""
-    return _make_symmetric(data, indices, diag=1.0 + 0.0j, transpose_extra=np.conj)
+def _transpose_one_diag(data, indices):
+    """Fill missing values by transposing, with ones on the diagonal."""
+    return _make_full(data, indices, diag=1.0)
 
 
-def _symmetrise_imcoh(data, indices):
-    """Symmetrise imaginary part of coherency data."""
-    return _make_symmetric(data, indices, diag=0.0, transpose_extra=lambda x: -x)
+def _transpose_conj_one_diag(data, indices):
+    """Fill missing values by transposing, with ones on the diagonal and conjugate."""
+    return _make_full(data, indices, diag=1.0 + 0.0j, transpose_extra=np.conj)
 
 
-def _symmetrise_plv(data, indices):
-    """Symmetrise phase-locking value data."""
-    return _make_symmetric(data, indices, diag=1.0)
+def _transpose_sign_flip_zero_diag(data, indices):
+    """Fill missing values by transposing with sign flip, and zeros on the diagonal."""
+    return _make_full(data, indices, diag=0.0, transpose_extra=lambda x: -x)
 
 
-def _symmetrise_ciplv(data, indices):
-    """Symmetrise corrected imaginary part of phase-locking value data."""
-    return _make_symmetric(data, indices, diag=0.0)
+def _fill_dpli(data, indices):
+    """Fill missing directed phase lag index values."""
+    return _make_full(data, indices, diag=0.5, transpose_extra=lambda x: 1.0 - x)
 
 
-def _symmetrise_ppc(data, indices):
-    """Symmetrise pairwise phase consistency data."""
-    return _make_symmetric(data, indices, diag=1.0)
-
-
-def _symmetrise_pli(data, indices):
-    """Symmetrise phase lag index data."""
-    return _make_symmetric(data, indices, diag=0.0)
-
-
-def _symmetrise_dpli(data, indices):
-    """Symmetrise directed phase lag index data."""
-    return _make_symmetric(data, indices, diag=0.5, transpose_extra=lambda x: 1.0 - x)
-
-
-def _symmetrise_psi(data, indices):
-    """Symmetrise phase slope index data."""
-    return _make_symmetric(data, indices, diag=0.0)
-
-
-def _symmetrise_smi(data, indices):
-    """Symmetrise symbolic mutual information data."""
-    return _make_symmetric(data, indices, diag=0.0)
-
-
-def _symmetrise_envelope_correlation(data, indices):
-    """Symmetrise envelope correlation data."""
-    return _make_symmetric(data, indices, diag=1.0)
-
-
-_CAN_SYMMETRISE = {
-    "coh": _symmetrise_coh,
-    "cohy": _symmetrise_cohy,
-    "imcoh": _symmetrise_imcoh,
-    "plv": _symmetrise_plv,
-    "ciplv": _symmetrise_ciplv,
-    "ppc": _symmetrise_ppc,
-    "pli": _symmetrise_pli,
-    "pli2_unbiased": _symmetrise_pli,
-    "dpli": _symmetrise_dpli,
-    "wpli": _symmetrise_pli,
-    "wpli2_debiased": _symmetrise_pli,
-    "phase-slope-index": _symmetrise_psi,
-    "SMI": _symmetrise_smi,
-    "wSMI": _symmetrise_smi,
-    "envelope correlation": _symmetrise_envelope_correlation,
+_CAN_FILL_MISSING = {
+    "coh": _transpose_one_diag,
+    "cohy": _transpose_conj_one_diag,
+    "imcoh": _transpose_sign_flip_zero_diag,
+    "plv": _transpose_one_diag,
+    "ciplv": _transpose_zero_diag,
+    "ppc": _transpose_one_diag,
+    "pli": _transpose_zero_diag,
+    "pli2_unbiased": _transpose_zero_diag,
+    "dpli": _fill_dpli,
+    "wpli": _transpose_zero_diag,
+    "wpli2_debiased": _transpose_zero_diag,
+    "phase-slope-index": _transpose_sign_flip_zero_diag,
+    "SMI": _transpose_zero_diag,
+    "wSMI": _transpose_zero_diag,
+    "envelope correlation": _transpose_one_diag,
 }

--- a/mne_connectivity/utils/transform_to_full.py
+++ b/mne_connectivity/utils/transform_to_full.py
@@ -15,8 +15,9 @@ def _get_full_connectivity(data, indices, n_nodes, method, missing):
     if indices == "all":
         return _make_square(data, indices, n_nodes)
     if isinstance(indices, tuple):
-        full_indices = np.indices((n_nodes, n_nodes))
+        indices = tuple(np.asarray(ind) for ind in indices)
         sorted_seeds = np.argsort(indices[0])
+        full_indices = np.indices((n_nodes, n_nodes))
         if not np.array_equal(
             indices[0][sorted_seeds], full_indices[0].ravel()
         ) or not np.array_equal(indices[1][sorted_seeds], full_indices[1].ravel()):
@@ -28,17 +29,16 @@ def _get_full_connectivity(data, indices, n_nodes, method, missing):
         return _make_square(data, indices, n_nodes)
 
     # Check if we can infer missing entries in the data for the method
-    if method not in CAN_SYMMETRISE:
+    if method not in _CAN_SYMMETRISE:
         raise ValueError(
             f"Cannot fill missing values for connectivity data for the method {method}."
         )
     data = _make_square(data, indices, n_nodes)
-    return CAN_SYMMETRISE[method](data, indices)
+    return _CAN_SYMMETRISE[method](data, indices)
 
 
 def _make_square(data, indices, n_nodes, fill=0.0):
     """Make raveled connectivity data square [n_nodes, n_nodes(, ...)]."""
-    fill = 0.0
     if np.iscomplexobj(data):
         fill = fill + 1j * fill
     square_matrix = np.full(
@@ -60,6 +60,10 @@ def _make_square(data, indices, n_nodes, fill=0.0):
 
 def _make_symmetric(data, indices, diag, transpose_extra=None):
     """Make the connectivity data symmetric."""
+    assert indices in ("lower", "upper"), (
+        "Expected indices to be 'lower' or 'upper' for symmetrisation, got "
+        f"{indices}. Please contact the MNE-Connectivity developers."
+    )
     # Always transpose
     data = data + data.transpose(1, 0, *range(2, data.ndim))
     # Perform something on top of the transpose if needed
@@ -125,7 +129,7 @@ def _symmetrise_envelope_correlation(data, indices):
     return _make_symmetric(data, indices, diag=1.0)
 
 
-CAN_SYMMETRISE = {
+_CAN_SYMMETRISE = {
     "coh": _symmetrise_coh,
     "cohy": _symmetrise_cohy,
     "imcoh": _symmetrise_imcoh,

--- a/mne_connectivity/utils/transform_to_full.py
+++ b/mne_connectivity/utils/transform_to_full.py
@@ -1,11 +1,19 @@
 import numpy as np
 
 
-def _symmetrise_connectivity(data, indices, n_nodes, method):
-    """Lorem ipsum."""
-    # Check if data is already full (no need to symmetrise)
+def _get_full_connectivity(data, indices, n_nodes, method, missing):
+    """Get full connectivity matrix from raveled data.
+
+    Attempts to fill missing values in the connectivity data where needed, if the
+    method is known and the logic to do so is possible from what data is available.
+    """
+    # Fill with specified missing value if requested
+    if missing != "raise":
+        return _make_square(data, indices, n_nodes, fill=missing)
+
+    # Check if data is already full (no need to fill missing values)
     if indices == "all":
-        return data.reshape((n_nodes, n_nodes, *data.shape[1:]))
+        return _make_square(data, indices, n_nodes)
     if isinstance(indices, tuple):
         full_indices = np.indices((n_nodes, n_nodes))
         sorted_seeds = np.argsort(indices[0])
@@ -13,22 +21,23 @@ def _symmetrise_connectivity(data, indices, n_nodes, method):
             indices[0][sorted_seeds], full_indices[0].ravel()
         ) or not np.array_equal(indices[1][sorted_seeds], full_indices[1].ravel()):
             raise ValueError(
-                "Cannot symmetrise connectivity data when indices are specified as a "
-                "tuple that does not represent the full connectivity matrix."
+                "Cannot fill missing values for connectivity data when indices are "
+                "specified as a tuple that does not represent the full connectivity "
+                "matrix."
             )
-        return data.reshape((n_nodes, n_nodes, *data.shape[1:]))
+        return _make_square(data, indices, n_nodes)
 
-    # Check if we can symmetrise the connectivity data for the given method
+    # Check if we can infer missing entries in the data for the method
     if method not in CAN_SYMMETRISE:
         raise ValueError(
-            f"Cannot symmetrise connectivity data for the method {method}."
+            f"Cannot fill missing values for connectivity data for the method {method}."
         )
     data = _make_square(data, indices, n_nodes)
     return CAN_SYMMETRISE[method](data, indices)
 
 
-def _make_square(data, indices, n_nodes):
-    """Make the connectivity data square [n_nodes, n_nodes(, ...)]."""
+def _make_square(data, indices, n_nodes, fill=0.0):
+    """Make raveled connectivity data square [n_nodes, n_nodes(, ...)]."""
     fill = 0.0
     if np.iscomplexobj(data):
         fill = fill + 1j * fill
@@ -36,18 +45,21 @@ def _make_square(data, indices, n_nodes):
         (n_nodes, n_nodes, *data.shape[1:]), fill_value=fill, dtype=data.dtype
     )
 
-    if indices == "lower":
-        square_matrix[np.tril_indices(n_nodes, k=-1)] = data
-    else:  # "upper"
-        square_matrix[np.triu_indices(n_nodes, k=1)] = data
+    if indices == "all":
+        indices = np.indices((n_nodes, n_nodes))
+    elif indices == "lower":
+        indices = np.tril_indices(n_nodes, k=-1)
+    elif indices == "upper":
+        indices = np.triu_indices(n_nodes, k=1)
+    # else indices is a tuple of arrays and can be used directly
+
+    square_matrix[indices] = data
 
     return square_matrix
 
 
 def _make_symmetric(data, indices, diag, transpose_extra=None):
     """Make the connectivity data symmetric."""
-    # Set the diagonal
-    data[np.diag_indices(data.shape[0])] = diag
     # Always transpose
     data = data + data.transpose(1, 0, *range(2, data.ndim))
     # Perform something on top of the transpose if needed
@@ -58,6 +70,8 @@ def _make_symmetric(data, indices, diag, transpose_extra=None):
         else:  # "upper"
             tril = np.tril_indices(data.shape[0], k=-1)
             data[tril] = transpose_extra(data[tril])
+    # Set the diagonal
+    data[np.diag_indices(data.shape[0])] = diag
     return data
 
 
@@ -101,11 +115,6 @@ def _symmetrise_dpli(data, indices):
     return _make_symmetric(data, indices, diag=0.5, transpose_extra=lambda x: 1.0 - x)
 
 
-def _symmetrise_wpli(data, indices):
-    """Symmetrise weighted phase lag index data."""
-    return _make_symmetric(data, indices, diag=0.0)
-
-
 def _symmetrise_smi(data, indices):
     """Symmetrise symbolic mutual information data."""
     return _make_symmetric(data, indices, diag=0.0)
@@ -126,8 +135,8 @@ CAN_SYMMETRISE = {
     "pli": _symmetrise_pli,
     "pli2_unbiased": _symmetrise_pli,
     "dpli": _symmetrise_dpli,
-    "wpli": _symmetrise_wpli,
-    "wpli2_debiased": _symmetrise_wpli,
+    "wpli": _symmetrise_pli,
+    "wpli2_debiased": _symmetrise_pli,
     "SMI": _symmetrise_smi,
     "wSMI": _symmetrise_smi,
     "envelope correlation": _symmetrise_envelope_correlation,

--- a/mne_connectivity/utils/transform_to_full.py
+++ b/mne_connectivity/utils/transform_to_full.py
@@ -119,6 +119,11 @@ def _symmetrise_dpli(data, indices):
     return _make_symmetric(data, indices, diag=0.5, transpose_extra=lambda x: 1.0 - x)
 
 
+def _symmetrise_psi(data, indices):
+    """Symmetrise phase slope index data."""
+    return _make_symmetric(data, indices, diag=0.0)
+
+
 def _symmetrise_smi(data, indices):
     """Symmetrise symbolic mutual information data."""
     return _make_symmetric(data, indices, diag=0.0)
@@ -141,6 +146,7 @@ _CAN_SYMMETRISE = {
     "dpli": _symmetrise_dpli,
     "wpli": _symmetrise_pli,
     "wpli2_debiased": _symmetrise_pli,
+    "phase-slope-index": _symmetrise_psi,
     "SMI": _symmetrise_smi,
     "wSMI": _symmetrise_smi,
     "envelope correlation": _symmetrise_envelope_correlation,

--- a/mne_connectivity/utils/transform_to_full.py
+++ b/mne_connectivity/utils/transform_to_full.py
@@ -16,11 +16,8 @@ def _get_full_connectivity(data, indices, n_nodes, method, missing):
         return _make_square(data, indices, n_nodes)
     if isinstance(indices, tuple):
         indices = tuple(np.asarray(ind) for ind in indices)
-        sorted_seeds = np.argsort(indices[0])
         full_indices = np.unravel_index(np.arange(n_nodes**2), (n_nodes, n_nodes))
-        if not np.array_equal(
-            indices[0][sorted_seeds], full_indices[0].ravel()
-        ) or not np.array_equal(indices[1][sorted_seeds], full_indices[1].ravel()):
+        if not np.array_equal(indices, full_indices):
             raise ValueError(
                 "Cannot fill missing values for connectivity data when indices are "
                 "specified as a tuple that does not represent the full connectivity "

--- a/mne_connectivity/utils/transform_to_full.py
+++ b/mne_connectivity/utils/transform_to_full.py
@@ -1,58 +1,8 @@
 import numpy as np
 
-KNOWN_METHODS = [
-    # spec_conn_epochs/time
-    "coh",
-    "cohy",
-    "imcoh",
-    "cacoh",
-    "mic",
-    "mim",
-    "plv",
-    "ciplv",
-    "ppc",
-    "pli2_unbiased",
-    "dpli",
-    "wpli",
-    "wpli2_debiased",
-    "gc",
-    "gc_tr",
-    # Mutual info
-    "SMI",
-    "wSMI",
-    # VAR models
-    "VAR(1)",
-    "VAR(p)",
-    "Time-varying VAR(1)",
-    "Time-varying VAR(p)",
-    # Other
-    "envelope correlation",
-    "phase-slope-index",
-]
-
-CAN_SYMMETRISE = {
-    "coh": _symmetrise_coh,
-    "cohy": _symmetrise_cohy,
-    "imcoh": _symmetrise_imcoh,
-    "cacoh": _symmetrise_coh,
-    "mic": _symmetrise_cohy,
-    "mim": _symmetrise_coh,
-    "SMI": _symmetrise_smi,
-    "wSMI": _symmetrise_smi,
-    "envelope correlation": _symmetrise_envelope_correlation,
-    "phase-slope-index": _symmetrise_phase_slope_index,
-    "plv": _symmetrise_plv,
-    "ciplv": _symmetrise_ciplv,
-    "ppc": _symmetrise_ppc,
-    "pli2_unbiased": _symmetrise_pli2_unbiased,
-    "dpli": _symmetrise_dpli,
-    "wpli": _symmetrise_wpli,
-    "wpli2_debiased": _symmetrise_wpli2_debiased,
-}
-
 
 def _symmetrise_connectivity(data, indices, n_nodes, method):
-    """"""
+    """Lorem ipsum."""
     # Check if data is already full (no need to symmetrise)
     if indices == "all":
         return data.reshape((n_nodes, n_nodes, *data.shape[1:]))
@@ -94,51 +44,76 @@ def _make_square(data, indices, n_nodes):
     return square_matrix
 
 
+def _make_symmetric(data, indices, diag, transpose_extra=None):
+    """Make the connectivity data symmetric."""
+    # Set the diagonal
+    data[np.diag_indices(data.shape[0])] = diag
+    # Always transpose
+    data = data + data.transpose(1, 0, *range(2, data.ndim))
+    # Perform something on top of the transpose if needed
+    if transpose_extra is not None:
+        if indices == "lower":
+            triu = np.triu_indices(data.shape[0], k=1)
+            data[triu] = transpose_extra(data[triu])
+        else:  # "upper"
+            tril = np.tril_indices(data.shape[0], k=-1)
+            data[tril] = transpose_extra(data[tril])
+    return data
+
+
 def _symmetrise_coh(data, indices):
     """Symmetrise coherence data."""
-    data = data + data.transpose(1, 0, *range(2, data.ndim))
-    data[np.diag_indices(data.shape[0])] = 1.0
-    return data
+    return _make_symmetric(data, indices, diag=1.0)
 
 
 def _symmetrise_cohy(data, indices):
     """Symmetrise coherency data."""
-    data = data + data.transpose(1, 0, *range(2, data.ndim))
-    data[np.diag_indices(data.shape[0])] = 1.0 + 1.0j
-    tril = np.tril_indices(data.shape[0], k=-1)
-    triu = np.triu_indices(data.shape[0], k=1)
-    if indices == "lower":
-        data[triu] = np.conj(data[tril])
-    else:  # "upper"
-        data[tril] = np.conj(data[triu])
-    return data
+    return _make_symmetric(data, indices, diag=1.0 + 0.0j, transpose_extra=np.conj)
 
 
 def _symmetrise_imcoh(data, indices):
     """Symmetrise imaginary part of coherency data."""
-    data = data + data.transpose(1, 0, *range(2, data.ndim))
-    data[np.diag_indices(data.shape[0])] = 0.0
-    tril = np.tril_indices(data.shape[0], k=-1)
-    triu = np.triu_indices(data.shape[0], k=1)
-    if indices == "lower":
-        data[triu] *= -1.0
-    else:  # "upper"
-        data[tril] *= -1.0
-    return data
+    return _make_symmetric(data, indices, diag=0.0, transpose_extra=lambda x: -x)
+
+
+def _symmetrise_plv(data, indices):
+    """Symmetrise phase-locking value data."""
+    return _make_symmetric(data, indices, diag=1.0)
+
+
+def _symmetrise_ciplv(data, indices):
+    """Symmetrise corrected imaginary part of phase-locking value data."""
+    return _make_symmetric(data, indices, diag=0.0)
+
+
+def _symmetrise_ppc(data, indices):
+    """Symmetrise pairwise phase consistency data."""
+    return _make_symmetric(data, indices, diag=1.0)
+
+
+def _symmetrise_pli(data, indices):
+    """Symmetrise phase lag index data."""
+    return _make_symmetric(data, indices, diag=0.0)
+
+
+def _symmetrise_dpli(data, indices):
+    """Symmetrise directed phase lag index data."""
+    return _make_symmetric(data, indices, diag=0.5, transpose_extra=lambda x: 1.0 - x)
+
+
+def _symmetrise_wpli(data, indices):
+    """Symmetrise weighted phase lag index data."""
+    return _make_symmetric(data, indices, diag=0.0)
 
 
 def _symmetrise_smi(data, indices):
     """Symmetrise symbolic mutual information data."""
-    data = data + data.transpose(1, 0, *range(2, data.ndim))
-    data[np.diag_indices(data.shape[0])] = 0.0
-    return data
+    return _make_symmetric(data, indices, diag=0.0)
 
 
 def _symmetrise_envelope_correlation(data, indices):
     """Symmetrise envelope correlation data."""
-    data = data + data.transpose(1, 0, *range(2, data.ndim))
-    data[np.diag_indices(data.shape[0])] = 1.0
-    return data
+    return _make_symmetric(data, indices, diag=1.0)
 
 
 CAN_SYMMETRISE = {
@@ -148,10 +123,11 @@ CAN_SYMMETRISE = {
     "plv": _symmetrise_plv,
     "ciplv": _symmetrise_ciplv,
     "ppc": _symmetrise_ppc,
-    "pli2_unbiased": _symmetrise_pli2_unbiased,
+    "pli": _symmetrise_pli,
+    "pli2_unbiased": _symmetrise_pli,
     "dpli": _symmetrise_dpli,
     "wpli": _symmetrise_wpli,
-    "wpli2_debiased": _symmetrise_wpli2_debiased,
+    "wpli2_debiased": _symmetrise_wpli,
     "SMI": _symmetrise_smi,
     "wSMI": _symmetrise_smi,
     "envelope correlation": _symmetrise_envelope_correlation,

--- a/mne_connectivity/utils/transform_to_full.py
+++ b/mne_connectivity/utils/transform_to_full.py
@@ -1,0 +1,158 @@
+import numpy as np
+
+KNOWN_METHODS = [
+    # spec_conn_epochs/time
+    "coh",
+    "cohy",
+    "imcoh",
+    "cacoh",
+    "mic",
+    "mim",
+    "plv",
+    "ciplv",
+    "ppc",
+    "pli2_unbiased",
+    "dpli",
+    "wpli",
+    "wpli2_debiased",
+    "gc",
+    "gc_tr",
+    # Mutual info
+    "SMI",
+    "wSMI",
+    # VAR models
+    "VAR(1)",
+    "VAR(p)",
+    "Time-varying VAR(1)",
+    "Time-varying VAR(p)",
+    # Other
+    "envelope correlation",
+    "phase-slope-index",
+]
+
+CAN_SYMMETRISE = {
+    "coh": _symmetrise_coh,
+    "cohy": _symmetrise_cohy,
+    "imcoh": _symmetrise_imcoh,
+    "cacoh": _symmetrise_coh,
+    "mic": _symmetrise_cohy,
+    "mim": _symmetrise_coh,
+    "SMI": _symmetrise_smi,
+    "wSMI": _symmetrise_smi,
+    "envelope correlation": _symmetrise_envelope_correlation,
+    "phase-slope-index": _symmetrise_phase_slope_index,
+    "plv": _symmetrise_plv,
+    "ciplv": _symmetrise_ciplv,
+    "ppc": _symmetrise_ppc,
+    "pli2_unbiased": _symmetrise_pli2_unbiased,
+    "dpli": _symmetrise_dpli,
+    "wpli": _symmetrise_wpli,
+    "wpli2_debiased": _symmetrise_wpli2_debiased,
+}
+
+
+def _symmetrise_connectivity(data, indices, n_nodes, method):
+    """"""
+    # Check if data is already full (no need to symmetrise)
+    if indices == "all":
+        return data.reshape((n_nodes, n_nodes, *data.shape[1:]))
+    if isinstance(indices, tuple):
+        full_indices = np.indices((n_nodes, n_nodes))
+        sorted_seeds = np.argsort(indices[0])
+        if not np.array_equal(
+            indices[0][sorted_seeds], full_indices[0].ravel()
+        ) or not np.array_equal(indices[1][sorted_seeds], full_indices[1].ravel()):
+            raise ValueError(
+                "Cannot symmetrise connectivity data when indices are specified as a "
+                "tuple that does not represent the full connectivity matrix."
+            )
+        return data.reshape((n_nodes, n_nodes, *data.shape[1:]))
+
+    # Check if we can symmetrise the connectivity data for the given method
+    if method not in CAN_SYMMETRISE:
+        raise ValueError(
+            f"Cannot symmetrise connectivity data for the method {method}."
+        )
+    data = _make_square(data, indices, n_nodes)
+    return CAN_SYMMETRISE[method](data, indices)
+
+
+def _make_square(data, indices, n_nodes):
+    """Make the connectivity data square [n_nodes, n_nodes(, ...)]."""
+    fill = 0.0
+    if np.iscomplexobj(data):
+        fill = fill + 1j * fill
+    square_matrix = np.full(
+        (n_nodes, n_nodes, *data.shape[1:]), fill_value=fill, dtype=data.dtype
+    )
+
+    if indices == "lower":
+        square_matrix[np.tril_indices(n_nodes, k=-1)] = data
+    else:  # "upper"
+        square_matrix[np.triu_indices(n_nodes, k=1)] = data
+
+    return square_matrix
+
+
+def _symmetrise_coh(data, indices):
+    """Symmetrise coherence data."""
+    data = data + data.transpose(1, 0, *range(2, data.ndim))
+    data[np.diag_indices(data.shape[0])] = 1.0
+    return data
+
+
+def _symmetrise_cohy(data, indices):
+    """Symmetrise coherency data."""
+    data = data + data.transpose(1, 0, *range(2, data.ndim))
+    data[np.diag_indices(data.shape[0])] = 1.0 + 1.0j
+    tril = np.tril_indices(data.shape[0], k=-1)
+    triu = np.triu_indices(data.shape[0], k=1)
+    if indices == "lower":
+        data[triu] = np.conj(data[tril])
+    else:  # "upper"
+        data[tril] = np.conj(data[triu])
+    return data
+
+
+def _symmetrise_imcoh(data, indices):
+    """Symmetrise imaginary part of coherency data."""
+    data = data + data.transpose(1, 0, *range(2, data.ndim))
+    data[np.diag_indices(data.shape[0])] = 0.0
+    tril = np.tril_indices(data.shape[0], k=-1)
+    triu = np.triu_indices(data.shape[0], k=1)
+    if indices == "lower":
+        data[triu] *= -1.0
+    else:  # "upper"
+        data[tril] *= -1.0
+    return data
+
+
+def _symmetrise_smi(data, indices):
+    """Symmetrise symbolic mutual information data."""
+    data = data + data.transpose(1, 0, *range(2, data.ndim))
+    data[np.diag_indices(data.shape[0])] = 0.0
+    return data
+
+
+def _symmetrise_envelope_correlation(data, indices):
+    """Symmetrise envelope correlation data."""
+    data = data + data.transpose(1, 0, *range(2, data.ndim))
+    data[np.diag_indices(data.shape[0])] = 1.0
+    return data
+
+
+CAN_SYMMETRISE = {
+    "coh": _symmetrise_coh,
+    "cohy": _symmetrise_cohy,
+    "imcoh": _symmetrise_imcoh,
+    "plv": _symmetrise_plv,
+    "ciplv": _symmetrise_ciplv,
+    "ppc": _symmetrise_ppc,
+    "pli2_unbiased": _symmetrise_pli2_unbiased,
+    "dpli": _symmetrise_dpli,
+    "wpli": _symmetrise_wpli,
+    "wpli2_debiased": _symmetrise_wpli2_debiased,
+    "SMI": _symmetrise_smi,
+    "wSMI": _symmetrise_smi,
+    "envelope correlation": _symmetrise_envelope_correlation,
+}

--- a/mne_connectivity/utils/transform_to_full.py
+++ b/mne_connectivity/utils/transform_to_full.py
@@ -17,7 +17,7 @@ def _get_full_connectivity(data, indices, n_nodes, method, missing):
     if isinstance(indices, tuple):
         indices = tuple(np.asarray(ind) for ind in indices)
         sorted_seeds = np.argsort(indices[0])
-        full_indices = np.indices((n_nodes, n_nodes))
+        full_indices = np.unravel_index(np.arange(n_nodes**2), (n_nodes, n_nodes))
         if not np.array_equal(
             indices[0][sorted_seeds], full_indices[0].ravel()
         ) or not np.array_equal(indices[1][sorted_seeds], full_indices[1].ravel()):
@@ -46,7 +46,7 @@ def _make_square(data, indices, n_nodes, fill=0.0):
     )
 
     if indices == "all":
-        indices = np.indices((n_nodes, n_nodes))
+        indices = np.unravel_index(np.arange(n_nodes**2), (n_nodes, n_nodes))
     elif indices == "lower":
         indices = np.tril_indices(n_nodes, k=-1)
     elif indices == "upper":

--- a/mne_connectivity/utils/transform_to_full.py
+++ b/mne_connectivity/utils/transform_to_full.py
@@ -116,5 +116,4 @@ _CAN_FILL_MISSING = {
     "phase-slope-index": _transpose_sign_flip_zero_diag,
     "SMI": _transpose_zero_diag,
     "wSMI": _transpose_zero_diag,
-    "envelope correlation": _transpose_one_diag,
 }

--- a/mne_connectivity/utils/transform_to_full.py
+++ b/mne_connectivity/utils/transform_to_full.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 import numpy as np
 
 
@@ -76,44 +78,19 @@ def _make_full(data, indices, diag, transpose_extra=None):
     return data
 
 
-def _transpose_zero_diag(data, indices):
-    """Fill missing values by transposing, with zeros on the diagonal."""
-    return _make_full(data, indices, diag=0.0)
-
-
-def _transpose_one_diag(data, indices):
-    """Fill missing values by transposing, with ones on the diagonal."""
-    return _make_full(data, indices, diag=1.0)
-
-
-def _transpose_conj_one_diag(data, indices):
-    """Fill missing values by transposing, with ones on the diagonal and conjugate."""
-    return _make_full(data, indices, diag=1.0 + 0.0j, transpose_extra=np.conj)
-
-
-def _transpose_sign_flip_zero_diag(data, indices):
-    """Fill missing values by transposing with sign flip, and zeros on the diagonal."""
-    return _make_full(data, indices, diag=0.0, transpose_extra=lambda x: -x)
-
-
-def _fill_dpli(data, indices):
-    """Fill missing directed phase lag index values."""
-    return _make_full(data, indices, diag=0.5, transpose_extra=lambda x: 1.0 - x)
-
-
 _CAN_FILL_MISSING = {
-    "coh": _transpose_one_diag,
-    "cohy": _transpose_conj_one_diag,
-    "imcoh": _transpose_sign_flip_zero_diag,
-    "plv": _transpose_one_diag,
-    "ciplv": _transpose_zero_diag,
-    "ppc": _transpose_one_diag,
-    "pli": _transpose_zero_diag,
-    "pli2_unbiased": _transpose_zero_diag,
-    "dpli": _fill_dpli,
-    "wpli": _transpose_zero_diag,
-    "wpli2_debiased": _transpose_zero_diag,
-    "phase-slope-index": _transpose_sign_flip_zero_diag,
-    "SMI": _transpose_zero_diag,
-    "wSMI": _transpose_zero_diag,
+    "coh": partial(_make_full, diag=1.0),
+    "cohy": partial(_make_full, diag=1.0 + 0.0j, transpose_extra=np.conj),
+    "imcoh": partial(_make_full, diag=0.0, transpose_extra=lambda x: -x),
+    "plv": partial(_make_full, diag=1.0),
+    "ciplv": partial(_make_full, diag=0.0),
+    "ppc": partial(_make_full, diag=1.0),
+    "pli": partial(_make_full, diag=0.0),
+    "pli2_unbiased": partial(_make_full, diag=0.0),
+    "dpli": partial(_make_full, diag=0.5, transpose_extra=lambda x: 1.0 - x),
+    "wpli": partial(_make_full, diag=0.0),
+    "wpli2_debiased": partial(_make_full, diag=0.0),
+    "phase-slope-index": partial(_make_full, diag=0.0, transpose_extra=lambda x: -x),
+    "SMI": partial(_make_full, diag=0.0),
+    "wSMI": partial(_make_full, diag=0.0),
 }

--- a/mne_connectivity/utils/transform_to_full.py
+++ b/mne_connectivity/utils/transform_to_full.py
@@ -78,6 +78,7 @@ def _make_full(data, indices, diag, transpose_extra=None):
     return data
 
 
+# TODO Env corr diagonal should be 0 when orthogonalized
 _CAN_FILL_MISSING = {
     "coh": partial(_make_full, diag=1.0),
     "cohy": partial(_make_full, diag=1.0 + 0.0j, transpose_extra=np.conj),
@@ -91,6 +92,7 @@ _CAN_FILL_MISSING = {
     "wpli": partial(_make_full, diag=0.0),
     "wpli2_debiased": partial(_make_full, diag=0.0),
     "phase-slope-index": partial(_make_full, diag=0.0, transpose_extra=lambda x: -x),
+    "envelope correlation": partial(_make_full, diag=1.0),
     "SMI": partial(_make_full, diag=0.0),
     "wSMI": partial(_make_full, diag=0.0),
 }

--- a/mne_connectivity/vector_ar/tests/test_var.py
+++ b/mne_connectivity/vector_ar/tests/test_var.py
@@ -417,8 +417,15 @@ def test_dynamic_mixin_errors():
     # Check components in the connectivity data get caught
     n_comps = 2
     mv_var_data = rng.standard_normal(size=(n_signals**2, n_comps))
+    indices = np.unravel_index(np.arange(n_signals**2), (n_signals, n_signals))
+    indices = ([[ind] for ind in indices[0]], [[ind] for ind in indices[1]])
     mv_var = Connectivity(
-        mv_var_data, n_nodes=n_signals, method="VAR(p)", lags=1, components=n_comps
+        mv_var_data,
+        n_nodes=n_signals,
+        method="VAR(p)",
+        indices=indices,
+        lags=1,
+        components=n_comps,
     )
     with pytest.raises(
         NotImplementedError,

--- a/mne_connectivity/vector_ar/var.py
+++ b/mne_connectivity/vector_ar/var.py
@@ -215,6 +215,7 @@ def vector_auto_regression(
                 times=list(range(lags)),
                 n_nodes=n_nodes,
                 names=names,
+                indices="all",
                 n_epochs_used=n_epochs,
                 times_used=times,
                 method="VAR(p)",
@@ -228,6 +229,7 @@ def vector_auto_regression(
                 data=coef[:, 0],  # take first and only lag
                 n_nodes=n_nodes,
                 names=names,
+                indices="all",
                 n_epochs_used=n_epochs,
                 times_used=times,
                 method="VAR(1)",
@@ -263,6 +265,7 @@ def vector_auto_regression(
                 times=list(range(lags)),
                 n_nodes=n_nodes,
                 names=names,
+                indices="all",
                 n_epochs_used=n_epochs,
                 times_used=times,
                 method="Time-varying VAR(p)",
@@ -276,6 +279,7 @@ def vector_auto_regression(
                 data=A_mats[..., 0],  # take first and only lag
                 n_nodes=n_nodes,
                 names=names,
+                indices="all",
                 n_epochs_used=n_epochs,
                 times_used=times,
                 method="Time-varying VAR(1)",

--- a/mne_connectivity/viz/_3d.py
+++ b/mne_connectivity/viz/_3d.py
@@ -65,7 +65,7 @@ def plot_sensors_connectivity(
     from mne_connectivity.base import BaseConnectivity
 
     if isinstance(con, BaseConnectivity):
-        con = con.get_data()
+        con = con.get_data("dense")
 
     renderer = _get_renderer(size=(600, 600), bgcolor=(0.5, 0.5, 0.5))
 

--- a/mne_connectivity/viz/__init__.py
+++ b/mne_connectivity/viz/__init__.py
@@ -2,3 +2,6 @@
 
 from ._3d import plot_sensors_connectivity
 from .circle import plot_connectivity_circle
+from .image import plot_spectrotemporal_connectivity
+from .line import plot_spectral_connectivity, plot_temporal_connectivity
+from .matrix import plot_connectivity

--- a/mne_connectivity/viz/helpers.py
+++ b/mne_connectivity/viz/helpers.py
@@ -23,52 +23,91 @@ def _check_data_is_real(data):
 def _handle_data_and_indices(con, ch_info):
     """Extract data and indices from connectivity object."""
     indices = con.indices
-    is_multivar = False
+    is_multivar = False  # Note: multivar connectivity is not supported for str indices
+    is_symmetric_tri = False  # matrix is symmetric and only lower/upper tri is stored
 
-    data = con.get_data("raveled")
-    if isinstance(indices, tuple):  # Explicit indices provided
+    # Explicit indices provided
+    if isinstance(indices, tuple):
+        data = con.get_data("raveled")
+        _check_if_nan(data)
         is_multivar = _check_if_multivariate_indices(indices)
         if not is_multivar:
             indices = (np.array(indices[0]), np.array(indices[1]))
         else:
-            # ragged multivariate indices can be stored as lists of arrays, but they
+            # Ragged multivariate indices can be stored as lists of arrays, but they
             # need to be arrays themselves so that connections can be picked
             indices = tuple(_ragged_to_array(idcs) for idcs in indices)
 
-    elif indices is None or indices == "all":  # All-to-all connectivity
-        # Construct explicit indices
-        # NOTE Cannot distinguish between bivariate and multivariate connectivity when
-        # indices is None or "all". Assume bivariate connectivity for now.
-        indices = np.tril_indices(con.n_nodes, -1)
-        square_shape = (con.n_nodes, con.n_nodes)
-        if data.ndim > 1:
-            square_shape += data.shape[1:]
-        data = data.reshape(*square_shape)[indices]
+        return data, indices, is_multivar, is_symmetric_tri
 
-        # Drop entries for bad channels from all-to-all data/indices
-        bad_idcs = []
-        if ch_info is not None:
-            bad_idcs = [con.names.index(bad) for bad in ch_info["bads"]]
-        if len(bad_idcs) > 0 and not is_multivar:
-            good_con_mask = np.ones(data.shape[0], dtype=bool)
-            for con_idx, (seed, target) in enumerate(zip(*indices)):
-                if seed in bad_idcs or target in bad_idcs:
-                    good_con_mask[con_idx] = False
-            data = data[good_con_mask]
-            indices = (indices[0][good_con_mask], indices[1][good_con_mask])
-        elif len(bad_idcs) > 0 and is_multivar:
-            indices = (
-                np.delete(indices[0][0], bad_idcs),
-                np.delete(indices[1][0], bad_idcs),
-            )
+    # Lower-tri, upper-tri, or all-to-all
+    try:  # Try to get dense data with missing values filled in
+        data = con.get_data("dense", missing="raise")
+        missing_filled = True
+    except ValueError:  # Fall back if missing can't be filled (for lower/upper)
+        data = con.get_data("dense", missing=np.nan)
+        missing_filled = False
+
+    if not missing_filled:
+        # Only take existing data if missing values can't be filled in
+        if indices == "lower":
+            indices = np.tril_indices(con.n_nodes, k=-1)
+        else:  # "upper"; can't be "all", since no missing values to (fail to) fill in
+            indices = np.triu_indices(con.n_nodes, k=1)
 
     else:
-        assert indices == "symmetric"
-        raise NotImplementedError("check how to handle symm indices")
+        # Check whether filled-in values make for symmetric matrix
+        symmetric = np.allclose(data, np.moveaxis(data, 0, 1), equal_nan=True)
+
+        # Check whether to ignore diagonal (if all values are the same)
+        if indices == "all":
+            # Check if diagonal is all close (could be all zeros, ones, NaNs)
+            diag = np.diagonal(data).ravel()
+            ignore_diag = bool(np.allclose(diag[1:], diag[0], equal_nan=True))
+        else:
+            ignore_diag = True  # diagonal trivial for filled-in lower/upper matrices
+
+        # Construct explicit indices
+        if symmetric:  # take only lower-/upper-tri values
+            is_symmetric_tri = True
+            if ignore_diag:
+                offset = 1 if indices == "upper" else -1  # "lower"
+            else:
+                offset = 0
+
+            if indices in ["lower", "all"]:  # take lower-tri for symmetric all-to-all
+                indices = np.tril_indices(con.n_nodes, k=offset)
+            else:  # "upper"
+                indices = np.triu_indices(con.n_nodes, k=offset)
+
+        else:  # take all values (maybe excluding irrelevant diagonal)
+            indices = np.unravel_index(
+                np.arange(con.n_nodes**2), (con.n_nodes, con.n_nodes)
+            )
+            if ignore_diag:
+                diag_indices = np.diag_indices(con.n_nodes)
+                diag_mask = np.ones(con.n_nodes**2, dtype=bool)
+                diag_mask[
+                    np.ravel_multi_index(diag_indices, (con.n_nodes, con.n_nodes))
+                ] = False
+                indices = (indices[0][diag_mask], indices[1][diag_mask])
+
+    # Drop entries for bad channels from data and indices
+    data = data[indices]
+    bad_idcs = []
+    if ch_info is not None:
+        bad_idcs = [con.names.index(bad) for bad in ch_info["bads"]]
+    if len(bad_idcs) > 0:
+        good_con_mask = np.ones(data.shape[0], dtype=bool)
+        for con_idx, (seed, target) in enumerate(zip(*indices)):
+            if seed in bad_idcs or target in bad_idcs:
+                good_con_mask[con_idx] = False
+        data = data[good_con_mask]
+        indices = (indices[0][good_con_mask], indices[1][good_con_mask])
 
     _check_if_nan(data)
 
-    return data, indices, is_multivar
+    return data, indices, is_multivar, is_symmetric_tri
 
 
 def _ragged_to_array(indices):

--- a/mne_connectivity/viz/helpers.py
+++ b/mne_connectivity/viz/helpers.py
@@ -1,0 +1,365 @@
+import mne
+import numpy as np
+from mne._fiff.pick import _picks_to_idx
+from mne.defaults import DEFAULTS
+from mne.stats.permutations import bootstrap_confidence_interval
+from mne.utils.check import _check_if_nan
+
+from ..utils import (
+    _check_if_multivariate_indices,
+    _get_unique_multivariate_nodes_and_indices,
+)
+
+
+def _check_data_is_real(data):
+    """Check that data is real-valued."""
+    if np.iscomplexobj(data):
+        raise ValueError(
+            "Plotting for complex-valued connectivity data is not supported. Consider "
+            "plotting the absolute values, or the real and imaginary parts separately."
+        )
+
+
+def _handle_data_and_indices(con, ch_info):
+    """Extract data and indices from connectivity object."""
+    indices = con.indices
+    is_multivar = False
+
+    data = con.get_data("raveled")
+    if isinstance(indices, tuple):  # Explicit indices provided
+        is_multivar = _check_if_multivariate_indices(indices)
+        if not is_multivar:
+            indices = (np.array(indices[0]), np.array(indices[1]))
+        else:
+            # ragged multivariate indices can be stored as lists of arrays, but they
+            # need to be arrays themselves so that connections can be picked
+            indices = tuple(_ragged_to_array(idcs) for idcs in indices)
+
+    elif indices is None or indices == "all":  # All-to-all connectivity
+        # Construct explicit indices
+        # NOTE Cannot distinguish between bivariate and multivariate connectivity when
+        # indices is None or "all". Assume bivariate connectivity for now.
+        indices = np.tril_indices(con.n_nodes, -1)
+        square_shape = (con.n_nodes, con.n_nodes)
+        if data.ndim > 1:
+            square_shape += data.shape[1:]
+        data = data.reshape(*square_shape)[indices]
+
+        # Drop entries for bad channels from all-to-all data/indices
+        bad_idcs = []
+        if ch_info is not None:
+            bad_idcs = [con.names.index(bad) for bad in ch_info["bads"]]
+        if len(bad_idcs) > 0 and not is_multivar:
+            good_con_mask = np.ones(data.shape[0], dtype=bool)
+            for con_idx, (seed, target) in enumerate(zip(*indices)):
+                if seed in bad_idcs or target in bad_idcs:
+                    good_con_mask[con_idx] = False
+            data = data[good_con_mask]
+            indices = (indices[0][good_con_mask], indices[1][good_con_mask])
+        elif len(bad_idcs) > 0 and is_multivar:
+            indices = (
+                np.delete(indices[0][0], bad_idcs),
+                np.delete(indices[1][0], bad_idcs),
+            )
+
+    else:
+        assert indices == "symmetric"
+        raise NotImplementedError("check how to handle symm indices")
+
+    _check_if_nan(data)
+
+    return data, indices, is_multivar
+
+
+def _ragged_to_array(indices):
+    """Convert (ragged) multivariate indices to an object array of channel sets."""
+    if isinstance(indices, np.ndarray):
+        return indices
+    array = np.empty(len(indices), dtype=object)
+    for idx, node in enumerate(indices):
+        array[idx] = node
+    return array
+
+
+def _check_info(info, ch_names):
+    """Check (or create) info object and ensure all channels are present."""
+    if info is None:
+        info = mne.create_info(ch_names=ch_names, sfreq=1.0, ch_types="misc")
+
+    # Make sure all channel names from con object found in info
+    missing_channels = [name for name in ch_names if name not in info["ch_names"]]
+    if len(missing_channels) != 0:
+        raise ValueError(
+            "Not all channel names from `con.names` found in `info`. Missing channels: "
+            f"{missing_channels}"
+        )
+
+    return info
+
+
+def _get_node_names_and_indices(ch_names, node_aliases, indices, is_multivar):
+    """Get/create names of seeds/targets in connections and their indices."""
+    if node_aliases is None:
+        node_aliases = dict()
+    # nodes are channel indices for bivariate and (ragged) channel sets for
+    # multivariate connectivity, so compare them as scalars and tuples, respectively
+    all_nodes = set()
+    for node in (*indices[0], *indices[1]):
+        if not is_multivar:
+            all_nodes.add(int(node))
+        elif isinstance(node, np.ma.MaskedArray):
+            all_nodes.add(tuple(node.compressed()))
+        else:
+            all_nodes.add(tuple(node))
+    if any(idx not in all_nodes for idx in node_aliases.keys()):
+        raise ValueError("All keys in `node_aliases` must be present in `con.indices`.")
+
+    # Get names of nodes (via aliases, directly, or create for multivar connections)
+    if not is_multivar:
+        unique_nodes = np.unique([*indices[0], *indices[1]]).tolist()
+        node_indices = (indices[0].copy(), indices[1].copy())  # use original indices
+        node_names = list(ch_names)  # copy, so that aliases don't rename `con.names`
+        for node_ind in unique_nodes:
+            if node_ind in node_aliases.keys():
+                node_names[node_ind] = node_aliases[node_ind]
+    else:
+        unique_nodes, node_indices = _get_unique_multivariate_nodes_and_indices(indices)
+        node_names = [f"node {node_idx}" for node_idx in range(len(unique_nodes))]
+        for node_idx, node_ind in enumerate(unique_nodes):
+            node_ind = tuple(node_ind)
+            if node_ind in node_aliases.keys():
+                node_names[node_idx] = node_aliases[node_ind]
+
+    return node_names, node_indices
+
+
+def _get_con_info(ch_info, node_names, indices, node_indices, is_multivar):
+    """Create info object for connectivity data."""
+    con_names = []
+    for seed, target in zip(*node_indices):
+        con_names.append(f"{node_names[seed]} ~ {node_names[target]}")
+
+    ch_types = ch_info.get_channel_types()
+    con_types = []
+    for seed, target in zip(*indices):
+        if not is_multivar:
+            seed_type = DEFAULTS["titles"][ch_types[seed]]
+            target_type = DEFAULTS["titles"][ch_types[target]]
+            con_types.append(f"{seed_type} ~ {target_type}")
+        else:
+            if isinstance(seed, np.ma.MaskedArray):
+                seed = seed.compressed()
+            if isinstance(target, np.ma.MaskedArray):
+                target = target.compressed()
+            seed_types = np.unique(
+                [DEFAULTS["titles"][ch_types[ch_idx]] for ch_idx in seed]
+            )
+            target_types = np.unique(
+                [DEFAULTS["titles"][ch_types[ch_idx]] for ch_idx in target]
+            )
+            con_types.append(f"{', '.join(seed_types)} ~ {', '.join(target_types)}")
+
+    con_info = mne.create_info(ch_names=con_names, sfreq=1.0, ch_types="misc")
+    # Can't store connectivity types in ch_types as they are not recognised
+    con_info["temp"] = dict()
+    con_info["temp"]["con_types"] = np.array(con_types)
+
+    return con_info
+
+
+def _handle_picks(picks, exclude, ch_info, indices, is_multivar, selection):
+    """Handle picks for connectivity data."""
+    ch_picks = _picks_to_idx(info=ch_info, picks=picks, none="all", exclude=exclude)
+    con_picks = []
+    for con_idx, (seed, target) in enumerate(zip(*indices)):
+        if not is_multivar:
+            seed, target = [seed], [target]
+        if selection == "both" or picks is None:
+            con_nodes = np.concatenate([seed, target])
+        elif selection == "seeds":
+            con_nodes = seed
+        else:  # selection == "targets"
+            con_nodes = target
+        if np.any([ch in ch_picks for ch in con_nodes]):
+            con_picks.append(con_idx)
+
+    return con_picks
+
+
+def _add_comps_as_connections(data, con_info, node_indices, comps_axis):
+    """Add multivariate components as additional connections."""
+    n_comps = data.shape[comps_axis]
+    new_shape = (data.shape[0] * n_comps,)
+    if comps_axis + 1 < data.ndim:
+        new_shape += data.shape[comps_axis + 1 :]
+    data = np.reshape(data, new_shape)
+    node_indices = (
+        np.repeat(node_indices[0], n_comps),
+        np.repeat(node_indices[1], n_comps),
+    )
+
+    new_con_names = []
+    for con_name in con_info["ch_names"]:
+        new_con_names.extend([f"{con_name} ({comp})" for comp in range(n_comps)])
+    new_con_types = np.repeat(con_info["temp"]["con_types"], n_comps)
+
+    with con_info._unlock():
+        con_info["ch_names"] = new_con_names
+    con_info["temp"]["con_types"] = new_con_types
+
+    return data, con_info, node_indices, n_comps
+
+
+def _combine_connections(data, combine, ci, n_comps=1):
+    """Combine data over connections."""
+    assert data.shape[0] % n_comps == 0, (
+        "Data to combine does not have a matching number of connections for each "
+        "component. Please contact the MNE-Connectivity developers."
+    )
+    n_cons = data.shape[0] // n_comps
+
+    if combine == "mean":
+        combine_func = lambda x: np.mean(x, axis=0)  # noqa: E731
+    else:
+        assert callable(combine), (
+            "The `combine` parameter is not callable as expected. "
+            "Please contact the MNE-Connectivity developers."
+        )
+        combine_func = combine
+
+    if ci is None:
+        ci_func = None
+    elif ci == "sd":
+        ci_func = lambda x: np.std(x, axis=0)  # noqa: E731
+    elif ci == "range":
+        ci_func = lambda x: (np.min(x, axis=0), np.max(x, axis=0))  # noqa: E731
+    else:
+        assert isinstance(ci, int | float), (
+            "The `ci` parameter is not a float as expected. "
+            "Please contact the MNE-Connectivity developers."
+        )
+        ci_func = lambda x: tuple(  # noqa: E731
+            bootstrap_confidence_interval(arr=x, ci=ci / 100, stat_fun=combine_func)
+        )
+
+    data_combined = np.empty((n_comps, *data.shape[1:]), dtype=data.dtype)
+    data_ci = None
+    if ci_func is not None:
+        data_ci = np.empty(data_combined.shape + (2,), dtype=data.dtype)
+    for comp_idx in range(n_comps):
+        data_combined[comp_idx] = combine_func(
+            data[n_cons * comp_idx : n_cons * (comp_idx + 1)]
+        )
+        if ci_func is not None:
+            ci_out = ci_func(data[n_cons * comp_idx : n_cons * (comp_idx + 1)])
+            if isinstance(ci_out, tuple):
+                assert len(ci_out) == 2, (
+                    f"Expected `len(ci_out)` of 2, got {len(ci_out)}. "
+                    "Please contact the MNE-Connectivity developers."
+                )
+                data_ci[comp_idx, ..., 0] = ci_out[0]
+                data_ci[comp_idx, ..., 1] = ci_out[1]
+            else:
+                data_ci[comp_idx, ..., 0] = data_combined[comp_idx] - ci_out
+                data_ci[comp_idx, ..., 1] = data_combined[comp_idx] + ci_out
+
+    if n_comps == 1:
+        con_names = np.array([f"combined nodes (n={n_cons})"])
+        node_names = con_names.copy()
+        node_indices = (np.array([0]), np.array([0]))
+    else:
+        con_names = np.array(
+            [f"combined nodes ({comp_idx}; n={n_cons})" for comp_idx in range(n_comps)]
+        )
+        node_names = con_names.copy()
+        node_indices = (np.arange(n_comps), np.arange(n_comps))
+
+    return data_combined, data_ci, con_names, node_names, node_indices
+
+
+def _setup_vmin_vmax(data, vmin, vmax):
+    """Handle vmin and vmax parameters for visualizing connectivity.
+
+    For the normal use-case (when `vmin` and `vmax` are None):
+    - vlim is set to (-abs(max), abs(max)) when data has both pos and neg values.
+    - vlim is set to (min, max) when data is exclusively pos or neg values.
+
+    Otherwise, vmin and vmax are callables/pre-specified values that drive the
+    operation.
+    """
+    data = data[~np.isnan(data)]
+
+    if vmax is None and vmin is None:
+        if ~np.all(data >= 0) and ~np.all(data <= 0):
+            vmax = np.abs(data).max()
+            vmin = -vmax
+        else:
+            vmin, vmax = data.min(), data.max()
+
+    else:
+        if callable(vmin):
+            vmin = vmin(data)
+        elif vmin is None:
+            vmin = np.min(data)
+
+        if callable(vmax):
+            vmax = vmax(data)
+        elif vmax is None:
+            vmax = np.max(data)
+
+    return vmin, vmax
+
+
+def _setup_cmap(cmap, vmin, vmax):
+    """Handle colormap for visualizing connectivity."""
+    if isinstance(cmap, tuple):
+        return cmap
+
+    if cmap is None:
+        if vmin >= 0 and vmax >= 0:
+            return "Reds"
+        if vmin < 0 and vmax < 0:
+            return "Blues_r"
+        return "RdBu_r"
+
+    return cmap
+
+
+def _butterfly_onpick(event, params):
+    """Add a channel name on click."""
+    params["need_draw"] = True
+    ax = event.artist.axes
+    ax_idx = np.where([ax is a for a in params["axes"]])[0]
+    if len(ax_idx) == 0:  # this can happen if ax param is used
+        return  # let the other axes handle it
+    else:
+        ax_idx = ax_idx[0]
+    lidx = np.where([line is event.artist for line in params["lines"][ax_idx]])[0][0]
+    ch_name = params["ch_names"][params["idxs"][ax_idx][lidx]]
+    text = params["texts"][ax_idx]
+    x = event.artist.get_xdata()[event.ind[0]]
+    y = event.artist.get_ydata()[event.ind[0]]
+    text.set_x(x)
+    text.set_y(y)
+    text.set_text(ch_name)
+    text.set_color(event.artist.get_color())
+    text.set_alpha(1.0)
+    text.set_zorder(len(ax.lines))  # to make sure it goes on top of the lines
+    text.set_path_effects(params["path_effects"])
+    # do NOT redraw here, since for butterfly plots hundreds of lines could
+    # potentially be picked -- use on_button_press (happens once per click)
+    # to do the drawing
+
+
+def _butterfly_on_button_press(event, params):
+    """Only draw once for picking."""
+    if params["need_draw"]:
+        event.canvas.draw()
+    else:
+        idx = np.where([event.inaxes is ax for ax in params["axes"]])[0]
+        if len(idx) == 1:
+            text = params["texts"][idx[0]]
+            text.set_alpha(0.0)
+            text.set_path_effects([])
+            event.canvas.draw()
+    params["need_draw"] = False

--- a/mne_connectivity/viz/helpers.py
+++ b/mne_connectivity/viz/helpers.py
@@ -207,12 +207,14 @@ def _handle_picks(picks, exclude, ch_info, indices, is_multivar, selection):
     for con_idx, (seed, target) in enumerate(zip(*indices)):
         if not is_multivar:
             seed, target = [seed], [target]
-        if selection == "both" or picks is None:
+        if selection == "both":
             con_nodes = np.concatenate([seed, target])
         elif selection == "seeds":
             con_nodes = seed
         else:  # selection == "targets"
             con_nodes = target
+        if picks is not None:
+            con_nodes = [node for node in con_nodes if node in ch_picks]
         if np.any([ch in ch_picks for ch in con_nodes]):
             con_picks.append(con_idx)
 

--- a/mne_connectivity/viz/helpers.py
+++ b/mne_connectivity/viz/helpers.py
@@ -57,7 +57,9 @@ def _handle_data_and_indices(con, ch_info):
             indices = np.triu_indices(con.n_nodes, k=1)
     else:
         # Check whether to ignore diagonal (if all values are the same)
-        if indices == "all":
+        if con.n_nodes == 1:
+            ignore_diag = False  # excluding diagonal would remove the only connection
+        elif indices == "all":
             # Check if diagonal is all close (could be all zeros, ones, NaNs)
             diag = np.diagonal(data).ravel()
             ignore_diag = bool(np.allclose(diag[1:], diag[0], equal_nan=True))

--- a/mne_connectivity/viz/helpers.py
+++ b/mne_connectivity/viz/helpers.py
@@ -25,7 +25,7 @@ def _handle_data_and_indices(con, ch_info):
     indices = con.indices
     is_multivar = False  # note: multivar connectivity is not supported for str indices
     is_symmetric = False  # whether returned data is tril/triu symmetric
-    has_diagonal = False  # whether returned data has diagonal entries
+    duplicate_cons_mask = None  # mask for duplicate connections in symmetric data
 
     # Explicit indices provided
     if isinstance(indices, tuple):
@@ -38,8 +38,9 @@ def _handle_data_and_indices(con, ch_info):
             # Ragged multivariate indices can be stored as lists of arrays, but they
             # need to be arrays themselves so that connections can be picked
             indices = tuple(_ragged_to_array(idcs) for idcs in indices)
+        duplicate_cons_mask = np.full(len(indices[0]), False, dtype=bool)
 
-        return data, indices, is_multivar, is_symmetric, has_diagonal
+        return data, indices, is_multivar, is_symmetric, duplicate_cons_mask
 
     # Lower-tri, upper-tri, or all-to-all
     try:  # Try to get dense data with missing values filled in
@@ -70,21 +71,22 @@ def _handle_data_and_indices(con, ch_info):
             data, data.transpose(1, 0, *range(2, data.ndim)), equal_nan=True
         )
         # Construct explicit indices
-        if is_symmetric:
-            # Only use indices for unique connections
-            if indices in ["lower", "all"]:
-                indices = np.tril_indices(con.n_nodes, k=0)
-            else:
-                indices = np.triu_indices(con.n_nodes, k=0)
-        else:
-            indices = np.unravel_index(
-                np.arange(con.n_nodes**2), (con.n_nodes, con.n_nodes)
-            )
+        indices = np.unravel_index(
+            np.arange(con.n_nodes**2), (con.n_nodes, con.n_nodes)
+        )
         if ignore_diag:
             diag_mask = indices[0] == indices[1]
             indices = (indices[0][~diag_mask], indices[1][~diag_mask])
-        else:
-            has_diagonal = True
+        if is_symmetric:
+            if con.indices in ["lower", "all"]:
+                keep_indices = np.tril_indices(con.n_nodes, k=0)
+            else:
+                keep_indices = np.triu_indices(con.n_nodes, k=0)
+            duplicate_cons_mask = np.array(
+                [ind not in list(zip(*keep_indices)) for ind in list(zip(*indices))]
+            )
+    if duplicate_cons_mask is None:
+        duplicate_cons_mask = np.full(len(indices[0]), False, dtype=bool)
 
     # Drop entries for bad channels from data and indices
     data = data[indices]
@@ -98,10 +100,11 @@ def _handle_data_and_indices(con, ch_info):
                 good_con_mask[con_idx] = False
         data = data[good_con_mask]
         indices = (indices[0][good_con_mask], indices[1][good_con_mask])
+        duplicate_cons_mask = duplicate_cons_mask[good_con_mask]
 
     _check_if_nan(data)
 
-    return data, indices, is_multivar, is_symmetric, has_diagonal
+    return data, indices, is_multivar, is_symmetric, duplicate_cons_mask
 
 
 def _ragged_to_array(indices):

--- a/mne_connectivity/viz/helpers.py
+++ b/mne_connectivity/viz/helpers.py
@@ -23,8 +23,10 @@ def _check_data_is_real(data):
 def _handle_data_and_indices(con, ch_info):
     """Extract data and indices from connectivity object."""
     indices = con.indices
-    is_multivar = False  # Note: multivar connectivity is not supported for str indices
-    is_symmetric_tri = False  # matrix is symmetric and only lower/upper tri is stored
+    is_multivar = False  # note: multivar connectivity is not supported for str indices
+    is_full = False  # whether returned data is a full matrix (w/ or w/out diagonal)
+    is_symmetric = False  # whether returned data is tril/triu symmetric
+    has_diagonal = False  # whether returned data has diagonal entries
 
     # Explicit indices provided
     if isinstance(indices, tuple):
@@ -38,7 +40,7 @@ def _handle_data_and_indices(con, ch_info):
             # need to be arrays themselves so that connections can be picked
             indices = tuple(_ragged_to_array(idcs) for idcs in indices)
 
-        return data, indices, is_multivar, is_symmetric_tri
+        return data, indices, is_multivar, is_full, is_symmetric, has_diagonal
 
     # Lower-tri, upper-tri, or all-to-all
     try:  # Try to get dense data with missing values filled in
@@ -54,11 +56,8 @@ def _handle_data_and_indices(con, ch_info):
             indices = np.tril_indices(con.n_nodes, k=-1)
         else:  # "upper"; can't be "all", since no missing values to (fail to) fill in
             indices = np.triu_indices(con.n_nodes, k=1)
-
     else:
-        # Check whether filled-in values make for symmetric matrix
-        symmetric = np.allclose(data, np.moveaxis(data, 0, 1), equal_nan=True)
-
+        is_full = True
         # Check whether to ignore diagonal (if all values are the same)
         if indices == "all":
             # Check if diagonal is all close (could be all zeros, ones, NaNs)
@@ -66,31 +65,26 @@ def _handle_data_and_indices(con, ch_info):
             ignore_diag = bool(np.allclose(diag[1:], diag[0], equal_nan=True))
         else:
             ignore_diag = True  # diagonal trivial for filled-in lower/upper matrices
-
+        # Check whether the matrix is symmetric
+        is_symmetric = np.allclose(
+            data, data.transpose(1, 0, *range(2, data.ndim)), equal_nan=True
+        )
         # Construct explicit indices
-        if symmetric:  # take only lower-/upper-tri values
-            is_symmetric_tri = True
-            if ignore_diag:
-                offset = 1 if indices == "upper" else -1  # "lower"
+        if is_symmetric:
+            # Only use indices for unique connections
+            if indices in ["lower", "all"]:
+                indices = np.tril_indices(con.n_nodes, k=0)
             else:
-                offset = 0
-
-            if indices in ["lower", "all"]:  # take lower-tri for symmetric all-to-all
-                indices = np.tril_indices(con.n_nodes, k=offset)
-            else:  # "upper"
-                indices = np.triu_indices(con.n_nodes, k=offset)
-
-        else:  # take all values (maybe excluding irrelevant diagonal)
+                indices = np.triu_indices(con.n_nodes, k=0)
+        else:
             indices = np.unravel_index(
                 np.arange(con.n_nodes**2), (con.n_nodes, con.n_nodes)
             )
-            if ignore_diag:
-                diag_indices = np.diag_indices(con.n_nodes)
-                diag_mask = np.ones(con.n_nodes**2, dtype=bool)
-                diag_mask[
-                    np.ravel_multi_index(diag_indices, (con.n_nodes, con.n_nodes))
-                ] = False
-                indices = (indices[0][diag_mask], indices[1][diag_mask])
+        if ignore_diag:
+            diag_mask = indices[0] == indices[1]
+            indices = (indices[0][~diag_mask], indices[1][~diag_mask])
+        else:
+            has_diagonal = True
 
     # Drop entries for bad channels from data and indices
     data = data[indices]
@@ -107,7 +101,7 @@ def _handle_data_and_indices(con, ch_info):
 
     _check_if_nan(data)
 
-    return data, indices, is_multivar, is_symmetric_tri
+    return data, indices, is_multivar, is_full, is_symmetric, has_diagonal
 
 
 def _ragged_to_array(indices):
@@ -175,6 +169,8 @@ def _get_node_names_and_indices(ch_names, node_aliases, indices, is_multivar):
 def _get_con_info(ch_info, node_names, indices, node_indices, is_multivar):
     """Create info object for connectivity data."""
     con_names = []
+    for node_idx, name in enumerate(node_names):
+        node_names[node_idx] = name.replace("~", "-")  # avoid confusion with con names
     for seed, target in zip(*node_indices):
         con_names.append(f"{node_names[seed]} ~ {node_names[target]}")
 

--- a/mne_connectivity/viz/helpers.py
+++ b/mne_connectivity/viz/helpers.py
@@ -24,7 +24,6 @@ def _handle_data_and_indices(con, ch_info):
     """Extract data and indices from connectivity object."""
     indices = con.indices
     is_multivar = False  # note: multivar connectivity is not supported for str indices
-    is_full = False  # whether returned data is a full matrix (w/ or w/out diagonal)
     is_symmetric = False  # whether returned data is tril/triu symmetric
     has_diagonal = False  # whether returned data has diagonal entries
 
@@ -40,7 +39,7 @@ def _handle_data_and_indices(con, ch_info):
             # need to be arrays themselves so that connections can be picked
             indices = tuple(_ragged_to_array(idcs) for idcs in indices)
 
-        return data, indices, is_multivar, is_full, is_symmetric, has_diagonal
+        return data, indices, is_multivar, is_symmetric, has_diagonal
 
     # Lower-tri, upper-tri, or all-to-all
     try:  # Try to get dense data with missing values filled in
@@ -57,7 +56,6 @@ def _handle_data_and_indices(con, ch_info):
         else:  # "upper"; can't be "all", since no missing values to (fail to) fill in
             indices = np.triu_indices(con.n_nodes, k=1)
     else:
-        is_full = True
         # Check whether to ignore diagonal (if all values are the same)
         if indices == "all":
             # Check if diagonal is all close (could be all zeros, ones, NaNs)
@@ -101,7 +99,7 @@ def _handle_data_and_indices(con, ch_info):
 
     _check_if_nan(data)
 
-    return data, indices, is_multivar, is_full, is_symmetric, has_diagonal
+    return data, indices, is_multivar, is_symmetric, has_diagonal
 
 
 def _ragged_to_array(indices):

--- a/mne_connectivity/viz/image.py
+++ b/mne_connectivity/viz/image.py
@@ -1,0 +1,284 @@
+from collections.abc import Callable
+
+import mne
+import numpy as np
+from matplotlib import pyplot as plt
+from mne._fiff.pick import pick_info
+from mne.utils.check import _check_option, _validate_type
+from mne.utils.numerics import _time_mask
+from mne.viz.utils import _plot_masked_image, plt_show
+
+from ..utils import fill_doc
+from .helpers import (
+    _add_comps_as_connections,
+    _check_data_is_real,
+    _check_info,
+    _combine_connections,
+    _get_con_info,
+    _get_node_names_and_indices,
+    _handle_data_and_indices,
+    _handle_picks,
+    _setup_cmap,
+    _setup_vmin_vmax,
+)
+
+
+@fill_doc
+def plot_spectrotemporal_connectivity(
+    con,
+    *,
+    info=None,
+    picks=None,
+    selection="both",
+    exclude="bads",
+    combine="mean",
+    node_aliases=None,
+    tmin=None,
+    tmax=None,
+    fmin=None,
+    fmax=None,
+    yscale="auto",
+    vmin=None,
+    vmax=None,
+    cnorm=None,
+    cmap=None,
+    colorbar=True,
+    mask=None,
+    mask_style=None,
+    mask_cmap="Greys",
+    mask_alpha=0.1,
+    show=True,
+):
+    """Plot spectro-temporal connectivity.
+
+    Parameters
+    ----------
+    con : ~mne_connectivity.SpectroTemporalConnectivity
+        The spectro-temporal connectivity object to plot.
+    %(viz_info)s
+    %(viz_picks)s
+    %(viz_selection)s
+    %(viz_exclude)s
+    %(viz_combine_image_spectrotemporal)s
+    %(viz_node_aliases)s
+    %(viz_tmin_tmax)s
+    %(viz_fmin_fmax)s
+    %(viz_yscale_image)s
+    %(viz_vmin_vmax)s
+    %(viz_cnorm)s
+    %(viz_cmap)s
+    %(viz_cbar)s
+    %(viz_mask)s
+    %(viz_mask_style)s
+    %(viz_mask_cmap)s
+    %(viz_mask_alpha)s
+    %(viz_show)s
+
+    Returns
+    -------
+    %(viz_figures)s
+
+    Notes
+    -----
+    %(viz_components_note)s
+    """
+    from mne_connectivity import SpectroTemporalConnectivity
+
+    _validate_type(
+        con, SpectroTemporalConnectivity, "con", "SpectroTemporalConnectivity"
+    )
+
+    return _plot_image_connectivity(
+        con=con,
+        picks=picks,
+        selection=selection,
+        exclude=exclude,
+        info=info,
+        combine=combine,
+        node_aliases=node_aliases,
+        xlim=(tmin, tmax),
+        ylim=(fmin, fmax),
+        xvar=con.times,
+        yvar=con.freqs,
+        xlabel="Time (s)",
+        ylabel="Frequency (Hz)",
+        yscale=yscale,
+        vmin=vmin,
+        vmax=vmax,
+        cnorm=cnorm,
+        cmap=cmap,
+        colorbar=colorbar,
+        mask=mask,
+        mask_style=mask_style,
+        mask_cmap=mask_cmap,
+        mask_alpha=mask_alpha,
+        show=show,
+    )
+
+
+def _plot_image_connectivity(
+    con,
+    picks,
+    selection,
+    exclude,
+    info,
+    combine,
+    node_aliases,
+    xlim,
+    ylim,
+    xvar,
+    xlabel,
+    yvar,
+    ylabel,
+    yscale,
+    vmin,
+    vmax,
+    cnorm,
+    cmap,
+    colorbar,
+    mask,
+    mask_style,
+    mask_cmap,
+    mask_alpha,
+    show,
+):
+    """Plot connectivity as image plots.
+
+    Connectivity has dims [connections, x, y], where x and y are epochs, frequencies, or
+    times.
+    """
+    _check_data_is_real(con.get_data())
+
+    _check_option("con.shape", len(con.shape), [3, 4], " length")
+
+    _check_option("selection", selection, ["both", "seeds", "targets"])
+
+    _validate_type(info, (mne.Info, None), "`info`", "mne.Info or None")
+
+    _validate_type(combine, (str, Callable, None), "`combine`")
+    if isinstance(combine, str):
+        _check_option("combine", combine, ["mean"], " as a string")
+
+    _validate_type(node_aliases, (dict, None), "`node_aliases`", "dict or None")
+
+    _check_option("xlim", len(xlim), [2], " length")
+    _check_option("ylim", len(ylim), [2], " length")
+
+    _check_option("yscale", yscale, ["linear", "log", "auto"])
+
+    _validate_type(mask, (np.ndarray, None), "`mask`", "numpy.ndarray or None")
+
+    _validate_type(colorbar, bool, "`colorbar`", "bool")
+
+    _validate_type(show, bool, "`show`", "bool")
+
+    ch_names = con.names
+    con_method = con.method if con.method is not None else "connectivity"
+    ch_info = _check_info(info, ch_names)
+    data, indices, is_multivar = _handle_data_and_indices(con, ch_info)
+
+    # Get info about nodes and connections
+    node_names, node_indices = _get_node_names_and_indices(
+        ch_names, node_aliases, indices, is_multivar
+    )
+    con_info = _get_con_info(ch_info, node_names, indices, node_indices, is_multivar)
+
+    # Get requested connections
+    picks = _handle_picks(picks, exclude, ch_info, indices, is_multivar, selection)
+    data = data[picks]
+    indices = (indices[0][picks], indices[1][picks])
+    node_indices = (node_indices[0][picks], node_indices[1][picks])
+    con_info = pick_info(con_info, picks)
+    con_info["temp"]["con_types"] = con_info["temp"]["con_types"][picks]
+
+    # Add multivariate components as additional connections
+    n_comps = 1
+    if data.ndim == 4:
+        data, con_info, node_indices, n_comps = _add_comps_as_connections(
+            data, con_info, node_indices, comps_axis=1
+        )
+
+    if mask is not None and mask.shape != data.shape[1:]:
+        raise ValueError(
+            f"Mask shape {mask.shape} does not match data shape {data.shape[1:]}."
+        )
+
+    # Mask data to relevant x and y values
+    xvar, yvar = np.asarray(xvar), np.asarray(yvar)
+    xvar_mask = np.nonzero(
+        _time_mask(
+            times=xvar, tmin=xlim[0], tmax=xlim[1], sfreq=None, include_tmax=True
+        )
+    )[0]
+    yvar_mask = np.nonzero(
+        _time_mask(
+            times=yvar, tmin=ylim[0], tmax=ylim[1], sfreq=None, include_tmax=True
+        )
+    )[0]
+    data = data[..., yvar_mask, :][..., xvar_mask]
+    if mask is not None:
+        mask = mask[yvar_mask, :][:, xvar_mask]
+
+    con_types = con_info["temp"]["con_types"]
+    figs = []
+    axes = []
+    for con_type in np.unique(con_types):
+        # Prepare connectivity info for plotting
+        type_mask = con_types == con_type
+        type_data = data[type_mask]
+        type_con_names = np.array(con_info["ch_names"])[type_mask]
+
+        # Combine connectivity across connections
+        if combine is not None:
+            (
+                type_data,
+                _,
+                type_con_names,
+                _,
+                _,
+            ) = _combine_connections(
+                data=type_data, combine=combine, ci=None, n_comps=n_comps
+            )
+
+        # Colormap handling
+        vmin, vmax = _setup_vmin_vmax(data=type_data, vmin=vmin, vmax=vmax)
+        cmap = _setup_cmap(cmap=cmap, vmin=vmin, vmax=vmax)
+
+        # Plot connectivity as image
+        type_figs = [
+            plt.figure(layout="constrained") for _ in range(type_data.shape[0])
+        ]
+        type_axes = [fig.add_subplot() for fig in type_figs]
+        for con_idx in range(type_data.shape[0]):
+            con_ax = type_axes[con_idx]
+            img, _ = _plot_masked_image(
+                ax=con_ax,
+                data=type_data[con_idx],
+                times=xvar[xvar_mask],
+                mask=mask,
+                yvals=yvar[yvar_mask],
+                cmap=cmap,
+                vmin=vmin,
+                vmax=vmax,
+                mask_style=mask_style,
+                mask_alpha=mask_alpha,
+                mask_cmap=mask_cmap,
+                yscale=yscale,
+                cnorm=cnorm,
+            )
+            con_ax.set_xlabel(xlabel)
+            con_ax.set_ylabel(ylabel)
+            if colorbar:
+                con_ax.get_figure().colorbar(
+                    mappable=img, ax=type_axes[con_idx], label="Connectivity (A.U.)"
+                )
+            con_ax.set_title(f"{con_type} | {type_con_names[con_idx]} | {con_method}")
+
+        figs.extend(type_figs)
+        axes.extend(type_axes)
+
+    plt_show(show)
+
+    if len(figs) == 1:
+        return figs[0], axes[0]
+    return figs, axes

--- a/mne_connectivity/viz/image.py
+++ b/mne_connectivity/viz/image.py
@@ -76,11 +76,11 @@ def plot_spectrotemporal_connectivity(
 
     Returns
     -------
-    %(viz_figures)s
+    %(viz_figure_image)s
 
     Notes
     -----
-    %(viz_components_note)s
+    %(viz_components_extra_con_note)s
     """
     from mne_connectivity import SpectroTemporalConnectivity
 

--- a/mne_connectivity/viz/image.py
+++ b/mne_connectivity/viz/image.py
@@ -88,7 +88,7 @@ def plot_spectrotemporal_connectivity(
         con, SpectroTemporalConnectivity, "con", "SpectroTemporalConnectivity"
     )
 
-    _check_data_is_real(con.get_data())
+    _check_data_is_real(con.get_data("raveled"))
 
     _check_option("con.shape", len(con.shape), [3, 4], " length")
 
@@ -113,7 +113,7 @@ def plot_spectrotemporal_connectivity(
     ch_names = con.names
     con_method = con.method if con.method is not None else "connectivity"
     ch_info = _check_info(info, ch_names)
-    data, indices, is_multivar = _handle_data_and_indices(con, ch_info)
+    data, indices, is_multivar, is_symmetric, _ = _handle_data_and_indices(con, ch_info)
 
     # Get info about nodes and connections
     node_names, node_indices = _get_node_names_and_indices(
@@ -160,6 +160,7 @@ def plot_spectrotemporal_connectivity(
         type_mask = con_types == con_type
         type_data = data[type_mask]
         type_con_names = np.array(con_info["ch_names"])[type_mask]
+        type_node_indices = tuple(idcs[type_mask] for idcs in node_indices)
 
         # Combine connectivity across connections
         if combine is not None:
@@ -176,6 +177,19 @@ def plot_spectrotemporal_connectivity(
         # Colormap handling
         vmin, vmax = _setup_vmin_vmax(data=type_data, vmin=vmin, vmax=vmax)
         cmap = _setup_cmap(cmap=cmap, vmin=vmin, vmax=vmax)
+
+        # Duplicate symmetric all-to-all connectivity
+        if is_symmetric and con.indices == "all" and combine is None:
+            # Find self-connections (do not duplicate)
+            diag_mask = type_node_indices[0] == type_node_indices[1]
+            # Duplicate connection data
+            type_data = np.concatenate([type_data, type_data[~diag_mask]], axis=0)
+            # Duplicate and flip seeds and targets in connections names
+            reverse_con_names = [
+                " ~ ".join(name.split(" ~ ")[::-1])
+                for name in type_con_names[~diag_mask]
+            ]
+            type_con_names = np.concatenate([type_con_names, reverse_con_names], axis=0)
 
         # Plot connectivity as image
         type_figs = [

--- a/mne_connectivity/viz/image.py
+++ b/mne_connectivity/viz/image.py
@@ -221,7 +221,6 @@ def _plot_image_connectivity(
 
     con_types = con_info["temp"]["con_types"]
     figs = []
-    axes = []
     for con_type in np.unique(con_types):
         # Prepare connectivity info for plotting
         type_mask = con_types == con_type
@@ -275,10 +274,9 @@ def _plot_image_connectivity(
             con_ax.set_title(f"{con_type} | {type_con_names[con_idx]} | {con_method}")
 
         figs.extend(type_figs)
-        axes.extend(type_axes)
 
     plt_show(show)
 
     if len(figs) == 1:
-        return figs[0], axes[0]
-    return figs, axes
+        return figs[0]
+    return figs

--- a/mne_connectivity/viz/image.py
+++ b/mne_connectivity/viz/image.py
@@ -88,65 +88,6 @@ def plot_spectrotemporal_connectivity(
         con, SpectroTemporalConnectivity, "con", "SpectroTemporalConnectivity"
     )
 
-    return _plot_image_connectivity(
-        con=con,
-        picks=picks,
-        selection=selection,
-        exclude=exclude,
-        info=info,
-        combine=combine,
-        node_aliases=node_aliases,
-        xlim=(tmin, tmax),
-        ylim=(fmin, fmax),
-        xvar=con.times,
-        yvar=con.freqs,
-        xlabel="Time (s)",
-        ylabel="Frequency (Hz)",
-        yscale=yscale,
-        vmin=vmin,
-        vmax=vmax,
-        cnorm=cnorm,
-        cmap=cmap,
-        colorbar=colorbar,
-        mask=mask,
-        mask_style=mask_style,
-        mask_cmap=mask_cmap,
-        mask_alpha=mask_alpha,
-        show=show,
-    )
-
-
-def _plot_image_connectivity(
-    con,
-    picks,
-    selection,
-    exclude,
-    info,
-    combine,
-    node_aliases,
-    xlim,
-    ylim,
-    xvar,
-    xlabel,
-    yvar,
-    ylabel,
-    yscale,
-    vmin,
-    vmax,
-    cnorm,
-    cmap,
-    colorbar,
-    mask,
-    mask_style,
-    mask_cmap,
-    mask_alpha,
-    show,
-):
-    """Plot connectivity as image plots.
-
-    Connectivity has dims [connections, x, y], where x and y are epochs, frequencies, or
-    times.
-    """
     _check_data_is_real(con.get_data())
 
     _check_option("con.shape", len(con.shape), [3, 4], " length")
@@ -160,9 +101,6 @@ def _plot_image_connectivity(
         _check_option("combine", combine, ["mean"], " as a string")
 
     _validate_type(node_aliases, (dict, None), "`node_aliases`", "dict or None")
-
-    _check_option("xlim", len(xlim), [2], " length")
-    _check_option("ylim", len(ylim), [2], " length")
 
     _check_option("yscale", yscale, ["linear", "log", "auto"])
 
@@ -204,16 +142,12 @@ def _plot_image_connectivity(
         )
 
     # Mask data to relevant x and y values
-    xvar, yvar = np.asarray(xvar), np.asarray(yvar)
+    xvar, yvar = np.asarray(con.times), np.asarray(con.freqs)
     xvar_mask = np.nonzero(
-        _time_mask(
-            times=xvar, tmin=xlim[0], tmax=xlim[1], sfreq=None, include_tmax=True
-        )
+        _time_mask(times=xvar, tmin=tmin, tmax=tmax, sfreq=None, include_tmax=True)
     )[0]
     yvar_mask = np.nonzero(
-        _time_mask(
-            times=yvar, tmin=ylim[0], tmax=ylim[1], sfreq=None, include_tmax=True
-        )
+        _time_mask(times=yvar, tmin=fmin, tmax=fmax, sfreq=None, include_tmax=True)
     )[0]
     data = data[..., yvar_mask, :][..., xvar_mask]
     if mask is not None:
@@ -265,8 +199,8 @@ def _plot_image_connectivity(
                 yscale=yscale,
                 cnorm=cnorm,
             )
-            con_ax.set_xlabel(xlabel)
-            con_ax.set_ylabel(ylabel)
+            con_ax.set_xlabel("Time (s)")
+            con_ax.set_ylabel("Frequency (Hz)")
             if colorbar:
                 con_ax.get_figure().colorbar(
                     mappable=img, ax=type_axes[con_idx], label="Connectivity (A.U.)"

--- a/mne_connectivity/viz/image.py
+++ b/mne_connectivity/viz/image.py
@@ -113,7 +113,9 @@ def plot_spectrotemporal_connectivity(
     ch_names = con.names
     con_method = con.method if con.method is not None else "connectivity"
     ch_info = _check_info(info, ch_names)
-    data, indices, is_multivar, is_symmetric, _ = _handle_data_and_indices(con, ch_info)
+    data, indices, is_multivar, is_symmetric, duplicate_cons_mask = (
+        _handle_data_and_indices(con, ch_info)
+    )
 
     # Get info about nodes and connections
     node_names, node_indices = _get_node_names_and_indices(
@@ -126,6 +128,7 @@ def plot_spectrotemporal_connectivity(
     data = data[picks]
     indices = (indices[0][picks], indices[1][picks])
     node_indices = (node_indices[0][picks], node_indices[1][picks])
+    duplicate_cons_mask = duplicate_cons_mask[picks]
     con_info = pick_info(con_info, picks)
     con_info["temp"]["con_types"] = con_info["temp"]["con_types"][picks]
 
@@ -135,6 +138,7 @@ def plot_spectrotemporal_connectivity(
         data, con_info, node_indices, n_comps = _add_comps_as_connections(
             data, con_info, node_indices, comps_axis=1
         )
+        duplicate_cons_mask = np.tile(duplicate_cons_mask, n_comps)
 
     if mask is not None and mask.shape != data.shape[1:]:
         raise ValueError(
@@ -161,6 +165,10 @@ def plot_spectrotemporal_connectivity(
         type_data = data[type_mask]
         type_con_names = np.array(con_info["ch_names"])[type_mask]
         type_node_indices = tuple(idcs[type_mask] for idcs in node_indices)
+        type_duplicate_cons_mask = duplicate_cons_mask[type_mask]
+
+        if all(type_duplicate_cons_mask):
+            continue  # skip if all connections for this type are duplicates
 
         # Combine connectivity across connections
         if combine is not None:
@@ -171,25 +179,23 @@ def plot_spectrotemporal_connectivity(
                 _,
                 _,
             ) = _combine_connections(
-                data=type_data, combine=combine, ci=None, n_comps=n_comps
+                data=type_data[~type_duplicate_cons_mask],
+                combine=combine,
+                ci=None,
+                n_comps=n_comps,
             )
 
         # Colormap handling
         vmin, vmax = _setup_vmin_vmax(data=type_data, vmin=vmin, vmax=vmax)
         cmap = _setup_cmap(cmap=cmap, vmin=vmin, vmax=vmax)
 
-        # Duplicate symmetric all-to-all connectivity
-        if is_symmetric and con.indices == "all" and combine is None:
-            # Find self-connections (do not duplicate)
-            diag_mask = type_node_indices[0] == type_node_indices[1]
-            # Duplicate connection data
-            type_data = np.concatenate([type_data, type_data[~diag_mask]], axis=0)
-            # Duplicate and flip seeds and targets in connections names
-            reverse_con_names = [
-                " ~ ".join(name.split(" ~ ")[::-1])
-                for name in type_con_names[~diag_mask]
-            ]
-            type_con_names = np.concatenate([type_con_names, reverse_con_names], axis=0)
+        # Remove duplicate connections in symmetric data
+        if is_symmetric and con.indices in ("lower", "upper") and combine is None:
+            type_data = type_data[~type_duplicate_cons_mask]
+            type_con_names = type_con_names[~type_duplicate_cons_mask]
+            type_node_indices = tuple(
+                idcs[~type_duplicate_cons_mask] for idcs in type_node_indices
+            )
 
         # Plot connectivity as image
         type_figs = [

--- a/mne_connectivity/viz/line.py
+++ b/mne_connectivity/viz/line.py
@@ -1,0 +1,720 @@
+from collections.abc import Callable
+from functools import partial
+
+import mne
+import numpy as np
+from matplotlib import pyplot as plt
+from mne._fiff.pick import pick_info
+from mne.utils.check import _check_option, _validate_type
+from mne.utils.numerics import _time_mask
+from mne.viz.circle import _plot_connectivity_circle
+from mne.viz.utils import plt_show
+
+from ..utils import fill_doc
+from .helpers import (
+    _add_comps_as_connections,
+    _butterfly_on_button_press,
+    _butterfly_onpick,
+    _check_data_is_real,
+    _check_info,
+    _combine_connections,
+    _get_con_info,
+    _get_node_names_and_indices,
+    _handle_data_and_indices,
+    _handle_picks,
+)
+
+
+@fill_doc
+def plot_spectral_connectivity(
+    con,
+    *,
+    info=None,
+    picks=None,
+    selection="both",
+    exclude="bads",
+    combine=None,
+    ci="sd",
+    fmin=None,
+    fmax=None,
+    node_aliases=None,
+    colors="auto",
+    cmap="turbo",
+    highlight=None,
+    interactive=True,
+    show=True,
+):
+    """Plot spectral connectivity as line plots, with circle plot overviews.
+
+    Parameters
+    ----------
+    con : ~mne_connectivity.SpectralConnectivity
+        The spectral connectivity object to plot.
+    %(viz_info)s
+    %(viz_picks)s
+    %(viz_selection_line)s
+    %(viz_exclude)s
+    %(viz_combine_line_spectral)s
+    %(viz_ci)s
+    %(viz_fmin_fmax)s
+    %(viz_node_aliases)s
+    %(viz_colors_line)s
+    %(viz_cmap_line)s
+    %(viz_highlight)s
+    %(viz_interactive)s
+    %(viz_show)s
+
+    Returns
+    -------
+    %(viz_figures)s
+
+    Notes
+    -----
+    %(viz_circle_line_note)s
+    %(viz_components_note)s
+    """
+    from mne_connectivity import SpectralConnectivity
+
+    _validate_type(con, SpectralConnectivity, "con", "SpectralConnectivity")
+
+    return _plot_line_connectivity(
+        con=con,
+        info=info,
+        picks=picks,
+        selection=selection,
+        exclude=exclude,
+        combine=combine,
+        ci=ci,
+        xlim=(fmin, fmax),
+        node_aliases=node_aliases,
+        colors=colors,
+        cmap=cmap,
+        highlight=highlight,
+        interactive=interactive,
+        show=show,
+        xvar=con.freqs,
+        xlabel="Frequency (Hz)",
+    )
+
+
+@fill_doc
+def plot_temporal_connectivity(
+    con,
+    *,
+    info=None,
+    picks=None,
+    selection="both",
+    exclude="bads",
+    combine=None,
+    ci="sd",
+    tmin=None,
+    tmax=None,
+    node_aliases=None,
+    colors="auto",
+    cmap="turbo",
+    highlight=None,
+    interactive=True,
+    show=True,
+):
+    """Plot temporal connectivity as line plots, with circle plot overviews.
+
+    Parameters
+    ----------
+    con : ~mne_connectivity.TemporalConnectivity
+        The temporal connectivity object to plot.
+    %(viz_info)s
+    %(viz_picks)s
+    %(viz_selection_line)s
+    %(viz_exclude)s
+    %(viz_combine_line_temporal)s
+    %(viz_ci)s
+    %(viz_tmin_tmax)s
+    %(viz_node_aliases)s
+    %(viz_colors_line)s
+    %(viz_cmap_line)s
+    %(viz_highlight)s
+    %(viz_interactive)s
+    %(viz_show)s
+
+    Returns
+    -------
+    %(viz_figures)s
+
+    Notes
+    -----
+    %(viz_circle_line_note)s
+    %(viz_components_note)s
+    """
+    from mne_connectivity import TemporalConnectivity
+
+    _validate_type(con, TemporalConnectivity, "con", "TemporalConnectivity")
+
+    return _plot_line_connectivity(
+        con=con,
+        info=info,
+        picks=picks,
+        selection=selection,
+        exclude=exclude,
+        combine=combine,
+        ci=ci,
+        xlim=(tmin, tmax),
+        node_aliases=node_aliases,
+        colors=colors,
+        cmap=cmap,
+        highlight=highlight,
+        interactive=interactive,
+        show=show,
+        xvar=con.times,
+        xlabel="Time (s)",
+    )
+
+
+def _plot_line_connectivity(
+    con,
+    info,
+    picks,
+    selection,
+    exclude,
+    combine,
+    ci,
+    xlim,
+    node_aliases,
+    colors,
+    cmap,
+    highlight,
+    interactive,
+    show,
+    xvar,
+    xlabel,
+):
+    """Plot connectivity as line plots with circle plot overviews.
+
+    Connectivity has dims [connections, frequencies | times].
+    """
+    _check_data_is_real(con.get_data())
+
+    _check_option("con.shape", len(con.shape), [2, 3], " length")
+
+    _check_option("selection", selection, ["both", "seeds", "targets"])
+
+    _validate_type(info, (mne.Info, None), "`info`", "mne.Info or None")
+
+    _validate_type(combine, (str, Callable, None), "`combine`")
+    if isinstance(combine, str):
+        _check_option("combine", combine, ["mean"], " as a string")
+
+    _validate_type(ci, (str, int, float, None), "`ci`")
+    if isinstance(ci, str):
+        _check_option("ci", ci, ["sd", "range"], " as a string")
+    elif isinstance(ci, int | float):
+        if not 0 < ci <= 100:
+            raise ValueError("If `ci` is a float, it must be > 0 and <= 100.")
+
+    _validate_type(node_aliases, (dict, None), "`node_aliases`", "dict or None")
+
+    _check_option("colors", colors, ["auto", "global", "relative"])
+
+    _validate_type(highlight, ("array-like", None), "`highlight`", "array-like or None")
+    if highlight is not None:
+        _check_option("highlight", np.ndim(highlight), [1, 2], " number of dimensions")
+        if np.shape(highlight)[-1] != 2:
+            raise ValueError("`highlight` must have shape (2,) or (n, 2).")
+        highlight = np.atleast_2d(highlight)  # so a single period can be iterated over
+
+    _validate_type(interactive, bool, "`interactive`", "bool")
+    _validate_type(show, bool, "`show`", "bool")
+
+    ch_names = con.names
+    con_method = con.method if con.method is not None else "connectivity"
+    ch_info = _check_info(info, ch_names)
+    data, indices, is_multivar = _handle_data_and_indices(con, ch_info)
+
+    # Get info about nodes and connections
+    node_names, node_indices = _get_node_names_and_indices(
+        ch_names, node_aliases, indices, is_multivar
+    )
+    con_info = _get_con_info(ch_info, node_names, indices, node_indices, is_multivar)
+
+    # Get requested connections
+    picks = _handle_picks(picks, exclude, ch_info, indices, is_multivar, selection)
+    data = data[picks]
+    indices = (indices[0][picks], indices[1][picks])
+    node_indices = (node_indices[0][picks], node_indices[1][picks])
+    con_info = pick_info(con_info, picks)
+    con_info["temp"]["con_types"] = con_info["temp"]["con_types"][picks]
+
+    # Add multivariate components as additional connections
+    n_comps = 1
+    if data.ndim == 3:
+        data, con_info, node_indices, n_comps = _add_comps_as_connections(
+            data, con_info, node_indices, comps_axis=1
+        )
+
+    # Mask data to relevant x values
+    xvar = np.asarray(xvar)
+    xvar_mask = np.nonzero(
+        _time_mask(
+            times=xvar, tmin=xlim[0], tmax=xlim[1], sfreq=None, include_tmax=True
+        )
+    )[0]
+    data = data[..., xvar_mask]
+    xvar = xvar[xvar_mask]
+
+    con_types = con_info["temp"]["con_types"]
+    figs = []
+    axes = []
+    for con_type in np.unique(con_types):
+        # Prepare connectivity info for plotting
+        type_mask = con_types == con_type
+        type_data = data[type_mask]
+        type_con_names = np.array(con_info["ch_names"])[type_mask]
+        type_node_names = node_names.copy()
+        type_node_indices = tuple(idcs[type_mask] for idcs in node_indices)
+
+        # Combine connectivity across connections
+        type_ci = None
+        if combine is not None:
+            (
+                type_data,
+                type_ci,
+                type_con_names,
+                type_node_names,
+                type_node_indices,
+            ) = _combine_connections(type_data, combine, ci, n_comps)
+
+        # Create figure and axes
+        fig = plt.figure(figsize=(15, 5), facecolor="w", layout="constrained")
+        plot_circle = True
+        line_subplot_idx = (1, 2)
+        if len(type_node_indices[0]) == 1:
+            plot_circle = False  # don't plot circle for a single connection
+            line_subplot_idx = (1, 3)
+        line_ax = fig.add_subplot(1, 3, line_subplot_idx)
+        circle_ax = None
+        if plot_circle:
+            # Prepare circle plot values
+            circle_names, circle_indices, is_all_to_all = _get_circle_names_and_indices(
+                type_node_names, type_node_indices
+            )
+            n_circle_nodes = len(circle_names)
+            node_is_selectable = _get_node_selectability(circle_indices, selection)
+            # If:
+            # - plot is interactive
+            # - connectivity data is (lower/upper-triangular) all-to-all
+            # - nodes as both seeds and targets in connections can be selected
+            # then colouring works best if connections are duplicated such that all
+            # nodes are seeds and targets
+            duplicate_cons = is_all_to_all and interactive and selection == "both"
+            if duplicate_cons:
+                circle_indices = (
+                    np.concatenate([circle_indices[0], circle_indices[1]]),
+                    np.concatenate([circle_indices[1], circle_indices[0]]),
+                )
+            if colors == "auto":
+                type_connection_colors = (
+                    "relative" if is_all_to_all and interactive else "global"
+                )
+            else:
+                type_connection_colors = colors
+            circle_con, circle_con_order = _get_circle_con(
+                circle_indices, n_circle_nodes, type_connection_colors, selection
+            )
+            # avoid a zero colour range (e.g. for a single pair of nodes), which
+            # would make MNE's circle plot divide by zero
+            circle_vmin, circle_vmax = circle_con.min(), circle_con.max()
+            if circle_vmin == circle_vmax:
+                circle_vmax = circle_vmin + 1
+
+            circle_ax = fig.add_subplot(1, 3, 3, polar=True)
+
+            # Plot connectivity as circle
+            fig, circle_ax = _plot_connectivity_circle(
+                con=circle_con,
+                node_names=circle_names,
+                indices=circle_indices,
+                node_width=None,
+                node_height=1.0,
+                node_colors=["black"],  # expects list
+                node_edgecolor="white",
+                node_linewidth=2.0,
+                facecolor="white",
+                textcolor="black",
+                colormap=cmap,
+                vmin=circle_vmin,
+                vmax=circle_vmax,
+                colorbar=False,
+                linewidth=1.5,
+                fontsize_names=8,
+                padding=6.0,
+                ax=circle_ax,
+                interactive=False,  # use our modified callback
+                title=(
+                    "Node selection\n"
+                    f"({selection.replace('both', 'seeds and targets')})"
+                    if interactive
+                    else "Nodes"
+                ),
+                show=show,
+            )
+            _set_node_alpha(circle_ax, node_is_selectable)
+            con_colors = _get_con_colors(circle_ax, circle_con_order)
+        else:
+            con_colors = "k"
+            duplicate_cons = False
+
+        # Plot connectivity as lines
+        fig, line_ax = _plot_connectivity_lines(
+            data=type_data,
+            ci=type_ci,
+            con_colors=con_colors,
+            con_names=type_con_names,
+            duplicate_cons=duplicate_cons,
+            fig=fig,
+            ax=line_ax,
+            xvar=xvar,
+            xlabel=xlabel,
+            title=f"{con_type} | {con_method}",
+            interactive=interactive,
+            line_alpha=0.75,
+            ci_alpha=0.3,
+            linewidth=2.0,
+            highlight=highlight,
+        )
+
+        # Add connectivity selection callback
+        if plot_circle and interactive:
+            callback = partial(
+                _plot_connectivity_circle_onpick,
+                fig=fig,
+                circle_ax=circle_ax,
+                line_ax=line_ax,
+                indices=circle_indices,
+                node_angles=np.linspace(0, 2 * np.pi, n_circle_nodes, endpoint=False),
+                duplicate_cons=duplicate_cons,
+                circle_con_order=circle_con_order,
+                selection=selection,
+                node_selectability=node_is_selectable,
+                has_ci=type_ci is not None,
+            )
+            fig.canvas.mpl_connect("button_press_event", callback)
+
+        # Hide duplicate connections initially
+        if plot_circle and duplicate_cons:
+            _hide_duplicate_cons(
+                fig,
+                circle_ax,
+                line_ax,
+                len(type_data),
+                circle_con_order,
+                has_ci=type_ci is not None,
+            )
+
+        figs.append(fig)
+        axes.append((line_ax, circle_ax))
+
+    plt_show(show)
+
+    if len(figs) == 1:
+        return figs[0], axes[0]
+    return figs, axes
+
+
+def _get_circle_names_and_indices(node_names, node_indices):
+    """Get names of nodes and indices of connections between them for circle plot."""
+    unique_nodes = np.unique(np.r_[node_indices[0], node_indices[1]])
+    circle_names = [node_names[idx] for idx in unique_nodes]
+
+    circle_indices = [np.searchsorted(unique_nodes, ind) for ind in node_indices]
+
+    is_all_to_all = []  # check if all-to-all connectivity
+    for ind, all_to_all_ind in zip(
+        circle_indices, np.tril_indices(len(circle_names), -1)
+    ):
+        if len(ind) != len(all_to_all_ind):
+            is_all_to_all.append(False)
+            break
+        if not (np.all(ind == all_to_all_ind) or np.all(ind == all_to_all_ind.T)):
+            is_all_to_all.append(False)
+            break
+        is_all_to_all.append(True)
+    is_all_to_all = all(is_all_to_all)
+
+    return circle_names, circle_indices, is_all_to_all
+
+
+def _get_node_selectability(circle_indices, selection):
+    """Get selectability of nodes in circle plot based on node selection type."""
+    n_unique_nodes = len(np.unique(np.r_[circle_indices[0], circle_indices[1]]))
+    if selection == "both":
+        node_selectability = [True] * n_unique_nodes
+    else:
+        if selection == "seeds":
+            relevant_indices = circle_indices[0]
+        else:  # selection == "targets"
+            relevant_indices = circle_indices[1]
+        node_selectability = [idx in relevant_indices for idx in range(n_unique_nodes)]
+
+    return node_selectability
+
+
+def _get_circle_con(circle_indices, n_nodes, connection_colors, selection):
+    """Get connectivity values for circle plot (determines colour)."""
+    if connection_colors == "relative":  # values span colourbar per node
+        node_angles = np.linspace(0, 2 * np.pi, n_nodes, endpoint=False)
+        circle_con = np.zeros(len(circle_indices[0]))
+        for con_idx, (seed, target) in enumerate(zip(*circle_indices)):
+            node_diff = node_angles[seed] - node_angles[target]
+            if node_diff > 0:
+                node_diff -= 2 * np.pi
+            circle_con[con_idx] = np.abs(node_diff)
+        # Normalise values for different number of connections per node
+        if selection != "both":
+            consider_indices = (
+                circle_indices[0] if selection == "seeds" else circle_indices[1]
+            )
+            for node_idx in range(n_nodes):
+                node_mask = consider_indices == node_idx
+                if np.any(node_mask):
+                    circle_con[node_mask] -= circle_con[node_mask].min()
+                    if circle_con[node_mask].size > 1:  # avoid division by zero
+                        circle_con[node_mask] /= circle_con[node_mask].max()
+    else:  # values span colourbar over all connections
+        circle_con = circle_indices[0] + circle_indices[1]
+
+    # mne.viz.circle._plot_connectivity_circle default behaviour is to sort connections
+    # by strength (valid as of MNE v1.11)
+    circle_con_order = np.argsort(circle_con)  # to map cons in circle plot to indices
+
+    return circle_con, circle_con_order
+
+
+def _set_node_alpha(circle_ax, node_is_selectable):
+    """Set alpha of nodes in circle plot based on selectability."""
+    for node_idx, node_selectable in enumerate(node_is_selectable):
+        node_patch = circle_ax.containers[0][node_idx]
+        if not node_selectable:
+            node_patch.set_alpha(0.3)
+
+
+def _get_con_colors(circle_ax, circle_con_order):
+    """Get colors of connections from circle plot."""
+    con_colors = [None] * len(circle_con_order)
+    for patch_idx, con_idx in enumerate(circle_con_order):
+        patch = circle_ax.patches[patch_idx]
+        con_colors[con_idx] = patch.get_edgecolor()
+
+    return con_colors
+
+
+def _plot_connectivity_circle_onpick(
+    event,
+    fig,
+    circle_ax,
+    line_ax,
+    indices,
+    node_angles,
+    duplicate_cons,
+    circle_con_order,
+    selection,
+    node_selectability,
+    has_ci,
+    ylim=(9, 10),
+):
+    """Isolate connections for a single node and reflect this in the line plot.
+
+    On left click, shows only connections related to the clicked node.
+    On right click, resets all connections.
+
+    `y_lim` radius is default in circle plot (valid in MNE v1.11).
+    """
+    if event.inaxes != circle_ax:
+        return
+
+    patches = circle_ax.patches
+    lines = line_ax.lines
+    collections = line_ax.collections
+    if event.button == 1:  # left click
+        if not ylim[0] <= event.ydata <= ylim[1]:
+            return  # ignore click if not near nodes
+
+        # all angles in range [0, 2*pi]
+        node_angles = node_angles % (np.pi * 2)
+        node = np.argmin(np.abs(event.xdata - node_angles))
+        if not node_selectability[node]:
+            return  # ignore click if node not selectable
+
+        for text in line_ax.texts:
+            text.set_alpha(0)  # hide any connection labels
+
+        for circle_idx, line_idx in enumerate(circle_con_order):
+            seed, target = indices[0][line_idx], indices[1][line_idx]
+            if selection == "both":
+                viable_nodes = [seed, target] if not duplicate_cons else [seed]
+            elif selection == "seeds":
+                viable_nodes = [seed]
+            else:  # selection == "targets"
+                viable_nodes = [target]
+            visible = node in viable_nodes
+            patches[circle_idx].set_visible(visible)
+            lines[line_idx].set_visible(visible)
+            lines[line_idx].set_picker(0 if not visible else True)
+            if has_ci:
+                collections[line_idx].set_visible(visible)
+        fig.canvas.draw()
+
+    elif event.button == 3:  # right click
+        n_cons = len(indices[0]) if not duplicate_cons else len(indices[0]) // 2
+        for circle_idx, line_idx in enumerate(circle_con_order):
+            # Make original connections visible and hide duplicated connections
+            visible = line_idx < n_cons
+            patches[circle_idx].set_visible(visible)
+            lines[line_idx].set_visible(visible)
+            lines[line_idx].set_picker(0 if not visible else True)
+            if has_ci:
+                collections[line_idx].set_visible(visible)
+        for text in line_ax.texts:
+            text.set_alpha(0)  # hide any connection labels
+        fig.canvas.draw()
+
+
+def _hide_duplicate_cons(fig, circle_ax, line_ax, n_cons, circle_con_order, has_ci):
+    """Hide duplicated connections in circle and line plots."""
+    for circle_idx, line_idx in enumerate(circle_con_order):
+        if line_idx >= n_cons:
+            circle_ax.patches[circle_idx].set_visible(False)
+            line_ax.lines[line_idx].set_visible(False)
+            line_ax.lines[line_idx].set_picker(False)
+            if has_ci:
+                line_ax.collections[line_idx].set_visible(False)
+    fig.canvas.draw()
+
+
+def _plot_connectivity_lines(
+    data,
+    ci,
+    con_colors,
+    con_names,
+    duplicate_cons,
+    fig,
+    ax,
+    xvar,
+    xlabel,
+    title,
+    interactive,
+    line_alpha,
+    ci_alpha,
+    linewidth,
+    highlight,
+):
+    """Plot data as butterfly plot."""
+    texts = list()
+    n_cons = data.shape[0]
+    idxs = np.arange(n_cons)
+    if duplicate_cons:
+        idxs = np.concatenate([idxs, idxs + n_cons])
+    lines = list()
+
+    if interactive:
+        # Parameters for butterfly interactive plots
+        if duplicate_cons:
+            con_names = np.concatenate([con_names, con_names])
+        params = dict(
+            axes=[ax],
+            texts=texts,
+            lines=[lines],
+            ch_names=con_names,
+            idxs=[idxs],
+            need_draw=False,
+            path_effects=None,
+        )
+        fig.canvas.mpl_connect("pick_event", partial(_butterfly_onpick, params=params))
+        fig.canvas.mpl_connect(
+            "button_press_event", partial(_butterfly_on_button_press, params=params)
+        )
+
+    # Map cons with least activity behind the more active ones
+    z_ord = data.std(axis=1).argsort()[::-1]
+
+    # plot connections
+    for con_idx, z in enumerate(z_ord):
+        if ci is not None:
+            ax.fill_between(
+                xvar,
+                ci[con_idx, :, 0],
+                ci[con_idx, :, 1],
+                zorder=z + 1,
+                color=con_colors[con_idx],
+                edgecolor=None,
+                alpha=ci_alpha,
+            )
+        lines.append(
+            ax.plot(
+                xvar,
+                data[con_idx],
+                picker=interactive,
+                zorder=z + 1,
+                color=con_colors[con_idx],
+                alpha=line_alpha,
+                linewidth=linewidth,
+            )[0]
+        )
+        lines[-1].set_pickradius(3.0)
+    if duplicate_cons:
+        for con_idx, z in enumerate(z_ord):
+            if ci is not None:
+                ax.fill_between(
+                    xvar,
+                    ci[con_idx],
+                    zorder=z + 1,
+                    color=con_colors[con_idx],
+                    alpha=ci_alpha,
+                )
+            lines.append(
+                ax.plot(
+                    xvar,
+                    data[con_idx],
+                    picker=interactive,
+                    zorder=z + 1,
+                    color=con_colors[con_idx + n_cons],
+                    alpha=line_alpha,
+                    linewidth=linewidth,
+                )[0]
+            )
+            lines[-1].set_pickradius(3.0)
+
+    ax.set_xlim(xvar[0], xvar[-1])
+
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel("Connectivity (A.U.)")
+    texts.append(
+        ax.text(
+            0,
+            0,
+            "",
+            zorder=3,
+            verticalalignment="baseline",
+            horizontalalignment="left",
+            fontweight="bold",
+            alpha=0,
+            clip_on=True,
+        )
+    )
+
+    ax.set_title(title)
+
+    # Plot highlights
+    if highlight is not None:
+        this_ylim = ax.get_ylim()
+        for this_highlight in highlight:
+            ax.fill_betweenx(
+                this_ylim,
+                this_highlight[0],
+                this_highlight[1],
+                facecolor="orange",
+                alpha=0.15,
+                zorder=99,
+            )
+        # Put back the y limits as fill_betweenx messes them up
+        ax.set_ylim(this_ylim)
+
+    return fig, ax

--- a/mne_connectivity/viz/line.py
+++ b/mne_connectivity/viz/line.py
@@ -227,7 +227,9 @@ def _plot_line_connectivity(
     ch_names = con.names
     con_method = con.method if con.method is not None else "connectivity"
     ch_info = _check_info(info, ch_names)
-    data, indices, is_multivar = _handle_data_and_indices(con, ch_info)
+    data, indices, is_multivar, is_symmetric_tri = _handle_data_and_indices(
+        con, ch_info
+    )
 
     # Get info about nodes and connections
     node_names, node_indices = _get_node_names_and_indices(
@@ -291,28 +293,38 @@ def _plot_line_connectivity(
             line_subplot_idx = (1, 3)
         line_ax = fig.add_subplot(1, 3, line_subplot_idx)
         circle_ax = None
+        self_con_mask = None  # for circle plot with duplicate cons
         if plot_circle:
             # Prepare circle plot values
-            circle_names, circle_indices, is_all_to_all = _get_circle_names_and_indices(
+            circle_names, circle_indices = _get_circle_names_and_indices(
                 type_node_names, type_node_indices
             )
             n_circle_nodes = len(circle_names)
             node_is_selectable = _get_node_selectability(circle_indices, selection)
             # If:
             # - plot is interactive
-            # - connectivity data is (lower/upper-triangular) all-to-all
+            # - connectivity data is (lower/upper-triangular) all-to-all symmetric
             # - nodes as both seeds and targets in connections can be selected
             # then colouring works best if connections are duplicated such that all
             # nodes are seeds and targets
-            duplicate_cons = is_all_to_all and interactive and selection == "both"
+            duplicate_cons = is_symmetric_tri and interactive and selection == "both"
             if duplicate_cons:
                 circle_indices = (
                     np.concatenate([circle_indices[0], circle_indices[1]]),
                     np.concatenate([circle_indices[1], circle_indices[0]]),
                 )
+                # Avoid duplicating self-connections (diagonal may be present)
+                orig_n_cons = len(circle_indices[0]) // 2
+                self_con_mask = (
+                    circle_indices[0][orig_n_cons:] == circle_indices[1][orig_n_cons:]
+                )
+                circle_indices = (
+                    circle_indices[0][~self_con_mask],
+                    circle_indices[1][~self_con_mask],
+                )
             if colors == "auto":
                 type_connection_colors = (
-                    "relative" if is_all_to_all and interactive else "global"
+                    "relative" if is_symmetric_tri and interactive else "global"
                 )
             else:
                 type_connection_colors = colors
@@ -369,6 +381,7 @@ def _plot_line_connectivity(
             con_colors=con_colors,
             con_names=type_con_names,
             duplicate_cons=duplicate_cons,
+            self_con_mask=self_con_mask,
             fig=fig,
             ax=line_ax,
             xvar=xvar,
@@ -391,6 +404,7 @@ def _plot_line_connectivity(
                 indices=circle_indices,
                 node_angles=np.linspace(0, 2 * np.pi, n_circle_nodes, endpoint=False),
                 duplicate_cons=duplicate_cons,
+                self_con_mask=self_con_mask,
                 circle_con_order=circle_con_order,
                 selection=selection,
                 node_selectability=node_is_selectable,
@@ -426,20 +440,7 @@ def _get_circle_names_and_indices(node_names, node_indices):
 
     circle_indices = [np.searchsorted(unique_nodes, ind) for ind in node_indices]
 
-    is_all_to_all = []  # check if all-to-all connectivity
-    for ind, all_to_all_ind in zip(
-        circle_indices, np.tril_indices(len(circle_names), -1)
-    ):
-        if len(ind) != len(all_to_all_ind):
-            is_all_to_all.append(False)
-            break
-        if not (np.all(ind == all_to_all_ind) or np.all(ind == all_to_all_ind.T)):
-            is_all_to_all.append(False)
-            break
-        is_all_to_all.append(True)
-    is_all_to_all = all(is_all_to_all)
-
-    return circle_names, circle_indices, is_all_to_all
+    return circle_names, circle_indices
 
 
 def _get_node_selectability(circle_indices, selection):
@@ -514,6 +515,7 @@ def _plot_connectivity_circle_onpick(
     indices,
     node_angles,
     duplicate_cons,
+    self_con_mask,
     circle_con_order,
     selection,
     node_selectability,
@@ -563,7 +565,11 @@ def _plot_connectivity_circle_onpick(
         fig.canvas.draw()
 
     elif event.button == 3:  # right click
-        n_cons = len(indices[0]) if not duplicate_cons else len(indices[0]) // 2
+        if not duplicate_cons:
+            n_cons = len(indices[0])
+        else:
+            # Need to account for self-connections that were not duplicated
+            n_cons = len(indices[0]) + sum(self_con_mask) // 2
         for circle_idx, line_idx in enumerate(circle_con_order):
             # Make original connections visible and hide duplicated connections
             visible = line_idx < n_cons
@@ -595,6 +601,7 @@ def _plot_connectivity_lines(
     con_colors,
     con_names,
     duplicate_cons,
+    self_con_mask,
     fig,
     ax,
     xvar,
@@ -611,13 +618,14 @@ def _plot_connectivity_lines(
     n_cons = data.shape[0]
     idxs = np.arange(n_cons)
     if duplicate_cons:
-        idxs = np.concatenate([idxs, idxs + n_cons])
+        n_duplicated_cons = n_cons - sum(self_con_mask)
+        idxs = np.concatenate([idxs, idxs[:n_duplicated_cons] + n_cons])
     lines = list()
 
     if interactive:
         # Parameters for butterfly interactive plots
         if duplicate_cons:
-            con_names = np.concatenate([con_names, con_names])
+            con_names = np.concatenate([con_names, con_names[~self_con_mask]])
         params = dict(
             axes=[ax],
             texts=texts,
@@ -666,7 +674,8 @@ def _plot_connectivity_lines(
                     xvar,
                     ci[con_idx],
                     zorder=z + 1,
-                    color=con_colors[con_idx],
+                    color=con_colors[con_idx + n_duplicated_cons],
+                    edgecolor=None,
                     alpha=ci_alpha,
                 )
             lines.append(
@@ -675,7 +684,7 @@ def _plot_connectivity_lines(
                     data[con_idx],
                     picker=interactive,
                     zorder=z + 1,
-                    color=con_colors[con_idx + n_cons],
+                    color=con_colors[con_idx + n_duplicated_cons],
                     alpha=line_alpha,
                     linewidth=linewidth,
                 )[0]

--- a/mne_connectivity/viz/line.py
+++ b/mne_connectivity/viz/line.py
@@ -191,7 +191,7 @@ def _plot_line_connectivity(
 
     Connectivity has dims [connections, frequencies | times].
     """
-    _check_data_is_real(con.get_data())
+    _check_data_is_real(con.get_data("raveled"))
 
     _check_option("con.shape", len(con.shape), [2, 3], " length")
 
@@ -227,7 +227,7 @@ def _plot_line_connectivity(
     ch_names = con.names
     con_method = con.method if con.method is not None else "connectivity"
     ch_info = _check_info(info, ch_names)
-    data, indices, is_multivar, is_symmetric_tri = _handle_data_and_indices(
+    data, indices, is_multivar, _, is_symmetric, _ = _handle_data_and_indices(
         con, ch_info
     )
 
@@ -293,7 +293,8 @@ def _plot_line_connectivity(
             line_subplot_idx = (1, 3)
         line_ax = fig.add_subplot(1, 3, line_subplot_idx)
         circle_ax = None
-        self_con_mask = None  # for circle plot with duplicate cons
+        duplicate_cons = False  # whether to duplicate connections for circle plot
+        diag_mask = None  # used alongside connection duplication
         if plot_circle:
             # Prepare circle plot values
             circle_names, circle_indices = _get_circle_names_and_indices(
@@ -303,36 +304,35 @@ def _plot_line_connectivity(
             node_is_selectable = _get_node_selectability(circle_indices, selection)
             # If:
             # - plot is interactive
-            # - connectivity data is (lower/upper-triangular) all-to-all symmetric
-            # - nodes as both seeds and targets in connections can be selected
-            # then colouring works best if connections are duplicated such that all
+            # - connectivity data can be represented as a full, symmetric matrix
+            # then visualisation works best if connections are duplicated such that all
             # nodes are seeds and targets
-            duplicate_cons = is_symmetric_tri and interactive and selection == "both"
-            if duplicate_cons:
+            if is_symmetric and interactive:
+                duplicate_cons = True
+                # Don't duplicate diagonal entries
+                diag_mask = circle_indices[0] == circle_indices[1]
                 circle_indices = (
-                    np.concatenate([circle_indices[0], circle_indices[1]]),
-                    np.concatenate([circle_indices[1], circle_indices[0]]),
-                )
-                # Avoid duplicating self-connections (diagonal may be present)
-                orig_n_cons = len(circle_indices[0]) // 2
-                self_con_mask = (
-                    circle_indices[0][orig_n_cons:] == circle_indices[1][orig_n_cons:]
-                )
-                circle_indices = (
-                    circle_indices[0][~self_con_mask],
-                    circle_indices[1][~self_con_mask],
+                    np.concatenate([circle_indices[0], circle_indices[1][~diag_mask]]),
+                    np.concatenate([circle_indices[1], circle_indices[0][~diag_mask]]),
                 )
             if colors == "auto":
+                # If connections span full matrix (diagonal optional) and plot is
+                # interactive, use 'relative' colouring, such that the connection
+                # colours span the colourmap space for each node. This makes interactive
+                # visualisation for large numbers of nodes much better.
+                # Otherwise, have the connection colours span the colourmap space for
+                # all connections, which is better for non-interactive plots and
+                # non-full connectivity data.
                 type_connection_colors = (
-                    "relative" if is_symmetric_tri and interactive else "global"
+                    "relative" if is_symmetric and interactive else "global"
                 )
             else:
                 type_connection_colors = colors
             circle_con, circle_con_order = _get_circle_con(
                 circle_indices, n_circle_nodes, type_connection_colors, selection
             )
-            # avoid a zero colour range (e.g. for a single pair of nodes), which
-            # would make MNE's circle plot divide by zero
+            # Avoid a zero colour range (e.g. for a single pair of nodes), which would
+            # make MNE's circle plot divide by zero
             circle_vmin, circle_vmax = circle_con.min(), circle_con.max()
             if circle_vmin == circle_vmax:
                 circle_vmax = circle_vmin + 1
@@ -372,7 +372,6 @@ def _plot_line_connectivity(
             con_colors = _get_con_colors(circle_ax, circle_con_order)
         else:
             con_colors = "k"
-            duplicate_cons = False
 
         # Plot connectivity as lines
         fig, line_ax = _plot_connectivity_lines(
@@ -381,7 +380,7 @@ def _plot_line_connectivity(
             con_colors=con_colors,
             con_names=type_con_names,
             duplicate_cons=duplicate_cons,
-            self_con_mask=self_con_mask,
+            diag_mask=diag_mask,
             fig=fig,
             ax=line_ax,
             xvar=xvar,
@@ -403,8 +402,8 @@ def _plot_line_connectivity(
                 line_ax=line_ax,
                 indices=circle_indices,
                 node_angles=np.linspace(0, 2 * np.pi, n_circle_nodes, endpoint=False),
+                n_cons=len(type_data),
                 duplicate_cons=duplicate_cons,
-                self_con_mask=self_con_mask,
                 circle_con_order=circle_con_order,
                 selection=selection,
                 node_selectability=node_is_selectable,
@@ -412,14 +411,14 @@ def _plot_line_connectivity(
             )
             fig.canvas.mpl_connect("button_press_event", callback)
 
-        # Hide duplicate connections initially
-        if plot_circle and duplicate_cons:
+        # Hide duplicate symmetric connections initially
+        if duplicate_cons:
             _hide_duplicate_cons(
-                fig,
-                circle_ax,
-                line_ax,
-                len(type_data),
-                circle_con_order,
+                fig=fig,
+                circle_ax=circle_ax,
+                line_ax=line_ax,
+                n_cons=len(type_data),
+                circle_con_order=circle_con_order,
                 has_ci=type_ci is not None,
             )
 
@@ -480,7 +479,7 @@ def _get_circle_con(circle_indices, n_nodes, connection_colors, selection):
                     if circle_con[node_mask].size > 1:  # avoid division by zero
                         circle_con[node_mask] /= circle_con[node_mask].max()
     else:  # values span colourbar over all connections
-        circle_con = circle_indices[0] + circle_indices[1]
+        circle_con = np.arange(len(circle_indices[0]))
 
     # mne.viz.circle._plot_connectivity_circle default behaviour is to sort connections
     # by strength (valid as of MNE v1.11)
@@ -514,8 +513,8 @@ def _plot_connectivity_circle_onpick(
     line_ax,
     indices,
     node_angles,
+    n_cons,
     duplicate_cons,
-    self_con_mask,
     circle_con_order,
     selection,
     node_selectability,
@@ -551,6 +550,10 @@ def _plot_connectivity_circle_onpick(
         for circle_idx, line_idx in enumerate(circle_con_order):
             seed, target = indices[0][line_idx], indices[1][line_idx]
             if selection == "both":
+                # For symmetric data with duplicate connections, selecting a node for
+                # both seed and target cons would show duplicate values. Instead, only
+                # show the seed connections for symmetric data (which implicitly
+                # includes the target connections).
                 viable_nodes = [seed, target] if not duplicate_cons else [seed]
             elif selection == "seeds":
                 viable_nodes = [seed]
@@ -565,33 +568,21 @@ def _plot_connectivity_circle_onpick(
         fig.canvas.draw()
 
     elif event.button == 3:  # right click
-        if not duplicate_cons:
-            n_cons = len(indices[0])
-        else:
-            # Need to account for self-connections that were not duplicated
-            n_cons = len(indices[0]) + sum(self_con_mask) // 2
-        for circle_idx, line_idx in enumerate(circle_con_order):
-            # Make original connections visible and hide duplicated connections
-            visible = line_idx < n_cons
-            patches[circle_idx].set_visible(visible)
-            lines[line_idx].set_visible(visible)
-            lines[line_idx].set_picker(0 if not visible else True)
-            if has_ci:
-                collections[line_idx].set_visible(visible)
+        # Make original connections visible and hide duplicate connections
+        _hide_duplicate_cons(fig, circle_ax, line_ax, n_cons, circle_con_order, has_ci)
         for text in line_ax.texts:
             text.set_alpha(0)  # hide any connection labels
-        fig.canvas.draw()
 
 
 def _hide_duplicate_cons(fig, circle_ax, line_ax, n_cons, circle_con_order, has_ci):
     """Hide duplicated connections in circle and line plots."""
     for circle_idx, line_idx in enumerate(circle_con_order):
-        if line_idx >= n_cons:
-            circle_ax.patches[circle_idx].set_visible(False)
-            line_ax.lines[line_idx].set_visible(False)
-            line_ax.lines[line_idx].set_picker(False)
-            if has_ci:
-                line_ax.collections[line_idx].set_visible(False)
+        visible = line_idx < n_cons
+        circle_ax.patches[circle_idx].set_visible(visible)
+        line_ax.lines[line_idx].set_visible(visible)
+        line_ax.lines[line_idx].set_picker(0 if not visible else True)
+        if has_ci:
+            line_ax.collections[line_idx].set_visible(visible)
     fig.canvas.draw()
 
 
@@ -601,7 +592,7 @@ def _plot_connectivity_lines(
     con_colors,
     con_names,
     duplicate_cons,
-    self_con_mask,
+    diag_mask,
     fig,
     ax,
     xvar,
@@ -618,14 +609,19 @@ def _plot_connectivity_lines(
     n_cons = data.shape[0]
     idxs = np.arange(n_cons)
     if duplicate_cons:
-        n_duplicated_cons = n_cons - sum(self_con_mask)
-        idxs = np.concatenate([idxs, idxs[:n_duplicated_cons] + n_cons])
+        n_duplicated_cons = (
+            n_cons - np.sum(diag_mask) if diag_mask is not None else n_cons
+        )
+        idxs = np.concatenate([idxs, np.arange(n_duplicated_cons) + n_cons])
     lines = list()
 
     if interactive:
         # Parameters for butterfly interactive plots
         if duplicate_cons:
-            con_names = np.concatenate([con_names, con_names[~self_con_mask]])
+            reverse_con_names = [
+                " ~ ".join(name.split(" ~ ")[::-1]) for name in con_names[~diag_mask]
+            ]
+            con_names = np.concatenate([con_names, reverse_con_names])
         params = dict(
             axes=[ax],
             texts=texts,
@@ -643,38 +639,21 @@ def _plot_connectivity_lines(
     # Map cons with least activity behind the more active ones
     z_ord = data.std(axis=1).argsort()[::-1]
 
-    # plot connections
-    for con_idx, z in enumerate(z_ord):
-        if ci is not None:
-            ax.fill_between(
-                xvar,
-                ci[con_idx, :, 0],
-                ci[con_idx, :, 1],
-                zorder=z + 1,
-                color=con_colors[con_idx],
-                edgecolor=None,
-                alpha=ci_alpha,
-            )
-        lines.append(
-            ax.plot(
-                xvar,
-                data[con_idx],
-                picker=interactive,
-                zorder=z + 1,
-                color=con_colors[con_idx],
-                alpha=line_alpha,
-                linewidth=linewidth,
-            )[0]
-        )
-        lines[-1].set_pickradius(3.0)
-    if duplicate_cons:
+    # Plot connections
+    def _plot_connections(mask=None, base_color_idx=0):
+        if mask is None:
+            mask = np.ones(z_ord.shape[0], dtype=bool)
+        unmasked_idx = 0
         for con_idx, z in enumerate(z_ord):
+            if not mask[con_idx]:
+                continue
             if ci is not None:
                 ax.fill_between(
                     xvar,
-                    ci[con_idx],
+                    ci[con_idx, :, 0],
+                    ci[con_idx, :, 1],
                     zorder=z + 1,
-                    color=con_colors[con_idx + n_duplicated_cons],
+                    color=con_colors[unmasked_idx + base_color_idx],
                     edgecolor=None,
                     alpha=ci_alpha,
                 )
@@ -684,12 +663,17 @@ def _plot_connectivity_lines(
                     data[con_idx],
                     picker=interactive,
                     zorder=z + 1,
-                    color=con_colors[con_idx + n_duplicated_cons],
+                    color=con_colors[unmasked_idx + base_color_idx],
                     alpha=line_alpha,
                     linewidth=linewidth,
                 )[0]
             )
             lines[-1].set_pickradius(3.0)
+            unmasked_idx += 1
+
+    _plot_connections()
+    if duplicate_cons:
+        _plot_connections(mask=~diag_mask, base_color_idx=n_cons)
 
     ax.set_xlim(xvar[0], xvar[-1])
 

--- a/mne_connectivity/viz/line.py
+++ b/mne_connectivity/viz/line.py
@@ -227,7 +227,9 @@ def _plot_line_connectivity(
     ch_names = con.names
     con_method = con.method if con.method is not None else "connectivity"
     ch_info = _check_info(info, ch_names)
-    data, indices, is_multivar, is_symmetric, _ = _handle_data_and_indices(con, ch_info)
+    data, indices, is_multivar, is_symmetric, duplicate_cons_mask = (
+        _handle_data_and_indices(con, ch_info)
+    )
 
     # Get info about nodes and connections
     node_names, node_indices = _get_node_names_and_indices(
@@ -240,6 +242,7 @@ def _plot_line_connectivity(
     data = data[picks]
     indices = (indices[0][picks], indices[1][picks])
     node_indices = (node_indices[0][picks], node_indices[1][picks])
+    duplicate_cons_mask = duplicate_cons_mask[picks]
     con_info = pick_info(con_info, picks)
     con_info["temp"]["con_types"] = con_info["temp"]["con_types"][picks]
 
@@ -249,6 +252,7 @@ def _plot_line_connectivity(
         data, con_info, node_indices, n_comps = _add_comps_as_connections(
             data, con_info, node_indices, comps_axis=1
         )
+        duplicate_cons_mask = np.tile(duplicate_cons_mask, n_comps)
 
     # Mask data to relevant x values
     xvar = np.asarray(xvar)
@@ -269,6 +273,10 @@ def _plot_line_connectivity(
         type_con_names = np.array(con_info["ch_names"])[type_mask]
         type_node_names = node_names.copy()
         type_node_indices = tuple(idcs[type_mask] for idcs in node_indices)
+        type_duplicate_cons_mask = duplicate_cons_mask[type_mask]
+
+        if all(type_duplicate_cons_mask):
+            continue  # skip if all connections for this type are duplicates
 
         # Combine connectivity across connections
         type_ci = None
@@ -279,7 +287,9 @@ def _plot_line_connectivity(
                 type_con_names,
                 type_node_names,
                 type_node_indices,
-            ) = _combine_connections(type_data, combine, ci, n_comps)
+            ) = _combine_connections(
+                type_data[~type_duplicate_cons_mask], combine, ci, n_comps
+            )
 
         # Create figure and axes
         fig = plt.figure(figsize=(15, 5), facecolor="w", layout="constrained")
@@ -290,28 +300,28 @@ def _plot_line_connectivity(
             line_subplot_idx = (1, 3)
         line_ax = fig.add_subplot(1, 3, line_subplot_idx)
         circle_ax = None
-        duplicate_cons = False  # whether to duplicate connections for circle plot
-        diag_mask = None  # used alongside connection duplication
         if plot_circle:
+            # If data is symmetric and the plot is not interactive, we should remove
+            # those duplicate connections, or we will have overlapping connections in
+            # the line plot (will mess up line colours and alphas).
+            # If the plot is interactive, we keep the duplicate connections, but just
+            # hide them initially until the user selects a node.
+            if is_symmetric and not interactive:
+                type_data = type_data[~type_duplicate_cons_mask]
+                type_con_names = type_con_names[~type_duplicate_cons_mask]
+                type_node_indices = tuple(
+                    idcs[~type_duplicate_cons_mask] for idcs in type_node_indices
+                )
+                type_duplicate_cons_mask = np.full(
+                    type_data.shape[0], False, dtype=bool
+                )
+
             # Prepare circle plot values
             circle_names, circle_indices = _get_circle_names_and_indices(
                 type_node_names, type_node_indices
             )
             n_circle_nodes = len(circle_names)
             node_is_selectable = _get_node_selectability(circle_indices, selection)
-            # If:
-            # - plot is interactive
-            # - connectivity data can be represented as a full, symmetric matrix
-            # then visualisation works best if connections are duplicated such that all
-            # nodes are seeds and targets
-            if is_symmetric and interactive:
-                duplicate_cons = True
-                # Don't duplicate diagonal entries
-                diag_mask = circle_indices[0] == circle_indices[1]
-                circle_indices = (
-                    np.concatenate([circle_indices[0], circle_indices[1][~diag_mask]]),
-                    np.concatenate([circle_indices[1], circle_indices[0][~diag_mask]]),
-                )
             if colors == "auto":
                 # If connections span full matrix (diagonal optional) and plot is
                 # interactive, use 'relative' colouring, such that the connection
@@ -376,8 +386,6 @@ def _plot_line_connectivity(
             ci=type_ci,
             con_colors=con_colors,
             con_names=type_con_names,
-            duplicate_cons=duplicate_cons,
-            diag_mask=diag_mask,
             fig=fig,
             ax=line_ax,
             xvar=xvar,
@@ -399,8 +407,7 @@ def _plot_line_connectivity(
                 line_ax=line_ax,
                 indices=circle_indices,
                 node_angles=np.linspace(0, 2 * np.pi, n_circle_nodes, endpoint=False),
-                n_cons=len(type_data),
-                duplicate_cons=duplicate_cons,
+                duplicate_cons_mask=type_duplicate_cons_mask,
                 circle_con_order=circle_con_order,
                 selection=selection,
                 node_selectability=node_is_selectable,
@@ -409,12 +416,12 @@ def _plot_line_connectivity(
             fig.canvas.mpl_connect("button_press_event", callback)
 
         # Hide duplicate symmetric connections initially
-        if duplicate_cons:
+        if plot_circle and interactive:
             _hide_duplicate_cons(
                 fig=fig,
                 circle_ax=circle_ax,
                 line_ax=line_ax,
-                n_cons=len(type_data),
+                duplicate_cons_mask=type_duplicate_cons_mask,
                 circle_con_order=circle_con_order,
                 has_ci=type_ci is not None,
             )
@@ -509,8 +516,7 @@ def _plot_connectivity_circle_onpick(
     line_ax,
     indices,
     node_angles,
-    n_cons,
-    duplicate_cons,
+    duplicate_cons_mask,
     circle_con_order,
     selection,
     node_selectability,
@@ -550,7 +556,9 @@ def _plot_connectivity_circle_onpick(
                 # both seed and target cons would show duplicate values. Instead, only
                 # show the seed connections for symmetric data (which implicitly
                 # includes the target connections).
-                viable_nodes = [seed, target] if not duplicate_cons else [seed]
+                viable_nodes = (
+                    [seed, target] if not any(duplicate_cons_mask) else [seed]
+                )
             elif selection == "seeds":
                 viable_nodes = [seed]
             else:  # selection == "targets"
@@ -565,15 +573,19 @@ def _plot_connectivity_circle_onpick(
 
     elif event.button == 3:  # right click
         # Make original connections visible and hide duplicate connections
-        _hide_duplicate_cons(fig, circle_ax, line_ax, n_cons, circle_con_order, has_ci)
+        _hide_duplicate_cons(
+            fig, circle_ax, line_ax, duplicate_cons_mask, circle_con_order, has_ci
+        )
         for text in line_ax.texts:
             text.set_alpha(0)  # hide any connection labels
 
 
-def _hide_duplicate_cons(fig, circle_ax, line_ax, n_cons, circle_con_order, has_ci):
+def _hide_duplicate_cons(
+    fig, circle_ax, line_ax, duplicate_cons_mask, circle_con_order, has_ci
+):
     """Hide duplicated connections in circle and line plots."""
     for circle_idx, line_idx in enumerate(circle_con_order):
-        visible = line_idx < n_cons
+        visible = ~duplicate_cons_mask[line_idx]
         circle_ax.patches[circle_idx].set_visible(visible)
         line_ax.lines[line_idx].set_visible(visible)
         line_ax.lines[line_idx].set_picker(0 if not visible else True)
@@ -587,8 +599,6 @@ def _plot_connectivity_lines(
     ci,
     con_colors,
     con_names,
-    duplicate_cons,
-    diag_mask,
     fig,
     ax,
     xvar,
@@ -604,20 +614,10 @@ def _plot_connectivity_lines(
     texts = list()
     n_cons = data.shape[0]
     idxs = np.arange(n_cons)
-    if duplicate_cons:
-        n_duplicated_cons = (
-            n_cons - np.sum(diag_mask) if diag_mask is not None else n_cons
-        )
-        idxs = np.concatenate([idxs, np.arange(n_duplicated_cons) + n_cons])
     lines = list()
 
     if interactive:
         # Parameters for butterfly interactive plots
-        if duplicate_cons:
-            reverse_con_names = [
-                " ~ ".join(name.split(" ~ ")[::-1]) for name in con_names[~diag_mask]
-            ]
-            con_names = np.concatenate([con_names, reverse_con_names])
         params = dict(
             axes=[ax],
             texts=texts,
@@ -636,40 +636,29 @@ def _plot_connectivity_lines(
     z_ord = data.std(axis=1).argsort()[::-1]
 
     # Plot connections
-    def _plot_connections(mask=None, base_color_idx=0):
-        if mask is None:
-            mask = np.ones(z_ord.shape[0], dtype=bool)
-        unmasked_idx = 0
-        for con_idx, z in enumerate(z_ord):
-            if not mask[con_idx]:
-                continue
-            if ci is not None:
-                ax.fill_between(
-                    xvar,
-                    ci[con_idx, :, 0],
-                    ci[con_idx, :, 1],
-                    zorder=z + 1,
-                    color=con_colors[unmasked_idx + base_color_idx],
-                    edgecolor=None,
-                    alpha=ci_alpha,
-                )
-            lines.append(
-                ax.plot(
-                    xvar,
-                    data[con_idx],
-                    picker=interactive,
-                    zorder=z + 1,
-                    color=con_colors[unmasked_idx + base_color_idx],
-                    alpha=line_alpha,
-                    linewidth=linewidth,
-                )[0]
+    for con_idx, z in enumerate(z_ord):
+        if ci is not None:
+            ax.fill_between(
+                xvar,
+                ci[con_idx, :, 0],
+                ci[con_idx, :, 1],
+                zorder=z + 1,
+                color=con_colors[con_idx],
+                edgecolor=None,
+                alpha=ci_alpha,
             )
-            lines[-1].set_pickradius(3.0)
-            unmasked_idx += 1
-
-    _plot_connections()
-    if duplicate_cons:
-        _plot_connections(mask=~diag_mask, base_color_idx=n_cons)
+        lines.append(
+            ax.plot(
+                xvar,
+                data[con_idx],
+                picker=interactive,
+                zorder=z + 1,
+                color=con_colors[con_idx],
+                alpha=line_alpha,
+                linewidth=linewidth,
+            )[0]
+        )
+        lines[-1].set_pickradius(3.0)
 
     ax.set_xlim(xvar[0], xvar[-1])
 

--- a/mne_connectivity/viz/line.py
+++ b/mne_connectivity/viz/line.py
@@ -262,7 +262,6 @@ def _plot_line_connectivity(
 
     con_types = con_info["temp"]["con_types"]
     figs = []
-    axes = []
     for con_type in np.unique(con_types):
         # Prepare connectivity info for plotting
         type_mask = con_types == con_type
@@ -421,13 +420,12 @@ def _plot_line_connectivity(
             )
 
         figs.append(fig)
-        axes.append((line_ax, circle_ax))
 
     plt_show(show)
 
     if len(figs) == 1:
-        return figs[0], axes[0]
-    return figs, axes
+        return figs[0]
+    return figs
 
 
 def _get_circle_names_and_indices(node_names, node_indices):

--- a/mne_connectivity/viz/line.py
+++ b/mne_connectivity/viz/line.py
@@ -227,9 +227,7 @@ def _plot_line_connectivity(
     ch_names = con.names
     con_method = con.method if con.method is not None else "connectivity"
     ch_info = _check_info(info, ch_names)
-    data, indices, is_multivar, _, is_symmetric, _ = _handle_data_and_indices(
-        con, ch_info
-    )
+    data, indices, is_multivar, is_symmetric, _ = _handle_data_and_indices(con, ch_info)
 
     # Get info about nodes and connections
     node_names, node_indices = _get_node_names_and_indices(

--- a/mne_connectivity/viz/line.py
+++ b/mne_connectivity/viz/line.py
@@ -66,12 +66,12 @@ def plot_spectral_connectivity(
 
     Returns
     -------
-    %(viz_figures)s
+    %(viz_figures_line)s
 
     Notes
     -----
     %(viz_circle_line_note)s
-    %(viz_components_note)s
+    %(viz_components_extra_con_note)s
     """
     from mne_connectivity import SpectralConnectivity
 
@@ -138,12 +138,12 @@ def plot_temporal_connectivity(
 
     Returns
     -------
-    %(viz_figures)s
+    %(viz_figures_line)s
 
     Notes
     -----
     %(viz_circle_line_note)s
-    %(viz_components_note)s
+    %(viz_components_extra_con_note)s
     """
     from mne_connectivity import TemporalConnectivity
 

--- a/mne_connectivity/viz/matrix.py
+++ b/mne_connectivity/viz/matrix.py
@@ -1,0 +1,254 @@
+from weakref import WeakKeyDictionary
+
+import mne
+import numpy as np
+from matplotlib import pyplot as plt
+from matplotlib.colors import Normalize
+from matplotlib.ticker import MaxNLocator
+from mne._fiff.pick import pick_info
+from mne.utils.check import _check_option, _validate_type
+from mne.viz.utils import _plot_masked_image, plt_show
+
+from ..utils import fill_doc
+from .helpers import (
+    _add_comps_as_connections,
+    _check_data_is_real,
+    _check_info,
+    _get_con_info,
+    _get_node_names_and_indices,
+    _handle_data_and_indices,
+    _handle_picks,
+    _setup_cmap,
+    _setup_vmin_vmax,
+)
+
+
+@fill_doc
+def plot_connectivity(
+    con,
+    *,
+    info=None,
+    picks=None,
+    selection="both",
+    exclude="bads",
+    node_aliases=None,
+    vmin=None,
+    vmax=None,
+    cnorm=None,
+    cmap=None,
+    colorbar=True,
+    node_labels="ticks",
+    mask=None,
+    mask_style=None,
+    mask_cmap="Greys",
+    mask_alpha=0.1,
+    show=True,
+):
+    """Plot connectivity as a matrix.
+
+    Parameters
+    ----------
+    con : ~mne_connectivity.Connectivity
+        The connectivity object to plot.
+    %(viz_info)s
+    %(viz_picks)s
+    %(viz_selection)s
+    %(viz_exclude)s
+    %(viz_node_aliases)s
+    %(viz_vmin_vmax)s
+    %(viz_cnorm)s
+    %(viz_cmap)s
+    %(viz_cbar)s
+    %(viz_node_labels_matrix)s
+    %(viz_mask)s
+    %(viz_mask_style)s
+    %(viz_mask_cmap)s
+    %(viz_mask_alpha)s
+    %(viz_show)s
+
+    Returns
+    -------
+    %(viz_figures)s
+
+    Notes
+    -----
+    %(viz_components_note)s
+    """
+    from mne_connectivity import Connectivity
+
+    _validate_type(con, Connectivity, "con", "Connectivity")
+
+    _check_data_is_real(con.get_data())
+
+    _check_option("con.shape", len(con.shape), [1, 2], " length")
+
+    _check_option("selection", selection, ["both", "seeds", "targets"])
+
+    _validate_type(info, (mne.Info, None), "`info`", "mne.Info or None")
+
+    _check_option("node_labels", node_labels, ["names", "ticks", None])
+
+    ch_names = con.names
+    con_method = con.method if con.method is not None else "connectivity"
+    ch_info = _check_info(info, ch_names)
+    data, indices, is_multivar = _handle_data_and_indices(con, ch_info)
+
+    # Get info about nodes and connections
+    node_names, node_indices = _get_node_names_and_indices(
+        ch_names, node_aliases, indices, is_multivar
+    )
+    con_info = _get_con_info(ch_info, node_names, indices, node_indices, is_multivar)
+
+    # Get requested connections
+    picks = _handle_picks(picks, exclude, ch_info, indices, is_multivar, selection)
+    data = data[picks]
+    indices = (indices[0][picks], indices[1][picks])
+    node_indices = (node_indices[0][picks], node_indices[1][picks])
+    con_info = pick_info(con_info, picks)
+    con_info["temp"]["con_types"] = con_info["temp"]["con_types"][picks]
+
+    # Add multivariate components as additional connections
+    if is_multivar:
+        data, con_info, node_indices, _ = _add_comps_as_connections(
+            data, con_info, node_indices, comps_axis=1
+        )
+
+    con_types = con_info["temp"]["con_types"]
+    figs = []
+    for con_type in np.unique(con_types):
+        # Prepare connectivity info for plotting
+        type_mask = con_types == con_type
+        type_node_indices = tuple(idcs[type_mask] for idcs in node_indices)
+        type_node_indices_unique = np.unique(type_node_indices)
+        type_node_names = [node_names[idx] for idx in type_node_indices_unique]
+        type_n_nodes = type_node_indices_unique.size
+        type_node_pos = {
+            node_idx: pos for pos, node_idx in enumerate(type_node_indices_unique)
+        }
+
+        # Make data square for plotting
+        square_matrix = np.full((type_n_nodes, type_n_nodes), fill_value=np.nan)
+        for idx, (seed_idx, target_idx) in enumerate(zip(*type_node_indices)):
+            square_matrix[type_node_pos[seed_idx], type_node_pos[target_idx]] = data[
+                idx
+            ]
+
+        # Colormap handling
+        vmin, vmax = _setup_vmin_vmax(data=square_matrix, vmin=vmin, vmax=vmax)
+        cmap = _setup_cmap(cmap=cmap, vmin=vmin, vmax=vmax)
+        if cnorm is None:
+            cnorm = Normalize(vmin=vmin, vmax=vmax)
+
+        # Create figure and axis
+        fig, ax = plt.subplots(
+            1, 1, figsize=(6, 6), facecolor="w", layout="constrained"
+        )
+
+        img, _ = _plot_masked_image(
+            ax=ax,
+            data=square_matrix,
+            times=np.arange(square_matrix.shape[1]),
+            yvals=np.arange(square_matrix.shape[0]),
+            cmap=cmap,
+            vmin=vmin,
+            vmax=vmax,
+            mask=mask,
+            mask_style=mask_style,
+            mask_alpha=mask_alpha,
+            mask_cmap=mask_cmap,
+            yscale="linear",
+            cnorm=cnorm,
+        )
+        ax.set_box_aspect(1)
+        if colorbar:
+            cbar = fig.colorbar(img, ax=ax, shrink=0.6, label="Connectivity (A.U.)")
+            cbar.ax.set_zorder(ax.get_zorder() - 1)
+
+        ax.set_title(f"{con_type} | {con_method}")
+        ax.set_xlabel("Targets")
+        ax.set_ylabel("Seeds")
+        if node_labels == "names":
+            ax.set_xticks(np.arange(type_n_nodes))
+            ax.set_yticks(np.arange(type_n_nodes))
+            ax.set_xticklabels(type_node_names, rotation=45)
+            ax.set_yticklabels(type_node_names)
+        if node_labels is None:
+            ax.set_xticks([])
+            ax.set_yticks([])
+        else:  # node_labels == "ticks"
+            ax.xaxis.set_major_locator(MaxNLocator(integer=True))
+            ax.yaxis.set_major_locator(MaxNLocator(integer=True))
+
+        ax.set_xlim(type_node_indices[1].min() - 0.5, type_node_indices[1].max() + 0.5)
+        ax.set_ylim(type_node_indices[0].max() + 0.5, type_node_indices[0].min() - 0.5)
+
+        def callback(event, ax=ax, fig=fig, node_names=type_node_names):
+            _plot_connectivity_matrix_onclick(event, ax, fig, node_names)
+
+        fig.canvas.mpl_connect("button_press_event", callback)
+
+        figs.append(fig)
+
+    plt_show(show)
+
+    if len(figs) == 1:
+        return figs[0]
+    return figs
+
+
+_MATRIX_ANNOTATIONS = WeakKeyDictionary()
+
+
+def _plot_connectivity_matrix_onclick(event, ax, fig, node_names):
+    """Annotate the clicked matrix cell with the corresponding channel names."""
+    if event.inaxes is not ax or event.xdata is None or event.ydata is None:
+        return
+
+    if event.button == 3:  # right-click to remove annotation
+        prev_annot = _MATRIX_ANNOTATIONS.get(ax)
+        if prev_annot is not None:
+            prev_annot[0].remove()
+            prev_annot[1].remove()
+            _MATRIX_ANNOTATIONS[ax] = None
+            fig.canvas.draw_idle()
+        return
+
+    col = int(np.floor(event.xdata + 0.5))
+    row = int(np.floor(event.ydata + 0.5))
+    if row < 0 or row >= len(node_names) or col < 0 or col >= len(node_names):
+        return
+
+    prev_annot = _MATRIX_ANNOTATIONS.get(ax)
+    if prev_annot is not None:
+        prev_annot[0].remove()
+        prev_annot[1].remove()
+        _MATRIX_ANNOTATIONS[ax] = None
+        fig.canvas.draw_idle()
+
+    annotation = ax.text(
+        col + 0.25,
+        row - 0.25,
+        f"{node_names[row]}\n~\n{node_names[col]}",
+        ha="left",
+        va="bottom",
+        color="white",
+        fontsize=8,
+        fontweight="bold",
+        bbox=dict(facecolor="black", alpha=0.6, edgecolor="none", boxstyle="round"),
+    )
+    annotation.set_in_layout(False)
+    annotation.set_zorder(10)
+
+    # Highlight the selected cell with a border
+    rect = plt.Rectangle(
+        (col - 0.5, row - 0.5),
+        1,
+        1,
+        linewidth=2,
+        edgecolor="k",
+        facecolor="none",
+    )
+    ax.add_patch(rect)
+
+    _MATRIX_ANNOTATIONS[ax] = (annotation, rect)
+    fig.canvas.draw_idle()

--- a/mne_connectivity/viz/matrix.py
+++ b/mne_connectivity/viz/matrix.py
@@ -90,7 +90,7 @@ def plot_connectivity(
     ch_names = con.names
     con_method = con.method if con.method is not None else "connectivity"
     ch_info = _check_info(info, ch_names)
-    data, indices, is_multivar, is_symmetric, has_diagonal = _handle_data_and_indices(
+    data, indices, is_multivar, _, duplicate_cons_mask = _handle_data_and_indices(
         con, ch_info
     )
 
@@ -113,6 +113,7 @@ def plot_connectivity(
     data = data[picks]
     indices = (indices[0][picks], indices[1][picks])
     node_indices = (node_indices[0][picks], node_indices[1][picks])
+    duplicate_cons_mask = duplicate_cons_mask[picks]
     con_info = pick_info(con_info, picks)
     con_info["temp"]["con_types"] = con_info["temp"]["con_types"][picks]
 
@@ -129,6 +130,10 @@ def plot_connectivity(
             node_idx: pos for pos, node_idx in enumerate(type_node_indices_unique)
         }
 
+        type_duplicate_cons_mask = duplicate_cons_mask[type_mask]
+        if all(type_duplicate_cons_mask):
+            continue  # skip if all connections for this type are duplicates
+
         # Colormap handling
         vmin, vmax = _setup_vmin_vmax(data=data, vmin=vmin, vmax=vmax)
         cmap = _setup_cmap(cmap=cmap, vmin=vmin, vmax=vmax)
@@ -143,13 +148,6 @@ def plot_connectivity(
                 square_matrix[type_node_pos[seed_idx], type_node_pos[target_idx]] = (
                     data[con_idx, comp_idx]
                 )
-            if is_symmetric:
-                stacked_matrix = np.dstack((square_matrix, square_matrix.T))
-                square_matrix = np.nansum(stacked_matrix, axis=-1)
-                # namsum sets nan + nan = 0, so we set those cases back to nan
-                square_matrix[np.isnan(stacked_matrix).all(axis=-1)] = np.nan
-                if has_diagonal:
-                    square_matrix[np.diag_indices_from(square_matrix)] *= 0.5
 
             # Create figure and axis
             fig, ax = plt.subplots(

--- a/mne_connectivity/viz/matrix.py
+++ b/mne_connectivity/viz/matrix.py
@@ -128,8 +128,12 @@ def plot_connectivity(
         type_node_pos = {
             node_idx: pos for pos, node_idx in enumerate(type_node_indices_unique)
         }
-        if data.ndim == 1:
-            data = data[:, np.newaxis]  # give non-multivar data a dummy comps dim
+
+        # Colormap handling
+        vmin, vmax = _setup_vmin_vmax(data=data, vmin=vmin, vmax=vmax)
+        cmap = _setup_cmap(cmap=cmap, vmin=vmin, vmax=vmax)
+        if cnorm is None:
+            cnorm = Normalize(vmin=vmin, vmax=vmax)
 
         # Plot data for each component separately
         for comp_idx in range(data.shape[1]):
@@ -146,12 +150,6 @@ def plot_connectivity(
                 square_matrix[np.isnan(stacked_matrix).all(axis=-1)] = np.nan
                 if has_diagonal:
                     square_matrix[np.diag_indices_from(square_matrix)] *= 0.5
-
-            # Colormap handling
-            vmin, vmax = _setup_vmin_vmax(data=square_matrix, vmin=vmin, vmax=vmax)
-            cmap = _setup_cmap(cmap=cmap, vmin=vmin, vmax=vmax)
-            if cnorm is None:
-                cnorm = Normalize(vmin=vmin, vmax=vmax)
 
             # Create figure and axis
             fig, ax = plt.subplots(

--- a/mne_connectivity/viz/matrix.py
+++ b/mne_connectivity/viz/matrix.py
@@ -95,6 +95,14 @@ def plot_connectivity(
         con, ch_info
     )
 
+    # Handle instances of multiple components in multivariate data
+    if data.ndim == 1:
+        n_comps = components = None
+        data = data[:, np.newaxis]  # give a dummy components dimension
+    else:
+        n_comps = data.shape[1]
+        components = con.coords["components"].data
+
     # Get info about nodes and connections
     node_names, node_indices = _get_node_names_and_indices(
         ch_names, node_aliases, indices, is_multivar
@@ -109,12 +117,6 @@ def plot_connectivity(
     con_info = pick_info(con_info, picks)
     con_info["temp"]["con_types"] = con_info["temp"]["con_types"][picks]
 
-    # Add multivariate components as additional connections
-    if is_multivar:
-        data, con_info, node_indices, _ = _add_comps_as_connections(
-            data, con_info, node_indices, comps_axis=1
-        )
-
     con_types = con_info["temp"]["con_types"]
     figs = []
     for con_type in np.unique(con_types):
@@ -127,77 +129,84 @@ def plot_connectivity(
         type_node_pos = {
             node_idx: pos for pos, node_idx in enumerate(type_node_indices_unique)
         }
+        if data.ndim == 1:
+            data = data[:, np.newaxis]  # give non-multivar data a dummy comps dim
 
-        # Make data square for plotting
-        square_matrix = np.full((type_n_nodes, type_n_nodes), np.nan)
-        for idx, (seed_idx, target_idx) in enumerate(zip(*type_node_indices)):
-            square_matrix[type_node_pos[seed_idx], type_node_pos[target_idx]] = data[
-                idx
-            ]
-        if is_symmetric:
-            stacked_matrix = np.dstack((square_matrix, square_matrix.T))
-            square_matrix = np.nansum(stacked_matrix, axis=-1)
-            # namsum sets nan + nan = 0, so we set those cases back to nan
-            square_matrix[np.isnan(stacked_matrix).all(axis=-1)] = np.nan
-            if has_diagonal:
-                square_matrix[np.diag_indices_from(square_matrix)] *= 0.5
+        # Plot data for each component separately
+        for comp_idx in range(data.shape[1]):
+            # Make data square for plotting
+            square_matrix = np.full((type_n_nodes, type_n_nodes), np.nan)
+            for con_idx, (seed_idx, target_idx) in enumerate(zip(*type_node_indices)):
+                square_matrix[type_node_pos[seed_idx], type_node_pos[target_idx]] = (
+                    data[con_idx, comp_idx]
+                )
+            if is_symmetric:
+                stacked_matrix = np.dstack((square_matrix, square_matrix.T))
+                square_matrix = np.nansum(stacked_matrix, axis=-1)
+                # namsum sets nan + nan = 0, so we set those cases back to nan
+                square_matrix[np.isnan(stacked_matrix).all(axis=-1)] = np.nan
+                if has_diagonal:
+                    square_matrix[np.diag_indices_from(square_matrix)] *= 0.5
 
-        # Colormap handling
-        vmin, vmax = _setup_vmin_vmax(data=square_matrix, vmin=vmin, vmax=vmax)
-        cmap = _setup_cmap(cmap=cmap, vmin=vmin, vmax=vmax)
-        if cnorm is None:
-            cnorm = Normalize(vmin=vmin, vmax=vmax)
+            # Colormap handling
+            vmin, vmax = _setup_vmin_vmax(data=square_matrix, vmin=vmin, vmax=vmax)
+            cmap = _setup_cmap(cmap=cmap, vmin=vmin, vmax=vmax)
+            if cnorm is None:
+                cnorm = Normalize(vmin=vmin, vmax=vmax)
 
-        # Create figure and axis
-        fig, ax = plt.subplots(
-            1, 1, figsize=(6, 6), facecolor="w", layout="constrained"
-        )
+            # Create figure and axis
+            fig, ax = plt.subplots(
+                1, 1, figsize=(6, 6), facecolor="w", layout="constrained"
+            )
 
-        min_node_idx = min(type_node_indices[0].min(), type_node_indices[1].min())
-        max_node_idx = max(type_node_indices[0].max(), type_node_indices[1].max())
-        img, _ = _plot_masked_image(
-            ax=ax,
-            data=square_matrix,
-            times=np.arange(min_node_idx, max_node_idx + 1),
-            yvals=np.arange(min_node_idx, max_node_idx + 1),
-            cmap=cmap,
-            vmin=vmin,
-            vmax=vmax,
-            mask=mask,
-            mask_style=mask_style,
-            mask_alpha=mask_alpha,
-            mask_cmap=mask_cmap,
-            yscale="linear",
-            cnorm=cnorm,
-        )
-        ax.set_box_aspect(1)
-        if colorbar:
-            cbar = fig.colorbar(img, ax=ax, shrink=0.6, label="Connectivity (A.U.)")
-            cbar.ax.set_zorder(ax.get_zorder() - 1)
+            min_node_idx = min(type_node_indices[0].min(), type_node_indices[1].min())
+            max_node_idx = max(type_node_indices[0].max(), type_node_indices[1].max())
+            img, _ = _plot_masked_image(
+                ax=ax,
+                data=square_matrix,
+                times=np.arange(min_node_idx, max_node_idx + 1),
+                yvals=np.arange(min_node_idx, max_node_idx + 1),
+                cmap=cmap,
+                vmin=vmin,
+                vmax=vmax,
+                mask=mask,
+                mask_style=mask_style,
+                mask_alpha=mask_alpha,
+                mask_cmap=mask_cmap,
+                yscale="linear",
+                cnorm=cnorm,
+            )
+            ax.set_box_aspect(1)
+            if colorbar:
+                cbar = fig.colorbar(img, ax=ax, shrink=0.6, label="Connectivity (A.U.)")
+                cbar.ax.set_zorder(ax.get_zorder() - 1)
 
-        ax.set_title(f"{con_type} | {con_method}")
-        ax.set_xlabel("Targets")
-        ax.set_ylabel("Seeds")
-        if node_labels == "names":
-            ax.set_xticks(np.arange(type_n_nodes))
-            ax.set_yticks(np.arange(type_n_nodes))
-            ax.set_xticklabels(type_node_names, rotation=45)
-            ax.set_yticklabels(type_node_names)
-        if node_labels is None:
-            ax.set_xticks([])
-            ax.set_yticks([])
-        else:  # node_labels == "ticks"
-            ax.xaxis.set_major_locator(MaxNLocator(integer=True))
-            ax.yaxis.set_major_locator(MaxNLocator(integer=True))
-        ax.set_xlim(min_node_idx - 0.5, max_node_idx + 0.5)
-        ax.set_ylim(max_node_idx + 0.5, min_node_idx - 0.5)
+            title = f"{con_type} | {con_method}"
+            if n_comps is not None:
+                title += f" | Component {components[comp_idx]}"
+            ax.set_title(title)
+            ax.set_xlabel("Targets")
+            ax.set_ylabel("Seeds")
+            if node_labels == "names":
+                ax.set_xticks(np.arange(type_n_nodes))
+                ax.set_yticks(np.arange(type_n_nodes))
+                ax.set_xticklabels(type_node_names, rotation=45)
+                ax.set_yticklabels(type_node_names)
+            if node_labels is None:
+                ax.set_xticks([])
+                ax.set_yticks([])
+            else:  # node_labels == "ticks"
+                ax.xaxis.set_major_locator(MaxNLocator(integer=True))
+                ax.yaxis.set_major_locator(MaxNLocator(integer=True))
+            ax.set_xlim(min_node_idx - 0.5, max_node_idx + 0.5)
+            ax.set_ylim(max_node_idx + 0.5, min_node_idx - 0.5)
 
-        def callback(event, ax=ax, fig=fig, node_names=type_node_names):
-            _plot_connectivity_matrix_onclick(event, ax, fig, node_names)
+            def callback(event, ax=ax, fig=fig, node_names=type_node_names):
+                _plot_connectivity_matrix_onclick(event, ax, fig, node_names)
 
-        fig.canvas.mpl_connect("button_press_event", callback)
+            fig.canvas.mpl_connect("button_press_event", callback)
 
-        figs.append(fig)
+            figs.append(fig)
 
     plt_show(show)
 

--- a/mne_connectivity/viz/matrix.py
+++ b/mne_connectivity/viz/matrix.py
@@ -78,7 +78,7 @@ def plot_connectivity(
 
     _validate_type(con, Connectivity, "con", "Connectivity")
 
-    _check_data_is_real(con.get_data())
+    _check_data_is_real(con.get_data("raveled"))
 
     _check_option("con.shape", len(con.shape), [1, 2], " length")
 
@@ -91,7 +91,9 @@ def plot_connectivity(
     ch_names = con.names
     con_method = con.method if con.method is not None else "connectivity"
     ch_info = _check_info(info, ch_names)
-    data, indices, is_multivar = _handle_data_and_indices(con, ch_info)
+    data, indices, is_multivar, is_symmetric, has_diagonal = _handle_data_and_indices(
+        con, ch_info
+    )
 
     # Get info about nodes and connections
     node_names, node_indices = _get_node_names_and_indices(
@@ -127,11 +129,18 @@ def plot_connectivity(
         }
 
         # Make data square for plotting
-        square_matrix = np.full((type_n_nodes, type_n_nodes), fill_value=np.nan)
+        square_matrix = np.full((type_n_nodes, type_n_nodes), np.nan)
         for idx, (seed_idx, target_idx) in enumerate(zip(*type_node_indices)):
             square_matrix[type_node_pos[seed_idx], type_node_pos[target_idx]] = data[
                 idx
             ]
+        if is_symmetric:
+            stacked_matrix = np.dstack((square_matrix, square_matrix.T))
+            square_matrix = np.nansum(stacked_matrix, axis=-1)
+            # namsum sets nan + nan = 0, so we set those cases back to nan
+            square_matrix[np.isnan(stacked_matrix).all(axis=-1)] = np.nan
+            if has_diagonal:
+                square_matrix[np.diag_indices_from(square_matrix)] *= 0.5
 
         # Colormap handling
         vmin, vmax = _setup_vmin_vmax(data=square_matrix, vmin=vmin, vmax=vmax)
@@ -144,11 +153,13 @@ def plot_connectivity(
             1, 1, figsize=(6, 6), facecolor="w", layout="constrained"
         )
 
+        min_node_idx = min(type_node_indices[0].min(), type_node_indices[1].min())
+        max_node_idx = max(type_node_indices[0].max(), type_node_indices[1].max())
         img, _ = _plot_masked_image(
             ax=ax,
             data=square_matrix,
-            times=np.arange(square_matrix.shape[1]),
-            yvals=np.arange(square_matrix.shape[0]),
+            times=np.arange(min_node_idx, max_node_idx + 1),
+            yvals=np.arange(min_node_idx, max_node_idx + 1),
             cmap=cmap,
             vmin=vmin,
             vmax=vmax,
@@ -178,9 +189,8 @@ def plot_connectivity(
         else:  # node_labels == "ticks"
             ax.xaxis.set_major_locator(MaxNLocator(integer=True))
             ax.yaxis.set_major_locator(MaxNLocator(integer=True))
-
-        ax.set_xlim(type_node_indices[1].min() - 0.5, type_node_indices[1].max() + 0.5)
-        ax.set_ylim(type_node_indices[0].max() + 0.5, type_node_indices[0].min() - 0.5)
+        ax.set_xlim(min_node_idx - 0.5, max_node_idx + 0.5)
+        ax.set_ylim(max_node_idx + 0.5, min_node_idx - 0.5)
 
         def callback(event, ax=ax, fig=fig, node_names=type_node_names):
             _plot_connectivity_matrix_onclick(event, ax, fig, node_names)

--- a/mne_connectivity/viz/matrix.py
+++ b/mne_connectivity/viz/matrix.py
@@ -11,7 +11,6 @@ from mne.viz.utils import _plot_masked_image, plt_show
 
 from ..utils import fill_doc
 from .helpers import (
-    _add_comps_as_connections,
     _check_data_is_real,
     _check_info,
     _get_con_info,
@@ -68,11 +67,11 @@ def plot_connectivity(
 
     Returns
     -------
-    %(viz_figures)s
+    %(viz_figures_matrix)s
 
     Notes
     -----
-    %(viz_components_note)s
+    %(viz_components_extra_fig_note)s
     """
     from mne_connectivity import Connectivity
 

--- a/mne_connectivity/viz/tests/test_plotting.py
+++ b/mne_connectivity/viz/tests/test_plotting.py
@@ -1,0 +1,435 @@
+# Authors: The MNE-Connectivity developers.
+#
+# License: BSD-3-Clause
+
+import mne
+import numpy as np
+import pytest
+from matplotlib.colors import LogNorm
+from mne.viz.utils import _fake_click
+from numpy.testing import assert_allclose
+
+from mne_connectivity import (
+    Connectivity,
+    SpectralConnectivity,
+    SpectroTemporalConnectivity,
+    TemporalConnectivity,
+    plot_connectivity,
+    plot_spectral_connectivity,
+    plot_spectrotemporal_connectivity,
+    plot_temporal_connectivity,
+    seed_target_multivariate_indices,
+)
+
+N_NODES, N_FREQS, N_TIMES = 4, 5, 3
+FREQS = np.arange(5.0, 5.0 + N_FREQS)
+TIMES = np.arange(N_TIMES) / 10.0
+# kind -> (plot function, class, extra positional args, per-connection data shape)
+PLOTTERS = dict(
+    matrix=(plot_connectivity, Connectivity, (), ()),
+    spectral=(plot_spectral_connectivity, SpectralConnectivity, (FREQS,), (N_FREQS,)),
+    temporal=(plot_temporal_connectivity, TemporalConnectivity, (TIMES,), (N_TIMES,)),
+    spectrotemporal=(
+        plot_spectrotemporal_connectivity,
+        SpectroTemporalConnectivity,
+        (FREQS, TIMES),
+        (N_FREQS, N_TIMES),
+    ),
+)
+# kwargs cropping the data, and the resulting x-axis limits, per kind
+CROP = dict(
+    spectral=(dict(fmin=6.0, fmax=8.0), (6.0, 8.0)),
+    temporal=(dict(tmin=0.0, tmax=0.1), (0.0, 0.1)),
+)
+N_CONS = N_NODES * (N_NODES - 1) // 2  # all-to-all is lower-triangular
+LINE_KINDS = ("spectral", "temporal")
+
+
+def make_con(kind, *, indices="all", n_comps=None, n_nodes=N_NODES, names=None):
+    """Create a connectivity object of the requested kind, with random data."""
+    _, klass, args, dims = PLOTTERS[kind]
+    n_cons = n_nodes**2 if isinstance(indices, str) else len(indices[0])
+    comps = () if n_comps is None else (n_comps,)
+    data = np.random.default_rng(44).random((n_cons, *comps, *dims))
+    kwargs = dict() if n_comps is None else dict(components=np.arange(n_comps))
+    if names is None:
+        names = [f"ch{ii}" for ii in range(n_nodes)]
+    return klass(
+        data, *args, n_nodes=n_nodes, names=names, indices=indices, method="coh",
+        **kwargs,
+    )  # fmt: skip
+
+
+def click_node(fig, circle_ax, node, n_nodes, button=1):
+    """Left/right click on a node of the circle plot."""
+    # nodes sit at radius 9-10; offset the angle slightly so that the click never
+    # lands exactly on the seam of the polar axes patch (where it is not contained)
+    angle = 2 * np.pi * node / n_nodes + 0.05
+    _fake_click(fig, circle_ax, (angle, 9.5), xform="data", button=button)
+
+
+def unpack(out, kind):
+    """Return the figures and the (line/image) axes of a plotting call as lists."""
+    figs, axes = (out, None) if kind == "matrix" else out
+    if not isinstance(figs, list):
+        figs, axes = [figs], [axes]
+    if kind == "matrix":
+        axes = [fig.axes[0] for fig in figs]
+    elif kind in LINE_KINDS:
+        axes = [line_ax for line_ax, _ in axes]
+    return figs, axes
+
+
+def visible(ax):
+    """Return the visibility of every line in an axes."""
+    return [line.get_visible() for line in ax.lines]
+
+
+@pytest.fixture
+def info():
+    """Return an info with two channel types (2 EEG, 2 grad) and no bads."""
+    return mne.create_info(
+        ["e0", "e1", "g0", "g1"], 100.0, ["eeg", "eeg", "grad", "grad"]
+    )
+
+
+def test_plot_connectivity_matrix_options():
+    """Test the colormap, colorbar, and masking options of the matrix plot."""
+    con = make_con("matrix")
+    # only the lower triangle of the all-to-all data is plotted
+    data = con.get_data("dense")[np.tril_indices(N_NODES, -1)]
+    lo, hi = data.min(), data.max()
+    mixed = np.abs(data - 0.5).max()
+    raveled = con.get_data("raveled")
+
+    def remake(values):  # a copy of `con` with different data
+        return Connectivity(values, n_nodes=N_NODES, names=con.names, method="coh")
+
+    for this_con, kwargs, clim, cmap in (
+        (con, dict(), (lo, hi), "Reds"),  # all-positive data spans its own limits
+        (con, dict(vmin=0.2, vmax=0.8, cmap="viridis"), (0.2, 0.8), "viridis"),
+        (con, dict(vmin=np.min, vmax=np.max), (lo, hi), "Reds"),  # callable bounds
+        (con, dict(vmin=0.2), (0.2, hi), "Reds"),  # a missing bound falls back
+        (con, dict(vmax=0.8), (lo, 0.8), "Reds"),
+        (remake(-raveled), dict(), (-hi, -lo), "Blues_r"),  # all-negative data
+        (remake(raveled - 0.5), dict(), (-mixed, mixed), "RdBu_r"),  # symmetric
+    ):
+        img = plot_connectivity(this_con, show=False, **kwargs).axes[0].images[0]
+        assert (img.get_clim(), img.cmap.name) == (clim, cmap), kwargs
+
+    fig = plot_connectivity(con, show=False)
+    fig.canvas.draw()
+    ax = fig.axes[0]
+    assert ax.get_title() == "misc ~ misc | coh"
+    assert (ax.get_xlabel(), ax.get_ylabel()) == ("Targets", "Seeds")
+    # only the lower triangle is filled, so the empty row/column is cropped away
+    assert ax.get_xlim() == (-0.5, N_NODES - 1.5)
+    assert ax.get_ylim() == (N_NODES - 0.5, 0.5)
+
+    # nodes are labelled by name, by tick index, or not at all
+    for node_labels, expected in (("names", con.names), ("ticks", ["0"]), (None, [])):
+        fig = plot_connectivity(con, node_labels=node_labels, show=False)
+        fig.canvas.draw()
+        labels = [text.get_text() for text in fig.axes[0].get_yticklabels()]
+        assert set(expected) <= set(labels)
+        assert (labels == []) == (node_labels is None)
+
+    # the colorbar can be turned off, and an explicit normalization wins
+    assert len(plot_connectivity(con, colorbar=False, show=False).axes) == 1
+    cnorm = LogNorm(vmin=0.1, vmax=1.0)
+    fig = plot_connectivity(con, cnorm=cnorm, show=False)
+    assert fig.axes[0].images[0].norm is cnorm
+
+    # masking
+    mask = np.zeros((N_NODES, N_NODES), dtype=bool)
+    mask[np.tril_indices(N_NODES, -2)] = True
+    ax = plot_connectivity(con, mask=mask, mask_style="both", show=False).axes[0]
+    assert len(ax.images) == 2  # masked and unmasked images
+    assert len(ax.collections) > 0  # contour around the mask
+
+
+def test_plot_connectivity_matrix_click():
+    """Test clicking cells of the matrix plot to annotate them."""
+    con = make_con("matrix")
+    fig = plot_connectivity(con, show=False)
+    fig.canvas.draw()
+    ax = fig.axes[0]
+    assert len(ax.texts) == 0
+
+    _fake_click(fig, ax, (1.0, 2.0), xform="data")
+    assert [text.get_text() for text in ax.texts] == ["ch2\n~\nch1"]
+    assert len(ax.patches) == 1  # cell highlighted with a rectangle
+
+    # clicking another cell replaces the previous annotation
+    _fake_click(fig, ax, (0.0, 3.0), xform="data")
+    assert [text.get_text() for text in ax.texts] == ["ch3\n~\nch0"]
+    assert len(ax.patches) == 1
+
+    # right-clicking clears it (twice is a no-op)
+    for _ in range(2):
+        _fake_click(fig, ax, (0.0, 3.0), xform="data", button=3)
+        assert len(ax.texts) == 0 and len(ax.patches) == 0
+
+    # clicks outside the axes or outside the matrix are ignored
+    _fake_click(fig, fig.axes[1], (0.5, 0.5))
+    _fake_click(fig, ax, (N_NODES + 1.0, 0.0), xform="data")
+    assert len(ax.texts) == 0
+
+
+@pytest.mark.parametrize("kind", LINE_KINDS)
+def test_plot_line_connectivity(kind):
+    """Test plotting connectivity as lines with a circle plot overview."""
+    plot_func = PLOTTERS[kind][0]
+    con = make_con(kind)
+    xvar = con.freqs if kind == "spectral" else con.times
+    xlabel = "Frequency (Hz)" if kind == "spectral" else "Time (s)"
+
+    fig, (line_ax, circle_ax) = plot_func(con, show=False)
+    assert (line_ax.get_xlabel(), line_ax.get_ylabel()) == (
+        xlabel,
+        "Connectivity (A.U.)",
+    )
+    assert line_ax.get_title() == "misc ~ misc | coh"
+    assert circle_ax.get_title() == "Node selection\n(seeds and targets)"
+    # all-to-all data are duplicated so that every node acts as a seed, but the
+    # duplicates start out hidden
+    assert visible(line_ax) == [True] * N_CONS + [False] * N_CONS
+    assert line_ax.get_xlim() == (xvar[0], xvar[-1])
+
+    # cropping the x axis
+    crop_kwargs, xlim = CROP[kind]
+    _, (line_ax, _) = plot_func(con, show=False, **crop_kwargs)
+    assert line_ax.get_xlim() == xlim
+
+    # highlighting, both as a single (start, stop) pair and as several
+    for highlight, n_extra in (((xvar[0], xvar[1]), 1), ([xvar[:2], xvar[-2:]], 2)):
+        _, (line_ax, _) = plot_func(con, highlight=highlight, show=False)
+        assert len(line_ax.collections) == n_extra
+
+    # without interactivity the connections are neither duplicated nor pickable
+    _, (line_ax, circle_ax) = plot_func(con, interactive=False, show=False)
+    assert circle_ax.get_title() == "Nodes"
+    assert visible(line_ax) == [True] * N_CONS
+    assert not any(line.get_picker() for line in line_ax.lines)
+
+
+@pytest.mark.parametrize("kind", LINE_KINDS)
+@pytest.mark.parametrize("ci", ("sd", "range", 95.0, None))
+def test_plot_line_connectivity_combine(kind, ci):
+    """Test aggregating connections in the line plots."""
+    plot_func = PLOTTERS[kind][0]
+    con = make_con(kind)
+    data = con.get_data("dense")[np.tril_indices(N_NODES, -1)]
+
+    fig, (line_ax, circle_ax) = plot_func(con, combine="mean", ci=ci, show=False)
+    assert circle_ax is None  # a single (combined) connection needs no circle plot
+    assert len(line_ax.lines) == 1
+    assert_allclose(line_ax.lines[0].get_ydata(), data.mean(axis=0))
+    assert len(line_ax.collections) == (0 if ci is None else 1)
+
+    # a callable combine is used as-is
+    _, (line_ax, _) = plot_func(
+        con, combine=lambda x: np.max(x, axis=0), ci=None, show=False
+    )
+    assert_allclose(line_ax.lines[0].get_ydata(), data.max(axis=0))
+
+
+def test_plot_line_connectivity_interactive():
+    """Test selecting nodes in the circle plot and connections in the line plot."""
+    con = make_con("spectral")
+    fig, (line_ax, circle_ax) = plot_spectral_connectivity(con, show=False)
+    fig.canvas.draw()
+    seeds, targets = np.tril_indices(N_NODES, -1)
+    # connections are duplicated with the seeds and targets swapped, so that every
+    # node can be selected as a seed
+    dup_seeds = np.concatenate([seeds, targets])
+    start = visible(line_ax)
+
+    for node in range(N_NODES):
+        click_node(fig, circle_ax, node, N_NODES)
+        assert visible(line_ax) == list(dup_seeds == node), f"node {node}"
+        # the connection labels are hidden again on selection
+        assert all(text.get_alpha() == 0 for text in line_ax.texts)
+    click_node(fig, circle_ax, 0, N_NODES, button=3)  # right click resets
+    assert visible(line_ax) == start
+
+    # clicks away from the nodes, with another button, or outside the circle plot
+    # do nothing
+    _fake_click(fig, circle_ax, (0.05, 5.0), xform="data")
+    click_node(fig, circle_ax, 1, N_NODES, button=2)
+    _fake_click(fig, line_ax, (0.5, 0.5))
+    assert visible(line_ax) == start
+
+    # clicking a connection labels it, clicking elsewhere hides the label
+    line = line_ax.lines[0]
+    _fake_click(fig, line_ax, (line.get_xdata()[1], line.get_ydata()[1]), xform="data")
+    (text,) = line_ax.texts
+    assert (text.get_text(), text.get_alpha()) == ("ch1 ~ ch0", 1.0)
+    _fake_click(fig, line_ax, (line_ax.get_xlim()[0], line_ax.get_ylim()[1]), "data")
+    assert text.get_alpha() == 0.0
+
+
+@pytest.mark.parametrize(
+    "selection, unselectable, selected, n_selected",
+    [("seeds", "ch0", "ch2", 2), ("targets", "ch3", "ch2", 1)],
+)
+@pytest.mark.parametrize("colors", ("auto", "global", "relative"))
+def test_plot_line_connectivity_selection(
+    selection, unselectable, selected, n_selected, colors
+):
+    """Test restricting the plotted (and selectable) connections to picked channels."""
+    con = make_con("spectral")
+    fig, (line_ax, circle_ax) = plot_spectral_connectivity(
+        con, picks=["ch1", "ch2"], selection=selection, colors=colors,
+        cmap="viridis", show=False,
+    )  # fmt: skip
+    fig.canvas.draw()
+    assert len(line_ax.lines) == 3  # connections are duplicated only for "both"
+    node_names = [text.get_text() for text in circle_ax.texts]
+    assert len(node_names) == 3
+
+    # nodes that cannot act as the selected role are drawn faded out
+    alphas = [node.get_alpha() for node in circle_ax.containers[0]]
+    assert [name for name, alpha in zip(node_names, alphas) if alpha is not None] == [
+        unselectable
+    ]
+
+    # clicking a faded node does nothing; a selectable one isolates its connections
+    click_node(fig, circle_ax, node_names.index(unselectable), len(node_names))
+    assert visible(line_ax) == [True] * 3
+    click_node(fig, circle_ax, node_names.index(selected), len(node_names))
+    assert sum(visible(line_ax)) == n_selected
+
+
+def test_plot_spectrotemporal_connectivity():
+    """Test plotting spectro-temporal connectivity as images."""
+    con = make_con("spectrotemporal")
+    data = con.get_data("dense")[np.tril_indices(N_NODES, -1)]
+
+    # connections are averaged by default, giving one figure instead of one each
+    fig, ax = plot_spectrotemporal_connectivity(con, show=False)
+    assert (ax.get_xlabel(), ax.get_ylabel()) == ("Time (s)", "Frequency (Hz)")
+    assert ax.get_title() == f"misc ~ misc | combined nodes (n={N_CONS}) | coh"
+    assert_allclose(ax.images[0].get_array(), data.mean(axis=0))
+    figs, axes = plot_spectrotemporal_connectivity(con, combine=None, show=False)
+    assert len(figs) == len(axes) == N_CONS
+    assert axes[0].get_title() == "misc ~ misc | ch1 ~ ch0 | coh"
+
+    # cropping in time and frequency, masking, and a log-spaced frequency axis
+    mask = np.zeros((N_FREQS, N_TIMES), dtype=bool)
+    mask[1:, 1:] = True
+    _, ax = plot_spectrotemporal_connectivity(
+        con, fmin=6.0, fmax=8.0, tmin=0.0, tmax=0.1, mask=mask, mask_style="mask",
+        mask_cmap=None, colorbar=False, show=False,
+    )  # fmt: skip
+    assert ax.images[0].get_array().shape == (3, 2)  # cropped
+    assert len(ax.images) == 2 and len(ax.get_figure().axes) == 1  # masked, no cbar
+    _, ax = plot_spectrotemporal_connectivity(con, yscale="log", show=False)
+    assert ax.get_yscale() == "log"
+
+
+@pytest.mark.parametrize("kind", list(PLOTTERS))
+def test_plot_connectivity_channel_types(kind, info):
+    """Test splitting figures by channel type and dropping bad channels."""
+    plot_func = PLOTTERS[kind][0]
+    con = make_con(kind, names=info["ch_names"])
+
+    types = ["EEG ~ EEG", "Gradiometers ~ EEG", "Gradiometers ~ Gradiometers"]
+    figs, axes = unpack(plot_func(con, info=info, show=False), kind)
+    assert len(figs) == len(axes) == 3
+    assert [ax.get_title().split(" | ")[0] for ax in axes] == types
+
+    # dropping a bad EEG channel leaves only one EEG node, so no EEG ~ EEG figure
+    info["bads"] = ["e1"]
+    figs, axes = unpack(plot_func(con, info=info, show=False), kind)
+    assert len(figs) == len(axes) == 2
+    assert [ax.get_title().split(" | ")[0] for ax in axes] == types[1:]
+
+
+@pytest.mark.parametrize("kind", list(PLOTTERS))
+@pytest.mark.parametrize("form", ("dense", "ragged", "masked"))
+def test_plot_connectivity_multivariate(kind, form):
+    """Test plotting multivariate connectivity with components and node aliases."""
+    plot_func = PLOTTERS[kind][0]
+    aliases = {(0, 1): "left", (2, 3, 4): "right"}
+    if form == "dense":  # a single pair of equally sized nodes, in both directions
+        indices = (np.array([[0, 1], [2, 3]]), np.array([[2, 3], [0, 1]]))
+        aliases = {(0, 1): "left", (2, 3): "right"}
+    elif form == "ragged":  # nodes of unequal size, giving 2 x 2 = 4 connections
+        indices = seed_target_multivariate_indices(
+            [[0, 1], [2, 3, 4]], [[2, 3, 4], [0, 1]]
+        )
+    else:  # the same nodes, padded out into a rectangular masked array
+        indices = tuple(
+            np.ma.masked_values(idcs, -1)
+            for idcs in ([[0, 1, -1], [2, 3, 4]], [[2, 3, 4], [0, 1, -1]])
+        )
+    n_cons = len(indices[0])
+    con = make_con(kind, indices=indices, n_comps=2, n_nodes=5)
+
+    figs, axes = unpack(plot_func(con, node_aliases=aliases, show=False), kind)
+    if kind == "spectrotemporal":  # connections are combined per component
+        assert len(figs) == 2
+        title = f"misc ~ misc | combined nodes (0; n={n_cons}) | coh"
+        assert axes[0].get_title() == title
+        return
+    assert len(figs) == len(axes) == 1
+    if kind in LINE_KINDS:
+        # each component of each connection is drawn as its own line
+        assert len(axes[0].lines) == n_cons * 2
+        figs[0].canvas.draw()
+        _fake_click(figs[0], axes[0], axes[0].lines[0].get_xydata()[1], xform="data")
+        assert axes[0].texts[0].get_text() == "left ~ right (0)"
+
+
+@pytest.mark.parametrize(
+    "kind, kwargs, error, match",
+    [
+        # checks specific to these functions
+        ("spectral", dict(con=0), TypeError, "instance of SpectralConnectivity"),
+        ("matrix", dict(complex=True), ValueError, "complex-valued connectivity"),
+        ("spectral", dict(bad_info=True), ValueError, "Missing channels"),
+        ("spectral", dict(node_aliases={9: "x"}), ValueError, "must be present in"),
+        ("spectral", dict(ci=101.0), ValueError, "must be > 0 and <= 100"),
+        ("spectral", dict(highlight=[1.0, 2.0, 3.0]), ValueError, "shape \\(2,\\)"),
+        (
+            "spectrotemporal",
+            dict(mask=np.zeros((2, 2), dtype=bool)),
+            ValueError,
+            "Mask shape .* does not match data shape",
+        ),
+        # one representative check per set of allowed option values
+        ("spectral", dict(selection="bad"), ValueError, "the 'selection' parameter"),
+        ("spectral", dict(combine="bad"), ValueError, "the 'combine' parameter"),
+        ("matrix", dict(node_labels="bad"), ValueError, "the 'node_labels' parameter"),
+    ],
+)
+def test_plot_connectivity_errors(kind, kwargs, error, match):
+    """Test the input validation of the connectivity plotting functions."""
+    plot_func, klass, args, _ = PLOTTERS[kind]
+    con = kwargs.pop("con", None)
+    if con is None:
+        con = make_con(kind)
+        if kwargs.pop("complex", False):
+            con = klass(
+                con.get_data("raveled") * 1j, *args, n_nodes=N_NODES, names=con.names
+            )
+    if kwargs.pop("bad_info", False):
+        kwargs["info"] = mne.create_info(["other"], 1.0, "misc")
+    with pytest.raises(error, match=match):
+        plot_func(con, show=False, **kwargs)
+
+
+def test_plot_connectivity_explicit_indices():
+    """Test plotting bivariate connectivity for explicitly indexed connections."""
+    # upper-triangular, i.e. all-to-all but not in the layout the plot expects
+    indices = (np.array([0, 0, 1]), np.array([1, 2, 2]))
+    con = make_con("spectral", indices=indices)
+    fig, (line_ax, _) = plot_spectral_connectivity(
+        con, node_aliases={0: "first"}, show=True
+    )
+    fig.canvas.draw()
+    assert len(line_ax.lines) == 3  # not all-to-all, so no duplicated connections
+    _fake_click(fig, line_ax, line_ax.lines[0].get_xydata()[1], xform="data")
+    assert line_ax.texts[0].get_text() == "first ~ ch1"
+    assert con.names == [f"ch{ii}" for ii in range(N_NODES)]  # not renamed in place

--- a/mne_connectivity/viz/tests/test_plotting.py
+++ b/mne_connectivity/viz/tests/test_plotting.py
@@ -6,9 +6,9 @@ import mne
 import numpy as np
 import pytest
 from matplotlib.colors import LogNorm
+from matplotlib.figure import Figure
 from mne.viz.utils import _fake_click
 from numpy.testing import assert_allclose
-from matplotlib.figure import Figure
 
 from mne_connectivity import (
     Connectivity,

--- a/mne_connectivity/viz/tests/test_plotting.py
+++ b/mne_connectivity/viz/tests/test_plotting.py
@@ -166,47 +166,73 @@ def test_plot_matrix_connectivity():
 
 
 @pytest.mark.parametrize("symmetric", (True, False, "unknown"))
+# Lower/upper with indonsistent diag isn't a valid combination
+# Multivariate (n_comps > 1) is only supported for explicit indices
 @pytest.mark.parametrize(
-    ["indices", "consistent_diag"],
+    ["indices", "consistent_diag", "n_components"],
     [
-        ("all", True),
-        ("all", False),
-        ("lower", True),
-        ("upper", True),
-        ("explicit", True),
-        ("explicit", False),
+        ("all", True, 1),
+        ("all", False, 1),
+        ("lower", True, 1),
+        ("upper", True, 1),
+        ("explicit", True, 1),
+        ("explicit", True, 2),
+        ("explicit", False, 1),
+        ("explicit", False, 2),
     ],
 )  # lower/upper with indonsistent diag isn't a valid combination
-def test_plot_matrix_connectivity_visible_cons(indices, symmetric, consistent_diag):
-    """Test connection visibility in the matrix plots."""
+def test_plot_matrix_connectivity_visible_cons(
+    indices, symmetric, consistent_diag, n_components
+):
+    """Test connection visibility in the matrix plots.
+
+    Multiple components are shown as separate figures.
+    """
     con = make_con(
-        "matrix", indices=indices, symmetric=symmetric, consistent_diag=consistent_diag
+        "matrix",
+        indices=indices,
+        symmetric=symmetric,
+        consistent_diag=consistent_diag,
+        n_comps=n_components,
     )
     n_cons = con.get_data("raveled").shape[0]
+    if n_components > 1:
+        components = con.coords["components"].data
 
-    fig = plot_connectivity(con, show=False)
-    fig.canvas.draw()
-    ax = fig.axes[0]
-    # Get image data, removing masked (i.e., NaN) values for missing entries
-    data = ax.images[-1].get_array().compressed()
+    figs = plot_connectivity(con, show=False)
+    if not isinstance(figs, list):
+        figs = [figs]
+    # One figure per component
+    assert len(figs) == n_components
+    for comp_idx, fig in enumerate(figs):
+        ax = fig.axes[0]
+        title = f"misc ~ misc | {con.method}"
+        if n_components > 1:
+            title += f" | Component {components[comp_idx]}"
+        assert ax.get_title() == title
 
-    # Check cell contents
-    if indices == "explicit":
-        # Show everything for explicit indices, regardless of possible symmetry or
-        # diagonal having no actual info
-        assert data.size == n_cons
-    else:  # lower, upper, or all
-        # Full matrix of connections will be plotted for data when all-to-all
-        # connectivity is present, or full matrix can be inferred from tril/triu portion
-        n_plotted_cons = N_NODES**2  # all cons as baseline
-        n_tri_cons = N_NODES * (N_NODES - 1) // 2
-        # Remove a tril/triu portion from plotted & visible when this cannot be inferred
-        if indices != "all" and symmetric == "unknown":
-            n_plotted_cons -= n_tri_cons  # remove a tril/triu portion
-        # Remove diagonal from plotted & visible when this is not informative
-        if consistent_diag:
-            n_plotted_cons -= N_NODES
-        assert data.size == n_plotted_cons
+        # Get image data, removing masked (i.e., NaN) values for missing entries
+        data = ax.images[-1].get_array().compressed()
+
+        # Check cell contents
+        if indices == "explicit":
+            # Show everything for explicit indices, regardless of possible symmetry or
+            # diagonal having no actual info
+            assert data.size == n_cons
+        else:  # lower, upper, or all
+            # Full matrix of connections will be plotted for data when all-to-all
+            # connectivity is present, or full matrix can be inferred from tril/triu
+            # portion
+            n_plotted_cons = N_NODES**2  # all cons as baseline
+            n_tri_cons = N_NODES * (N_NODES - 1) // 2
+            # Remove a tril/triu portion from plotted & visible when this cannot be
+            # inferred
+            if indices != "all" and symmetric == "unknown":
+                n_plotted_cons -= n_tri_cons  # remove a tril/triu portion
+            # Remove diagonal from plotted & visible when this is not informative
+            if consistent_diag:
+                n_plotted_cons -= N_NODES
+            assert data.size == n_plotted_cons
 
 
 def test_plot_matrix_connectivity_options():

--- a/mne_connectivity/viz/tests/test_plotting.py
+++ b/mne_connectivity/viz/tests/test_plotting.py
@@ -127,7 +127,45 @@ def info():
     )
 
 
-def test_plot_connectivity_matrix_options():
+def test_plot_matrix_connectivity():
+    """Test plotting connectivity as a matrix."""
+    con = make_con("matrix")
+
+    fig = plot_connectivity(con, show=True)
+    fig.canvas.draw()
+    ax = fig.axes[0]
+    assert (ax.get_xlabel(), ax.get_ylabel()) == ("Targets", "Seeds")
+    assert ax.get_title() == f"misc ~ misc | {con.method}"
+    assert ax.images[-1].colorbar.ax.get_ylabel() == "Connectivity (A.U.)"
+    # Should be a square matrix spanning min-max nodes
+    assert ax.get_xlim() == (-0.5, N_NODES - 0.5)
+    assert ax.get_ylim() == (N_NODES - 0.5, -0.5)
+
+    # Check square matrix also plotted when picking subset of nodes
+    picks = (1,)
+    indices = np.tril_indices(N_NODES, k=-1)  # explicit "lower" indices
+    for selection in ("seeds", "targets", "both"):
+        fig = plot_connectivity(con, picks=picks, selection=selection, show=True)
+        fig.canvas.draw()
+        ax = fig.axes[0]
+        # Find which connections should be plotted
+        eligible_seeds = [idx for idx, seed in enumerate(indices[0]) if seed in picks]
+        eligible_targets = [
+            idx for idx, target in enumerate(indices[1]) if target in picks
+        ]
+        if selection == "both":
+            eligible_cons = sorted(set(eligible_seeds) | set(eligible_targets))
+        elif selection == "seeds":
+            eligible_cons = eligible_seeds
+        else:  # selection == "targets"
+            eligible_cons = eligible_targets
+        min_node = np.min([indices[0][eligible_cons], indices[1][eligible_cons]])
+        max_node = np.max([indices[0][eligible_cons], indices[1][eligible_cons]])
+        assert ax.get_xlim() == (min_node - 0.5, max_node + 0.5)
+        assert ax.get_ylim() == (max_node + 0.5, min_node - 0.5)
+
+
+def test_plot_matrix_connectivity_options():
     """Test the colormap, colorbar, and masking options of the matrix plot."""
     con = make_con("matrix")
     # only the lower triangle of the all-to-all data is plotted
@@ -136,8 +174,16 @@ def test_plot_connectivity_matrix_options():
     mixed = np.abs(data - 0.5).max()
     raveled = con.get_data("raveled")
 
-    def remake(values):  # a copy of `con` with different data
-        return Connectivity(values, n_nodes=N_NODES, names=con.names, method="coh")
+    plot_connectivity(con)
+
+    def remake(con, values):  # a copy of `con` with different data
+        return Connectivity(
+            values,
+            n_nodes=con.n_nodes,
+            indices=con.indices,
+            names=con.names,
+            method=con.method,
+        )
 
     for this_con, kwargs, clim, cmap in (
         (con, dict(), (lo, hi), "Reds"),  # all-positive data spans its own limits
@@ -145,20 +191,11 @@ def test_plot_connectivity_matrix_options():
         (con, dict(vmin=np.min, vmax=np.max), (lo, hi), "Reds"),  # callable bounds
         (con, dict(vmin=0.2), (0.2, hi), "Reds"),  # a missing bound falls back
         (con, dict(vmax=0.8), (lo, 0.8), "Reds"),
-        (remake(-raveled), dict(), (-hi, -lo), "Blues_r"),  # all-negative data
-        (remake(raveled - 0.5), dict(), (-mixed, mixed), "RdBu_r"),  # symmetric
+        (remake(con, -raveled), dict(), (-hi, -lo), "Blues_r"),  # all-negative data
+        (remake(con, raveled - 0.5), dict(), (-mixed, mixed), "RdBu_r"),  # symmetric
     ):
         img = plot_connectivity(this_con, show=False, **kwargs).axes[0].images[0]
         assert (img.get_clim(), img.cmap.name) == (clim, cmap), kwargs
-
-    fig = plot_connectivity(con, show=False)
-    fig.canvas.draw()
-    ax = fig.axes[0]
-    assert ax.get_title() == "misc ~ misc | coh"
-    assert (ax.get_xlabel(), ax.get_ylabel()) == ("Targets", "Seeds")
-    # only the lower triangle is filled, so the empty row/column is cropped away
-    assert ax.get_xlim() == (-0.5, N_NODES - 1.5)
-    assert ax.get_ylim() == (N_NODES - 0.5, 0.5)
 
     # nodes are labelled by name, by tick index, or not at all
     for node_labels, expected in (("names", con.names), ("ticks", ["0"]), (None, [])):
@@ -182,7 +219,7 @@ def test_plot_connectivity_matrix_options():
     assert len(ax.collections) > 0  # contour around the mask
 
 
-def test_plot_connectivity_matrix_click():
+def test_plot_matrix_connectivity_click():
     """Test clicking cells of the matrix plot to annotate them."""
     con = make_con("matrix")
     fig = plot_connectivity(con, show=False)

--- a/mne_connectivity/viz/tests/test_plotting.py
+++ b/mne_connectivity/viz/tests/test_plotting.py
@@ -165,6 +165,50 @@ def test_plot_matrix_connectivity():
         assert ax.get_ylim() == (max_node + 0.5, min_node - 0.5)
 
 
+@pytest.mark.parametrize("symmetric", (True, False, "unknown"))
+@pytest.mark.parametrize(
+    ["indices", "consistent_diag"],
+    [
+        ("all", True),
+        ("all", False),
+        ("lower", True),
+        ("upper", True),
+        ("explicit", True),
+        ("explicit", False),
+    ],
+)  # lower/upper with indonsistent diag isn't a valid combination
+def test_plot_matrix_connectivity_visible_cons(indices, symmetric, consistent_diag):
+    """Test connection visibility in the matrix plots."""
+    con = make_con(
+        "matrix", indices=indices, symmetric=symmetric, consistent_diag=consistent_diag
+    )
+    n_cons = con.get_data("raveled").shape[0]
+
+    fig = plot_connectivity(con, show=False)
+    fig.canvas.draw()
+    ax = fig.axes[0]
+    # Get image data, removing masked (i.e., NaN) values for missing entries
+    data = ax.images[-1].get_array().compressed()
+
+    # Check cell contents
+    if indices == "explicit":
+        # Show everything for explicit indices, regardless of possible symmetry or
+        # diagonal having no actual info
+        assert data.size == n_cons
+    else:  # lower, upper, or all
+        # Full matrix of connections will be plotted for data when all-to-all
+        # connectivity is present, or full matrix can be inferred from tril/triu portion
+        n_plotted_cons = N_NODES**2  # all cons as baseline
+        n_tri_cons = N_NODES * (N_NODES - 1) // 2
+        # Remove a tril/triu portion from plotted & visible when this cannot be inferred
+        if indices != "all" and symmetric == "unknown":
+            n_plotted_cons -= n_tri_cons  # remove a tril/triu portion
+        # Remove diagonal from plotted & visible when this is not informative
+        if consistent_diag:
+            n_plotted_cons -= N_NODES
+        assert data.size == n_plotted_cons
+
+
 def test_plot_matrix_connectivity_options():
     """Test the colormap, colorbar, and masking options of the matrix plot."""
     con = make_con("matrix")

--- a/mne_connectivity/viz/tests/test_plotting.py
+++ b/mne_connectivity/viz/tests/test_plotting.py
@@ -50,14 +50,14 @@ def make_con(
     indices="lower",
     symmetric=True,
     consistent_diag=True,
-    n_comps=None,
+    n_comps=1,
     n_nodes=N_NODES,
     names=None,
 ):
     """Create a connectivity object of the requested kind, with random data."""
     _, klass, args, dims = PLOTTERS[kind]
-    comps = () if n_comps is None else (n_comps,)
-    kwargs = dict() if n_comps is None else dict(components=np.arange(n_comps))
+    comps = () if n_comps == 1 else (n_comps,)
+    kwargs = dict() if n_comps == 1 else dict(components=np.arange(n_comps))
 
     # Create random data for full connectivity
     data = np.random.default_rng(44).random((n_nodes, n_nodes, *comps, *dims))
@@ -84,6 +84,14 @@ def make_con(
         data = data[np.tril_indices(n_nodes, -1)]
     else:  # upper
         data = data[np.triu_indices(n_nodes, 1)]
+
+    # Make indices multivariate
+    if n_comps > 1:
+        assert isinstance(indices, tuple)
+        indices = (
+            np.array([[ind] for ind in indices[0]]),
+            np.array([[ind] for ind in indices[1]]),
+        )
 
     if names is None:
         names = [f"ch{ii}" for ii in range(n_nodes)]

--- a/mne_connectivity/viz/tests/test_plotting.py
+++ b/mne_connectivity/viz/tests/test_plotting.py
@@ -21,6 +21,10 @@ from mne_connectivity import (
     plot_temporal_connectivity,
     seed_target_multivariate_indices,
 )
+from mne_connectivity.utils import (
+    _check_if_multivariate_indices,
+    _get_unique_multivariate_nodes_and_indices,
+)
 
 N_NODES, N_FREQS, N_TIMES = 4, 5, 3
 FREQS = np.arange(5.0, 5.0 + N_FREQS)
@@ -60,6 +64,16 @@ def make_con(
     comps = () if n_comps == 1 else (n_comps,)
     kwargs = dict() if n_comps == 1 else dict(components=np.arange(n_comps))
 
+    # Handle multivariate indices
+    original_n_nodes, original_indices = None, None
+    if isinstance(indices, tuple) and _check_if_multivariate_indices(indices):
+        # Convert multivariate indices into bivariate (unnested) format in terms of
+        # the unique channel sets. Save the original indices and n_nodes to restore
+        # later when constructing the connectivity object.
+        original_n_nodes, original_indices = n_nodes, indices
+        nodes, indices = _get_unique_multivariate_nodes_and_indices(indices)
+        n_nodes = len(nodes)
+
     # Create random data for full connectivity
     data = np.random.default_rng(44).random((n_nodes, n_nodes, *comps, *dims))
     assert symmetric in (True, False, "unknown")
@@ -70,7 +84,7 @@ def make_con(
         data = (data + data.transpose(1, 0, *range(2, data.ndim))) / 2.0
     else:
         method = "imcoh"
-    if consistent_diag:
+    if consistent_diag and n_nodes > 1:
         data[np.arange(n_nodes), np.arange(n_nodes)] = 0.0
 
     # Trim the data to the requested connections
@@ -86,13 +100,13 @@ def make_con(
     else:  # upper
         data = data[np.triu_indices(n_nodes, 1)]
 
-    # Make indices multivariate
-    if n_comps > 1:
-        assert isinstance(indices, tuple)
-        indices = (
-            np.array([[ind] for ind in indices[0]]),
-            np.array([[ind] for ind in indices[1]]),
-        )
+    # Handle multivariate connectivity
+    if original_indices is not None:
+        # Restore the original indices and n_nodes if indices was a multivariate tuple
+        n_nodes, indices = original_n_nodes, original_indices
+    elif n_comps > 1:
+        # Convert indices to multivariate form (may have been 'explicit')
+        indices = ([[ind] for ind in indices[0]], [[ind] for ind in indices[1]])
 
     if names is None:
         names = [f"ch{ii}" for ii in range(n_nodes)]
@@ -109,18 +123,6 @@ def click_node(fig, circle_ax, node, n_nodes, button=1):
     # lands exactly on the seam of the polar axes patch (where it is not contained)
     angle = 2 * np.pi * node / n_nodes + 0.05
     _fake_click(fig, circle_ax, (angle, 9.5), xform="data", button=button)
-
-
-def unpack(out, kind):
-    """Return the figures and the (line/image) axes of a plotting call as lists."""
-    figs, axes = (out, None) if kind == "matrix" else out
-    if not isinstance(figs, list):
-        figs, axes = [figs], [axes]
-    if kind == "matrix":
-        axes = [fig.axes[0] for fig in figs]
-    elif kind in LINE_KINDS:
-        axes = [line_ax for line_ax, _ in axes]
-    return figs, axes
 
 
 def visible(ax):
@@ -386,8 +388,8 @@ def test_plot_line_connectivity_visible_cons(
     For connectivity data that is symmetric, it is better to start with only a subset of
     the connections visible, and alter this as different nodes are selected in the
     circle plot. For symmetric lower-/upper-triangular data, we also fill in the missing
-    values to improve interactive visualisation. We exlude the diagonal connections from
-    plotting if they are not informative (i.e., if they are all the same value).
+    values to improve interactive visualisation. We exclude the diagonal connections
+    from plotting if they are not informative (i.e., if they are all the same value).
     """
     plot_func = PLOTTERS[kind][0]
     con = make_con(
@@ -641,10 +643,8 @@ def test_plot_spectrotemporal_connectivity_combine():
     assert isinstance(fig, Figure)  # single figure, returned directly
     ax = fig.axes[0]
     assert_allclose(ax.images[0].get_array(), data.mean(axis=0))
-    assert (
-        ax.get_title()
-        == f"misc ~ misc | combined nodes (n={data.shape[0]}) | {con.method}"
-    )
+    expected_title = f"misc ~ misc | combined nodes (n={data.shape[0]}) | {con.method}"
+    assert ax.get_title() == expected_title
 
     # a callable combine is used as-is
     fig = plot_spectrotemporal_connectivity(
@@ -653,6 +653,7 @@ def test_plot_spectrotemporal_connectivity_combine():
     assert isinstance(fig, Figure)  # single figure, returned directly
     ax = fig.axes[0]
     assert_allclose(ax.images[0].get_array(), data.max(axis=0))
+    assert ax.get_title() == expected_title
 
 
 @pytest.mark.parametrize("kind", list(PLOTTERS))
@@ -662,14 +663,14 @@ def test_plot_connectivity_channel_types(kind, info):
     con = make_con(kind, names=info["ch_names"])
 
     types = ["EEG ~ EEG", "Gradiometers ~ EEG", "Gradiometers ~ Gradiometers"]
-    figs = unpack(plot_func(con, info=info, show=False), kind)
+    figs = plot_func(con, info=info, show=False)
     axes = [fig.axes[0] for fig in figs]
     assert len(figs) == len(axes) == 3
     assert [ax.get_title().split(" | ")[0] for ax in axes] == types
 
     # dropping a bad EEG channel leaves only one EEG node, so no EEG ~ EEG figure
     info["bads"] = ["e1"]
-    figs = unpack(plot_func(con, info=info, show=False), kind)
+    figs = plot_func(con, info=info, show=False)
     axes = [fig.axes[0] for fig in figs]
     assert len(figs) == len(axes) == 2
     assert [ax.get_title().split(" | ")[0] for ax in axes] == types[1:]
@@ -694,22 +695,33 @@ def test_plot_connectivity_multivariate(kind, form):
             for idcs in ([[0, 1, -1], [2, 3, 4]], [[2, 3, 4], [0, 1, -1]])
         )
     n_cons = len(indices[0])
-    con = make_con(kind, indices=indices, n_comps=2, n_nodes=5)
+    n_components = 2
+    con = make_con(
+        kind, indices=indices, n_comps=n_components, n_nodes=5, symmetric=False
+    )  # do not use symmetric, otherwise lines overlap when picking
+    components = con.coords["components"].data
 
-    figs = unpack(plot_func(con, node_aliases=aliases, show=False), kind)
-    axes = [fig.axes[0] for fig in figs]
-    if kind == "spectrotemporal":  # connections are combined per component
-        assert len(figs) == 2
-        title = f"misc ~ misc | combined nodes (0; n={n_cons}) | coh"
-        assert axes[0].get_title() == title
-        return
-    assert len(figs) == len(axes) == 1
-    if kind in LINE_KINDS:
-        # each component of each connection is drawn as its own line
-        assert len(axes[0].lines) == n_cons * 2
-        figs[0].canvas.draw()
-        _fake_click(figs[0], axes[0], axes[0].lines[0].get_xydata()[1], xform="data")
-        assert axes[0].texts[0].get_text() == "left ~ right (0)"
+    figs = plot_func(con, node_aliases=aliases, show=False)
+    if kind in ["matrix", "spectrotemporal"]:  # one fig per component
+        axes = [fig.axes[0] for fig in figs]
+        assert len(figs) == n_components
+        for ax, comp in zip(axes, components, strict=True):
+            if kind == "matrix":
+                title = f"misc ~ misc | {con.method} | Component {comp}"
+            else:
+                title = (
+                    f"misc ~ misc | combined nodes ({comp}; n={n_cons}) | {con.method}"
+                )
+            assert ax.get_title() == title
+    else:  # line plots allow multiple components per fig
+        assert isinstance(figs, Figure)  # single figure, returned directly
+        axes = figs.axes
+        if kind in LINE_KINDS:
+            # each component of each connection is drawn as its own line
+            assert len(axes[0].lines) == n_cons * 2
+            figs.canvas.draw()
+            _fake_click(figs, axes[0], axes[0].lines[0].get_xydata()[1], xform="data")
+            assert axes[0].texts[0].get_text() == "left ~ right (0)"
 
 
 @pytest.mark.parametrize(
@@ -742,7 +754,11 @@ def test_plot_connectivity_errors(kind, kwargs, error, match):
         con = make_con(kind)
         if kwargs.pop("complex", False):
             con = klass(
-                con.get_data("raveled") * 1j, *args, n_nodes=N_NODES, names=con.names
+                con.get_data("raveled") * 1j,
+                *args,
+                n_nodes=N_NODES,
+                indices=con.indices,
+                names=con.names,
             )
     if kwargs.pop("bad_info", False):
         kwargs["info"] = mne.create_info(["other"], 1.0, "misc")

--- a/mne_connectivity/viz/tests/test_plotting.py
+++ b/mne_connectivity/viz/tests/test_plotting.py
@@ -139,8 +139,7 @@ def test_plot_matrix_connectivity():
     """Test plotting connectivity as a matrix."""
     con = make_con("matrix")
 
-    fig = plot_connectivity(con, show=True)
-    fig.canvas.draw()
+    fig = plot_connectivity(con, show=False)
     ax = fig.axes[0]
     assert (ax.get_xlabel(), ax.get_ylabel()) == ("Targets", "Seeds")
     assert ax.get_title() == f"misc ~ misc | {con.method}"
@@ -153,8 +152,7 @@ def test_plot_matrix_connectivity():
     picks = (1,)
     indices = np.tril_indices(N_NODES, k=-1)  # explicit "lower" indices
     for selection in ("seeds", "targets", "both"):
-        fig = plot_connectivity(con, picks=picks, selection=selection, show=True)
-        fig.canvas.draw()
+        fig = plot_connectivity(con, picks=picks, selection=selection, show=False)
         ax = fig.axes[0]
         # Find which connections should be plotted
         eligible_seeds = [idx for idx, seed in enumerate(indices[0]) if seed in picks]
@@ -334,7 +332,8 @@ def test_plot_line_connectivity(kind):
     xvar = con.freqs if kind == "spectral" else con.times
     xlabel = "Frequency (Hz)" if kind == "spectral" else "Time (s)"
 
-    fig, (line_ax, circle_ax) = plot_func(con, show=False)
+    fig = plot_func(con, show=False)
+    line_ax, circle_ax = fig.axes
     assert (line_ax.get_xlabel(), line_ax.get_ylabel()) == (
         xlabel,
         "Connectivity (A.U.)",
@@ -345,16 +344,19 @@ def test_plot_line_connectivity(kind):
 
     # cropping the x axis
     crop_kwargs, xlim = CROP[kind]
-    _, (line_ax, _) = plot_func(con, show=False, **crop_kwargs)
+    fig = plot_func(con, show=False, **crop_kwargs)
+    line_ax, circle_ax = fig.axes
     assert line_ax.get_xlim() == xlim
 
     # highlighting, both as a single (start, stop) pair and as several
     for highlight, n_extra in (((xvar[0], xvar[1]), 1), ([xvar[:2], xvar[-2:]], 2)):
-        _, (line_ax, _) = plot_func(con, highlight=highlight, show=False)
+        fig = plot_func(con, highlight=highlight, show=False)
+        line_ax, circle_ax = fig.axes
         assert len(line_ax.collections) == n_extra
 
     # without interactivity the connections aren't pickable, and all are visible
-    _, (line_ax, circle_ax) = plot_func(con, interactive=False, show=False)
+    fig = plot_func(con, interactive=False, show=False)
+    line_ax, circle_ax = fig.axes
     assert circle_ax.get_title() == "Nodes"
     assert visible(line_ax) == [True] * n_cons
     assert not any(line.get_picker() for line in line_ax.lines)
@@ -391,7 +393,8 @@ def test_plot_line_connectivity_visible_cons(
     )
     n_cons = con.get_data("raveled").shape[0]
 
-    fig, (line_ax, circle_ax) = plot_func(con, selection=selection, show=False)
+    fig = plot_func(con, selection=selection, show=False)
+    line_ax, circle_ax = fig.axes
 
     # Check line visibility
     if indices == "explicit":
@@ -427,23 +430,24 @@ def test_plot_line_connectivity_combine(kind, ci):
     con = make_con(kind)
     data = con.get_data("dense")[np.tril_indices(N_NODES, -1)]
 
-    fig, (line_ax, circle_ax) = plot_func(con, combine="mean", ci=ci, show=False)
-    assert circle_ax is None  # a single (combined) connection needs no circle plot
+    fig = plot_func(con, combine="mean", ci=ci, show=False)
+    line_ax = fig.axes[0]
+    assert len(fig.axes) == 1  # a single (combined) connection needs no circle plot
     assert len(line_ax.lines) == 1
     assert_allclose(line_ax.lines[0].get_ydata(), data.mean(axis=0))
     assert len(line_ax.collections) == (0 if ci is None else 1)
 
     # a callable combine is used as-is
-    _, (line_ax, _) = plot_func(
-        con, combine=lambda x: np.max(x, axis=0), ci=None, show=False
-    )
+    fig = plot_func(con, combine=lambda x: np.max(x, axis=0), ci=None, show=False)
+    line_ax = fig.axes[0]
     assert_allclose(line_ax.lines[0].get_ydata(), data.max(axis=0))
 
 
 def test_plot_line_connectivity_interactive():
     """Test selecting nodes in the circle plot and connections in the line plot."""
     con = make_con("spectral")
-    fig, (line_ax, circle_ax) = plot_spectral_connectivity(con, show=False)
+    fig = plot_spectral_connectivity(con, show=False)
+    line_ax, circle_ax = fig.axes
     fig.canvas.draw()
     seeds, targets = np.tril_indices(N_NODES, -1)
     # connections are duplicated with the seeds and targets swapped, so that every
@@ -485,10 +489,11 @@ def test_plot_line_connectivity_selection(
 ):
     """Test restricting the plotted (and selectable) connections to picked channels."""
     con = make_con("spectral")
-    fig, (line_ax, circle_ax) = plot_spectral_connectivity(
+    fig = plot_spectral_connectivity(
         con, picks=["ch1", "ch2"], selection=selection, colors=colors,
         cmap="viridis", show=False,
     )  # fmt: skip
+    line_ax, circle_ax = fig.axes
     fig.canvas.draw()
     assert len(line_ax.lines) == 3  # connections are duplicated only for "both"
     node_names = [text.get_text() for text in circle_ax.texts]
@@ -513,7 +518,8 @@ def test_plot_spectrotemporal_connectivity():
     data = con.get_data("dense")[np.tril_indices(N_NODES, -1)]
 
     # connections are averaged by default, giving one figure instead of one each
-    fig, ax = plot_spectrotemporal_connectivity(con, show=False)
+    fig = plot_spectrotemporal_connectivity(con, show=False)
+    ax = fig.axes[0]
     assert (ax.get_xlabel(), ax.get_ylabel()) == ("Time (s)", "Frequency (Hz)")
     assert ax.get_title() == f"misc ~ misc | combined nodes (n={N_CONS}) | coh"
     assert_allclose(ax.images[0].get_array(), data.mean(axis=0))
@@ -524,13 +530,15 @@ def test_plot_spectrotemporal_connectivity():
     # cropping in time and frequency, masking, and a log-spaced frequency axis
     mask = np.zeros((N_FREQS, N_TIMES), dtype=bool)
     mask[1:, 1:] = True
-    _, ax = plot_spectrotemporal_connectivity(
+    fig = plot_spectrotemporal_connectivity(
         con, fmin=6.0, fmax=8.0, tmin=0.0, tmax=0.1, mask=mask, mask_style="mask",
         mask_cmap=None, colorbar=False, show=False,
     )  # fmt: skip
+    ax = fig.axes[0]
     assert ax.images[0].get_array().shape == (3, 2)  # cropped
     assert len(ax.images) == 2 and len(ax.get_figure().axes) == 1  # masked, no cbar
-    _, ax = plot_spectrotemporal_connectivity(con, yscale="log", show=False)
+    fig = plot_spectrotemporal_connectivity(con, yscale="log", show=False)
+    ax = fig.axes[0]
     assert ax.get_yscale() == "log"
 
 
@@ -541,13 +549,15 @@ def test_plot_connectivity_channel_types(kind, info):
     con = make_con(kind, names=info["ch_names"])
 
     types = ["EEG ~ EEG", "Gradiometers ~ EEG", "Gradiometers ~ Gradiometers"]
-    figs, axes = unpack(plot_func(con, info=info, show=False), kind)
+    figs = unpack(plot_func(con, info=info, show=False), kind)
+    axes = [fig.axes[0] for fig in figs]
     assert len(figs) == len(axes) == 3
     assert [ax.get_title().split(" | ")[0] for ax in axes] == types
 
     # dropping a bad EEG channel leaves only one EEG node, so no EEG ~ EEG figure
     info["bads"] = ["e1"]
-    figs, axes = unpack(plot_func(con, info=info, show=False), kind)
+    figs = unpack(plot_func(con, info=info, show=False), kind)
+    axes = [fig.axes[0] for fig in figs]
     assert len(figs) == len(axes) == 2
     assert [ax.get_title().split(" | ")[0] for ax in axes] == types[1:]
 
@@ -573,7 +583,8 @@ def test_plot_connectivity_multivariate(kind, form):
     n_cons = len(indices[0])
     con = make_con(kind, indices=indices, n_comps=2, n_nodes=5)
 
-    figs, axes = unpack(plot_func(con, node_aliases=aliases, show=False), kind)
+    figs = unpack(plot_func(con, node_aliases=aliases, show=False), kind)
+    axes = [fig.axes[0] for fig in figs]
     if kind == "spectrotemporal":  # connections are combined per component
         assert len(figs) == 2
         title = f"misc ~ misc | combined nodes (0; n={n_cons}) | coh"
@@ -631,9 +642,8 @@ def test_plot_connectivity_explicit_indices():
     # upper-triangular, i.e. all-to-all but not in the layout the plot expects
     indices = (np.array([0, 0, 1]), np.array([1, 2, 2]))
     con = make_con("spectral", indices=indices)
-    fig, (line_ax, _) = plot_spectral_connectivity(
-        con, node_aliases={0: "first"}, show=True
-    )
+    fig = plot_spectral_connectivity(con, node_aliases={0: "first"}, show=False)
+    line_ax, circle_ax = fig.axes
     fig.canvas.draw()
     assert len(line_ax.lines) == 3  # not all-to-all, so no duplicated connections
     _fake_click(fig, line_ax, line_ax.lines[0].get_xydata()[1], xform="data")

--- a/mne_connectivity/viz/tests/test_plotting.py
+++ b/mne_connectivity/viz/tests/test_plotting.py
@@ -41,21 +41,55 @@ CROP = dict(
     spectral=(dict(fmin=6.0, fmax=8.0), (6.0, 8.0)),
     temporal=(dict(tmin=0.0, tmax=0.1), (0.0, 0.1)),
 )
-N_CONS = N_NODES * (N_NODES - 1) // 2  # all-to-all is lower-triangular
 LINE_KINDS = ("spectral", "temporal")
 
 
-def make_con(kind, *, indices="all", n_comps=None, n_nodes=N_NODES, names=None):
+def make_con(
+    kind,
+    *,
+    indices="lower",
+    symmetric=True,
+    consistent_diag=True,
+    n_comps=None,
+    n_nodes=N_NODES,
+    names=None,
+):
     """Create a connectivity object of the requested kind, with random data."""
     _, klass, args, dims = PLOTTERS[kind]
-    n_cons = n_nodes**2 if isinstance(indices, str) else len(indices[0])
     comps = () if n_comps is None else (n_comps,)
-    data = np.random.default_rng(44).random((n_cons, *comps, *dims))
     kwargs = dict() if n_comps is None else dict(components=np.arange(n_comps))
+
+    # Create random data for full connectivity
+    data = np.random.default_rng(44).random((n_nodes, n_nodes, *comps, *dims))
+    assert symmetric in (True, False, "unknown")
+    if symmetric == "unknown":
+        method = "unknown"
+    elif symmetric:
+        method = "coh"
+        data = (data + data.transpose(1, 0, *range(2, data.ndim))) / 2.0
+    else:
+        method = "imcoh"
+    if consistent_diag:
+        data[np.arange(n_nodes), np.arange(n_nodes)] = 0.0
+
+    # Trim the data to the requested connections
+    if indices == "explicit":  # all-to-all tuple
+        indices = np.unravel_index(np.arange(n_nodes**2), (n_nodes, n_nodes))
+    assert indices in ("all", "lower", "upper") or isinstance(indices, tuple)
+    if isinstance(indices, tuple):
+        data = data[indices]
+    elif indices == "all":
+        data = data.reshape((-1, *data.shape[2:]))
+    elif indices == "lower":
+        data = data[np.tril_indices(n_nodes, -1)]
+    else:  # upper
+        data = data[np.triu_indices(n_nodes, 1)]
+
     if names is None:
         names = [f"ch{ii}" for ii in range(n_nodes)]
+
     return klass(
-        data, *args, n_nodes=n_nodes, names=names, indices=indices, method="coh",
+        data, *args, n_nodes=n_nodes, names=names, indices=indices, method=method,
         **kwargs,
     )  # fmt: skip
 
@@ -181,6 +215,7 @@ def test_plot_line_connectivity(kind):
     """Test plotting connectivity as lines with a circle plot overview."""
     plot_func = PLOTTERS[kind][0]
     con = make_con(kind)
+    n_cons = con.get_data("raveled").shape[0]
     xvar = con.freqs if kind == "spectral" else con.times
     xlabel = "Frequency (Hz)" if kind == "spectral" else "Time (s)"
 
@@ -189,11 +224,8 @@ def test_plot_line_connectivity(kind):
         xlabel,
         "Connectivity (A.U.)",
     )
-    assert line_ax.get_title() == "misc ~ misc | coh"
+    assert line_ax.get_title() == f"misc ~ misc | {con.method}"
     assert circle_ax.get_title() == "Node selection\n(seeds and targets)"
-    # all-to-all data are duplicated so that every node acts as a seed, but the
-    # duplicates start out hidden
-    assert visible(line_ax) == [True] * N_CONS + [False] * N_CONS
     assert line_ax.get_xlim() == (xvar[0], xvar[-1])
 
     # cropping the x axis
@@ -206,11 +238,70 @@ def test_plot_line_connectivity(kind):
         _, (line_ax, _) = plot_func(con, highlight=highlight, show=False)
         assert len(line_ax.collections) == n_extra
 
-    # without interactivity the connections are neither duplicated nor pickable
+    # without interactivity the connections aren't pickable, and all are visible
     _, (line_ax, circle_ax) = plot_func(con, interactive=False, show=False)
     assert circle_ax.get_title() == "Nodes"
-    assert visible(line_ax) == [True] * N_CONS
+    assert visible(line_ax) == [True] * n_cons
     assert not any(line.get_picker() for line in line_ax.lines)
+
+
+@pytest.mark.parametrize("kind", LINE_KINDS)
+@pytest.mark.parametrize("symmetric", (True, False, "unknown"))
+@pytest.mark.parametrize(
+    ["indices", "consistent_diag"],
+    [
+        ("all", True),
+        ("all", False),
+        ("lower", True),
+        ("upper", True),
+        ("explicit", True),
+        ("explicit", False),
+    ],
+)  # lower/upper with indonsistent diag isn't a valid combination
+@pytest.mark.parametrize("selection", ("seeds", "targets", "both"))
+def test_plot_line_connectivity_visible_cons(
+    kind, indices, symmetric, consistent_diag, selection
+):
+    """Test connection visibility in the line plots.
+
+    For connectivity data that is symmetric, it is better to start with only a subset of
+    the connections visible, and alter this as different nodes are selected in the
+    circle plot. For symmetric lower-/upper-triangular data, we also fill in the missing
+    values to improve interactive visualisation. We exlude the diagonal connections from
+    plotting if they are not informative (i.e., if they are all the same value).
+    """
+    plot_func = PLOTTERS[kind][0]
+    con = make_con(
+        kind, indices=indices, symmetric=symmetric, consistent_diag=consistent_diag
+    )
+    n_cons = con.get_data("raveled").shape[0]
+
+    fig, (line_ax, circle_ax) = plot_func(con, selection=selection, show=False)
+
+    # Check line visibility
+    if indices == "explicit":
+        # Show everything for explicit indices, regardless of possible symmetry or
+        # diagonal having no actual info
+        assert visible(line_ax) == [True] * n_cons
+    else:  # lower, upper, or all
+        # Full matrix of connections will be plotted for data when all-to-all
+        # connectivity is present, or full matrix can be inferred from tril/triu portion
+        n_plotted_cons = n_visible_cons = N_NODES**2  # all cons as baseline
+        n_tri_cons = N_NODES * (N_NODES - 1) // 2
+        # Remove a tril/triu portion from plotted & visible when this cannot be inferred
+        if indices != "all" and symmetric == "unknown":
+            n_plotted_cons -= n_tri_cons  # remove a tril/triu portion
+            n_visible_cons -= n_tri_cons
+        # Remove a tril/triu portion from visible when data is symmetric
+        if symmetric is True:
+            n_visible_cons -= n_tri_cons
+        # Remove diagonal from plotted & visible when this is not informative
+        if consistent_diag:
+            n_plotted_cons -= N_NODES
+            n_visible_cons -= N_NODES
+        assert visible(line_ax) == [True] * n_visible_cons + [False] * (
+            n_plotted_cons - n_visible_cons
+        )
 
 
 @pytest.mark.parametrize("kind", LINE_KINDS)

--- a/mne_connectivity/viz/tests/test_plotting.py
+++ b/mne_connectivity/viz/tests/test_plotting.py
@@ -8,6 +8,7 @@ import pytest
 from matplotlib.colors import LogNorm
 from mne.viz.utils import _fake_click
 from numpy.testing import assert_allclose
+from matplotlib.figure import Figure
 
 from mne_connectivity import (
     Connectivity,
@@ -186,7 +187,7 @@ def test_plot_matrix_connectivity():
         ("explicit", False, 1),
         ("explicit", False, 2),
     ],
-)  # lower/upper with indonsistent diag isn't a valid combination
+)  # lower/upper with inconsistent diag isn't a valid combination
 def test_plot_matrix_connectivity_visible_cons(
     indices, symmetric, consistent_diag, n_components
 ):
@@ -365,19 +366,20 @@ def test_plot_line_connectivity(kind):
 @pytest.mark.parametrize("kind", LINE_KINDS)
 @pytest.mark.parametrize("symmetric", (True, False, "unknown"))
 @pytest.mark.parametrize(
-    ["indices", "consistent_diag"],
+    ["indices", "consistent_diag", "n_components"],
     [
-        ("all", True),
-        ("all", False),
-        ("lower", True),
-        ("upper", True),
-        ("explicit", True),
-        ("explicit", False),
+        ("all", True, 1),
+        ("all", False, 1),
+        ("lower", True, 1),
+        ("upper", True, 1),
+        ("explicit", True, 1),
+        ("explicit", False, 1),
+        ("explicit", True, 2),
+        ("explicit", False, 2),
     ],
-)  # lower/upper with indonsistent diag isn't a valid combination
-@pytest.mark.parametrize("selection", ("seeds", "targets", "both"))
+)  # lower/upper with inconsistent diag isn't a valid combination
 def test_plot_line_connectivity_visible_cons(
-    kind, indices, symmetric, consistent_diag, selection
+    kind, indices, symmetric, consistent_diag, n_components
 ):
     """Test connection visibility in the line plots.
 
@@ -389,18 +391,22 @@ def test_plot_line_connectivity_visible_cons(
     """
     plot_func = PLOTTERS[kind][0]
     con = make_con(
-        kind, indices=indices, symmetric=symmetric, consistent_diag=consistent_diag
+        kind,
+        indices=indices,
+        symmetric=symmetric,
+        consistent_diag=consistent_diag,
+        n_comps=n_components,
     )
     n_cons = con.get_data("raveled").shape[0]
 
-    fig = plot_func(con, selection=selection, show=False)
-    line_ax, circle_ax = fig.axes
+    fig = plot_func(con, show=False)
+    line_ax, _ = fig.axes
 
     # Check line visibility
     if indices == "explicit":
         # Show everything for explicit indices, regardless of possible symmetry or
         # diagonal having no actual info
-        assert visible(line_ax) == [True] * n_cons
+        assert visible(line_ax) == [True] * n_cons * n_components
     else:  # lower, upper, or all
         # Full matrix of connections will be plotted for data when all-to-all
         # connectivity is present, or full matrix can be inferred from tril/triu portion
@@ -515,17 +521,101 @@ def test_plot_line_connectivity_selection(
 def test_plot_spectrotemporal_connectivity():
     """Test plotting spectro-temporal connectivity as images."""
     con = make_con("spectrotemporal")
-    data = con.get_data("dense")[np.tril_indices(N_NODES, -1)]
+    data = con.get_data("raveled")
+    n_cons = data.shape[0]
 
-    # connections are averaged by default, giving one figure instead of one each
+    # Connections are averaged by default, giving one figure instead of one each
     fig = plot_spectrotemporal_connectivity(con, show=False)
     ax = fig.axes[0]
     assert (ax.get_xlabel(), ax.get_ylabel()) == ("Time (s)", "Frequency (Hz)")
-    assert ax.get_title() == f"misc ~ misc | combined nodes (n={N_CONS}) | coh"
+    assert ax.get_title() == f"misc ~ misc | combined nodes (n={n_cons}) | coh"
     assert_allclose(ax.images[0].get_array(), data.mean(axis=0))
-    figs, axes = plot_spectrotemporal_connectivity(con, combine=None, show=False)
-    assert len(figs) == len(axes) == N_CONS
-    assert axes[0].get_title() == "misc ~ misc | ch1 ~ ch0 | coh"
+
+    # Check without combining connections, which gives one figure per connection
+    figs = plot_spectrotemporal_connectivity(con, combine=None, show=False)
+    assert len(figs) == n_cons
+    indices = np.tril_indices(N_NODES, -1)  # explicit "lower" indices
+    for fig, seed, target in zip(figs, indices[0], indices[1], strict=True):
+        assert fig.axes[0].get_title() == f"misc ~ misc | ch{seed} ~ ch{target} | coh"
+
+
+@pytest.mark.parametrize("symmetric", (True, False, "unknown"))
+@pytest.mark.parametrize(
+    ["indices", "consistent_diag", "n_components"],
+    [
+        ("all", True, 1),
+        ("all", False, 1),
+        ("lower", True, 1),
+        ("upper", True, 1),
+        ("explicit", True, 1),
+        ("explicit", False, 1),
+        ("explicit", True, 2),
+        ("explicit", False, 2),
+    ],
+)  # lower/upper with inconsistent diag isn't a valid combination
+def test_plot_spectrotemporal_connectivity_visible_cons(
+    indices, symmetric, consistent_diag, n_components
+):
+    """Test connection visibility in spectro-temporal plots."""
+    n_nodes = 3  # fewer nodes to reduce number of opened figures
+    con = make_con(
+        "spectrotemporal",
+        indices=indices,
+        symmetric=symmetric,
+        consistent_diag=consistent_diag,
+        n_comps=n_components,
+        n_nodes=n_nodes,
+    )
+    n_cons = con.get_data("raveled").shape[0]
+    components = con.coords["components"].data if n_components > 1 else None
+
+    figs_combined = plot_spectrotemporal_connectivity(con, show=False)
+    figs_all = plot_spectrotemporal_connectivity(con, combine=None, show=False)
+
+    if indices == "explicit":
+        # Show everything for explicit indices, regardless of possible symmetry or
+        # diagonal having no actual info
+        n_plotted_cons = n_cons * n_components
+        n_combined_cons = n_cons
+    else:
+        # Full matrix of connections will be plotted for data when all-to-all
+        # connectivity is present, or full matrix can be inferred from tril/triu portion
+        # and it is asymmetric. If full matrix is inferred from tril/triu portion and it
+        # is symmetric, only the tril/triu portion is plotted.
+        n_plotted_cons = n_combined_cons = n_nodes**2  # all cons as baseline
+        n_tri_cons = n_nodes * (n_nodes - 1) // 2
+        if indices != "all" and symmetric is not False:
+            n_plotted_cons -= n_tri_cons  # remove a tril/triu portion
+            n_combined_cons -= n_tri_cons
+        # Symmetric portions aren't included when combining connections
+        if indices == "all" and symmetric is True:
+            n_combined_cons -= n_tri_cons  # remove a tril/triu portion
+        if consistent_diag:
+            n_plotted_cons -= n_nodes  # remove diagonal
+            n_combined_cons -= n_nodes
+        n_plotted_cons *= n_components  # each component is plotted separately
+
+    if n_components > 1:
+        assert len(figs_combined) == n_components  # one figure per component
+        assert len(figs_all) == n_plotted_cons  # one figure per con * comp
+        for comp_idx, comp in enumerate(components):
+            assert (
+                f"combined nodes ({comp}; n={n_combined_cons})"
+                in figs_combined[comp_idx].axes[0].get_title()
+            )
+            assert "combined nodes" not in figs_all[comp_idx].axes[0].get_title()
+    else:
+        assert isinstance(figs_combined, Figure)  # single figure, returned directly
+        assert len(figs_all) == n_plotted_cons  # one figure per connection
+        assert (
+            f"combined nodes (n={n_combined_cons})" in figs_combined.axes[0].get_title()
+        )
+        assert "combined nodes" not in figs_all[0].axes[0].get_title()
+
+
+def test_plot_spectrotemporal_connectivity_options():
+    """Test the options of the spectro-temporal connectivity plot."""
+    con = make_con("spectrotemporal")
 
     # cropping in time and frequency, masking, and a log-spaced frequency axis
     mask = np.zeros((N_FREQS, N_TIMES), dtype=bool)
@@ -540,6 +630,29 @@ def test_plot_spectrotemporal_connectivity():
     fig = plot_spectrotemporal_connectivity(con, yscale="log", show=False)
     ax = fig.axes[0]
     assert ax.get_yscale() == "log"
+
+
+def test_plot_spectrotemporal_connectivity_combine():
+    """Test aggregating connections in the spectro-temporal plots."""
+    con = make_con("spectrotemporal")
+    data = con.get_data("raveled")
+
+    fig = plot_spectrotemporal_connectivity(con, combine="mean", show=False)
+    assert isinstance(fig, Figure)  # single figure, returned directly
+    ax = fig.axes[0]
+    assert_allclose(ax.images[0].get_array(), data.mean(axis=0))
+    assert (
+        ax.get_title()
+        == f"misc ~ misc | combined nodes (n={data.shape[0]}) | {con.method}"
+    )
+
+    # a callable combine is used as-is
+    fig = plot_spectrotemporal_connectivity(
+        con, combine=lambda x: np.max(x, axis=0), show=False
+    )
+    assert isinstance(fig, Figure)  # single figure, returned directly
+    ax = fig.axes[0]
+    assert_allclose(ax.images[0].get_array(), data.max(axis=0))
 
 
 @pytest.mark.parametrize("kind", list(PLOTTERS))
@@ -635,17 +748,3 @@ def test_plot_connectivity_errors(kind, kwargs, error, match):
         kwargs["info"] = mne.create_info(["other"], 1.0, "misc")
     with pytest.raises(error, match=match):
         plot_func(con, show=False, **kwargs)
-
-
-def test_plot_connectivity_explicit_indices():
-    """Test plotting bivariate connectivity for explicitly indexed connections."""
-    # upper-triangular, i.e. all-to-all but not in the layout the plot expects
-    indices = (np.array([0, 0, 1]), np.array([1, 2, 2]))
-    con = make_con("spectral", indices=indices)
-    fig = plot_spectral_connectivity(con, node_aliases={0: "first"}, show=False)
-    line_ax, circle_ax = fig.axes
-    fig.canvas.draw()
-    assert len(line_ax.lines) == 3  # not all-to-all, so no duplicated connections
-    _fake_click(fig, line_ax, line_ax.lines[0].get_xydata()[1], xform="data")
-    assert line_ax.texts[0].get_text() == "first ~ ch1"
-    assert con.names == [f"ch{ii}" for ii in range(N_NODES)]  # not renamed in place

--- a/mne_connectivity/viz/tests/test_plotting.py
+++ b/mne_connectivity/viz/tests/test_plotting.py
@@ -153,7 +153,7 @@ def test_plot_matrix_connectivity():
 
     # Check square matrix also plotted when picking subset of nodes
     picks = (1,)
-    indices = np.tril_indices(N_NODES, k=-1)  # explicit "lower" indices
+    indices = np.unravel_index(np.arange(N_NODES**2), (N_NODES, N_NODES))
     for selection in ("seeds", "targets", "both"):
         fig = plot_connectivity(con, picks=picks, selection=selection, show=False)
         ax = fig.axes[0]
@@ -412,22 +412,38 @@ def test_plot_line_connectivity_visible_cons(
     else:  # lower, upper, or all
         # Full matrix of connections will be plotted for data when all-to-all
         # connectivity is present, or full matrix can be inferred from tril/triu portion
-        n_plotted_cons = n_visible_cons = N_NODES**2  # all cons as baseline
-        n_tri_cons = N_NODES * (N_NODES - 1) // 2
-        # Remove a tril/triu portion from plotted & visible when this cannot be inferred
+        plot_indices = np.unravel_index(np.arange(N_NODES**2), (N_NODES, N_NODES))
+        # Remove a tril/triu portion from plotted when this cannot be inferred
         if indices != "all" and symmetric == "unknown":
-            n_plotted_cons -= n_tri_cons  # remove a tril/triu portion
-            n_visible_cons -= n_tri_cons
+            if indices == "lower":
+                drop_indices = np.triu_indices(N_NODES, k=1)
+            else:
+                drop_indices = np.tril_indices(N_NODES, k=-1)
+            drop_indices = list(zip(*drop_indices))
+            cons_mask = np.array(
+                [ind not in drop_indices for ind in list(zip(*plot_indices))]
+            )
+            plot_indices = (plot_indices[0][cons_mask], plot_indices[1][cons_mask])
+        # Remove diagonal from plotted when this is not informative
+        if consistent_diag:
+            drop_indices = list(zip(*np.diag_indices(N_NODES)))
+            cons_mask = np.array(
+                [ind not in drop_indices for ind in list(zip(*plot_indices))]
+            )
+            plot_indices = (plot_indices[0][cons_mask], plot_indices[1][cons_mask])
+        visible_cons = np.ones(len(plot_indices[0]), dtype=bool)
         # Remove a tril/triu portion from visible when data is symmetric
         if symmetric is True:
-            n_visible_cons -= n_tri_cons
-        # Remove diagonal from plotted & visible when this is not informative
-        if consistent_diag:
-            n_plotted_cons -= N_NODES
-            n_visible_cons -= N_NODES
-        assert visible(line_ax) == [True] * n_visible_cons + [False] * (
-            n_plotted_cons - n_visible_cons
-        )
+            if indices == "upper":
+                drop_indices = np.tril_indices(N_NODES, k=-1)
+            else:  # "lower" or "all"
+                drop_indices = np.triu_indices(N_NODES, k=1)
+            drop_indices = list(zip(*drop_indices))
+            cons_mask = np.array(
+                [ind not in drop_indices for ind in list(zip(*plot_indices))]
+            )
+            visible_cons[~cons_mask] = False
+        assert visible(line_ax) == visible_cons.tolist()
 
 
 @pytest.mark.parametrize("kind", LINE_KINDS)
@@ -457,15 +473,14 @@ def test_plot_line_connectivity_interactive():
     fig = plot_spectral_connectivity(con, show=False)
     line_ax, circle_ax = fig.axes
     fig.canvas.draw()
-    seeds, targets = np.tril_indices(N_NODES, -1)
-    # connections are duplicated with the seeds and targets swapped, so that every
-    # node can be selected as a seed
-    dup_seeds = np.concatenate([seeds, targets])
+    indices = np.unravel_index(np.arange(N_NODES**2), (N_NODES, N_NODES))
+    diag_mask = indices[0] == indices[1]
+    indices = (indices[0][~diag_mask], indices[1][~diag_mask])  # remove diagonal
     start = visible(line_ax)
 
     for node in range(N_NODES):
         click_node(fig, circle_ax, node, N_NODES)
-        assert visible(line_ax) == list(dup_seeds == node), f"node {node}"
+        assert visible(line_ax) == list(indices[0] == node), f"node {node}"
         # the connection labels are hidden again on selection
         assert all(text.get_alpha() == 0 for text in line_ax.texts)
     click_node(fig, circle_ax, 0, N_NODES, button=3)  # right click resets
@@ -487,37 +502,42 @@ def test_plot_line_connectivity_interactive():
     assert text.get_alpha() == 0.0
 
 
-@pytest.mark.parametrize(
-    "selection, unselectable, selected, n_selected",
-    [("seeds", "ch0", "ch2", 2), ("targets", "ch3", "ch2", 1)],
-)
+@pytest.mark.parametrize("selection, selected", [("seeds", "ch2"), ("targets", "ch2")])
 @pytest.mark.parametrize("colors", ("auto", "global", "relative"))
-def test_plot_line_connectivity_selection(
-    selection, unselectable, selected, n_selected, colors
-):
+@pytest.mark.parametrize("symmetric", (True, False))
+def test_plot_line_connectivity_selection(selection, selected, colors, symmetric):
     """Test restricting the plotted (and selectable) connections to picked channels."""
-    con = make_con("spectral")
+    # Note: using 'lower' indices, so 'upper' portion will be inferred in plots
+    con = make_con("spectral", symmetric=symmetric)
+    picks = ["ch1", "ch2"]
+    unselectable = ["ch0", "ch3"]
     fig = plot_spectral_connectivity(
-        con, picks=["ch1", "ch2"], selection=selection, colors=colors,
-        cmap="viridis", show=False,
+        con, picks=picks, selection=selection, colors=colors, cmap="viridis",
+        show=False,
     )  # fmt: skip
     line_ax, circle_ax = fig.axes
     fig.canvas.draw()
-    assert len(line_ax.lines) == 3  # connections are duplicated only for "both"
+    # For tril indices, ch1 appears 1x in seeds, 2x in targets; ch2 appears 2x in seeds,
+    # 1x in targets. Because we fill missing 'upper' values to get full matrix, ch1 &
+    # ch2 both end up appearing 3x in seeds, 3x in targets (so 6 connections total)
+    n_picked_cons = 6
+    assert len(line_ax.lines) == n_picked_cons
+    # Afterinferring missing portions, the picked connections exist between all 4 chans
     node_names = [text.get_text() for text in circle_ax.texts]
-    assert len(node_names) == 3
+    assert len(node_names) == 4
 
     # nodes that cannot act as the selected role are drawn faded out
     alphas = [node.get_alpha() for node in circle_ax.containers[0]]
-    assert [name for name, alpha in zip(node_names, alphas) if alpha is not None] == [
-        unselectable
-    ]
+    assert [
+        name for name, alpha in zip(node_names, alphas) if alpha is not None
+    ] == unselectable
 
     # clicking a faded node does nothing; a selectable one isolates its connections
-    click_node(fig, circle_ax, node_names.index(unselectable), len(node_names))
-    assert visible(line_ax) == [True] * 3
+    visible_before = visible(line_ax)
+    click_node(fig, circle_ax, node_names.index(unselectable[0]), len(node_names))
+    assert visible(line_ax) == visible_before
     click_node(fig, circle_ax, node_names.index(selected), len(node_names))
-    assert sum(visible(line_ax)) == n_selected
+    assert sum(visible(line_ax)) == 3  # 3 cons per channel (as seed or target)
 
 
 def test_plot_spectrotemporal_connectivity():
@@ -665,14 +685,14 @@ def test_plot_connectivity_channel_types(kind, info):
     types = ["EEG ~ EEG", "Gradiometers ~ EEG", "Gradiometers ~ Gradiometers"]
     figs = plot_func(con, info=info, show=False)
     axes = [fig.axes[0] for fig in figs]
-    assert len(figs) == len(axes) == 3
+    assert len(figs) == len(axes) == len(types)
     assert [ax.get_title().split(" | ")[0] for ax in axes] == types
 
     # dropping a bad EEG channel leaves only one EEG node, so no EEG ~ EEG figure
     info["bads"] = ["e1"]
     figs = plot_func(con, info=info, show=False)
     axes = [fig.axes[0] for fig in figs]
-    assert len(figs) == len(axes) == 2
+    assert len(figs) == len(axes) == len(types) - 1
     assert [ax.get_title().split(" | ")[0] for ax in axes] == types[1:]
 
 

--- a/mne_connectivity/wsmi.py
+++ b/mne_connectivity/wsmi.py
@@ -19,11 +19,10 @@ except ImportError:
 
 from mne.utils import _time_mask, logger, verbose
 from mne.utils.check import _check_option, _validate_type
-from mne.utils.docs import fill_doc
 from scipy.signal import butter, filtfilt
 
 from .base import Connectivity, EpochConnectivity
-from .utils import check_indices
+from .utils import check_indices, fill_doc
 
 
 def _define_symbols(kernel):
@@ -328,8 +327,8 @@ def _validate_kernel(kernel, tau):
         )
 
 
-@fill_doc
 @verbose
+@fill_doc
 def wsmi(
     data,
     kernel,
@@ -357,13 +356,7 @@ def wsmi(
     tau : int
         Time delay (lag; in samples) between consecutive pattern elements.
         Must be > 0.
-    indices : tuple of array_like | ``'lower'`` | ``'upper'`` | ``'all'``
-        Two array-likes with indices of connections for which to compute connectivity.
-        For example, to compute connectivity between channels 0 and 2, and between
-        channels 1 and 3, use ``indices = (np.array([0, 1]), np.array([2, 3]))``.
-        If ``'lower'``, compute lower-triangular part of connectivity matrix. If
-        ``'upper'``, compute upper-triangular part of connectivity matrix. If ``'all'``,
-        compute all connections. Default is ``'lower'``.
+    %(indices_with_str_only_bivar)s
     sfreq : float | None
         The sampling frequency. Required if ``data`` is an array-like.
     names : array_like | None
@@ -427,6 +420,8 @@ def wsmi(
     1. Symbolic transformation of time series using ordinal patterns
     2. Computation of mutual information between symbolic sequences
     3. Weighting based on pattern distance for enhanced sensitivity
+    %(tri_indices_efficiency_note)s
+    %(tuple_bivar_indices_note)s
 
     .. versionadded:: 0.8
 

--- a/mne_connectivity/wsmi.py
+++ b/mne_connectivity/wsmi.py
@@ -16,6 +16,7 @@ try:  # MNE 1.13+
     from mne._numba import jit
 except ImportError:
     from mne.fixes import jit
+
 from mne.utils import _time_mask, logger, verbose
 from mne.utils.check import _check_option, _validate_type
 from mne.utils.docs import fill_doc
@@ -333,7 +334,7 @@ def wsmi(
     data,
     kernel,
     tau,
-    indices=None,
+    indices="lower",
     sfreq=None,
     names=None,
     tmin=None,
@@ -356,11 +357,13 @@ def wsmi(
     tau : int
         Time delay (lag; in samples) between consecutive pattern elements.
         Must be > 0.
-    indices : tuple of array_like | None
+    indices : tuple of array_like | ``'lower'`` | ``'upper'`` | ``'all'``
         Two array-likes with indices of connections for which to compute connectivity.
-        If ``None``, all connections are computed (lower triangular matrix).
         For example, to compute connectivity between channels 0 and 2, and between
         channels 1 and 3, use ``indices = (np.array([0, 1]), np.array([2, 3]))``.
+        If ``'lower'``, compute lower-triangular connectivity. If ``'upper'``, compute
+        upper-triangular connectivity. If ``'all'``, compute all connections. Default is
+        ``'lower'``.
     sfreq : float | None
         The sampling frequency. Required if ``data`` is an array-like.
     names : array_like | None
@@ -436,6 +439,11 @@ def wsmi(
     _validate_type(average, bool, "average")
     _check_option("anti_aliasing", anti_aliasing, (True, False, "auto"))
 
+    # Check indices
+    _validate_type(indices, (tuple, str), "indices")
+    if isinstance(indices, str):
+        _check_option("indices", indices, ["lower", "upper", "all"], "if a string")
+
     # Handle both MNE Epochs and array inputs
     picks = None
     is_epochs = isinstance(data, BaseEpochs)
@@ -454,8 +462,8 @@ def wsmi(
         data_for_comp = data.get_data()
         n_epochs, n_nodes, n_times_epoch = data_for_comp.shape
 
-        # Only exclude bad channels when indices is None
-        if indices is None:
+        # Exclude bad channels when custom tuple indices not passed
+        if not isinstance(indices, tuple):
             picks = _picks_to_idx(info, picks="all", exclude="bads")
             # Apply picks to data for computation
             data_for_comp = data_for_comp[:, picks, :]
@@ -508,10 +516,17 @@ def wsmi(
     )
 
     # Handle indices parameter
-    if indices is None:
-        logger.info("using all connections for lower-triangular matrix")
-        # Compute lower-triangular connections
-        indices_use = np.tril_indices(n_channels, k=-1)
+    if not isinstance(indices, tuple):
+        if indices == "all":
+            logger.info("Computing all connections for full connectivity matrix")
+            # Only compute tril, then transform to full matrix later
+            indices_use = np.tril_indices(n_channels, k=-1)
+        else:
+            logger.info(f"Computing connections for {indices}-triangular matrix")
+            if indices == "upper":
+                indices_use = np.triu_indices(n_channels, k=1)
+            else:  # "lower"
+                indices_use = np.tril_indices(n_channels, k=-1)
     else:
         # User provided explicit indices
         indices_use = check_indices(indices)
@@ -527,19 +542,7 @@ def wsmi(
                 f"Index {max_idx} is out of range for {n_channels} channels"
             )
 
-        # Check that indices don't refer to the same channel (no self-connectivity)
-        same_channel_mask = indices_use[0] == indices_use[1]
-        if np.any(same_channel_mask):
-            invalid_pairs = [
-                (indices_use[0][i], indices_use[1][i])
-                for i in range(len(indices_use[0]))
-                if same_channel_mask[i]
-            ]
-            raise ValueError(
-                f"Self-connectivity not supported. Found invalid pairs: {invalid_pairs}"
-            )
-
-        logger.info(f"computing connectivity for {len(indices_use[0])} connections")
+        logger.info(f"Computing connectivity for {len(indices_use[0])} connections")
 
     # unique signals for which we actually need to compute values for
     sig_idx = np.unique(np.r_[indices_use[0], indices_use[1]])
@@ -600,18 +603,24 @@ def wsmi(
     result = result.transpose(2, 0, 1)  # make epochs first dimension
 
     # --- Packaging results ---
-    if indices is None:
-        # Make it a lower-triangular matrix
-        result = np.tril(result, k=-1)
-        # Return all-to-all connectivity matrices raveled into a 1D array
+    if not isinstance(indices, tuple):
+        # Fill entries for bad channels
         if len(picks) < n_nodes:
             # Bad channels were excluded, need to create full n_nodes x n_nodes matrix
             # and fill only the good channel entries
-            con = np.zeros((n_epochs, n_nodes, n_nodes))
-            con[np.ix_(range(n_epochs), picks, picks)] = result
-        else:
-            con = result
-        con = con.reshape(n_epochs, -1)
+            full_result = np.full((n_epochs, n_nodes, n_nodes), np.nan)
+            full_result[np.ix_(range(n_epochs), picks, picks)] = result
+            result = full_result
+
+        # Ravel dense matrix
+        if indices == "all":
+            con = result.reshape(n_epochs, -1)
+        elif indices == "lower":
+            tril_inds = np.tril_indices(n_nodes, k=-1)
+            con = result[:, tril_inds[0], tril_inds[1]]
+        else:  # "upper":
+            triu_inds = np.triu_indices(n_nodes, k=1)
+            con = result[:, triu_inds[0], triu_inds[1]]
     else:
         # Extract only requested connections
         con = result[:, idx_map[0], idx_map[1]]
@@ -628,7 +637,7 @@ def wsmi(
         metadata=metadata,
     )
     if average:
-        result_connectivity = Connectivity(data=np.mean(con, axis=0), **con_kwargs)
+        result_connectivity = Connectivity(data=np.nanmean(con, axis=0), **con_kwargs)
     else:
         result_connectivity = EpochConnectivity(data=con, **con_kwargs)
 

--- a/mne_connectivity/wsmi.py
+++ b/mne_connectivity/wsmi.py
@@ -435,9 +435,9 @@ def wsmi(
     _check_option("anti_aliasing", anti_aliasing, (True, False, "auto"))
 
     # Check indices
-    _validate_type(indices, (tuple, str), "indices")
+    _validate_type(indices, (tuple, str), "`indices`")
     if isinstance(indices, str):
-        _check_option("indices", indices, ["lower", "upper", "all"], " as a string")
+        _check_option("indices", indices, ["lower", "upper", "all"], "as a string")
 
     # Handle both MNE Epochs and array inputs
     picks = None

--- a/mne_connectivity/wsmi.py
+++ b/mne_connectivity/wsmi.py
@@ -361,9 +361,9 @@ def wsmi(
         Two array-likes with indices of connections for which to compute connectivity.
         For example, to compute connectivity between channels 0 and 2, and between
         channels 1 and 3, use ``indices = (np.array([0, 1]), np.array([2, 3]))``.
-        If ``'lower'``, compute lower-triangular connectivity. If ``'upper'``, compute
-        upper-triangular connectivity. If ``'all'``, compute all connections. Default is
-        ``'lower'``.
+        If ``'lower'``, compute lower-triangular part of connectivity matrix. If
+        ``'upper'``, compute upper-triangular part of connectivity matrix. If ``'all'``,
+        compute all connections. Default is ``'lower'``.
     sfreq : float | None
         The sampling frequency. Required if ``data`` is an array-like.
     names : array_like | None
@@ -442,7 +442,7 @@ def wsmi(
     # Check indices
     _validate_type(indices, (tuple, str), "indices")
     if isinstance(indices, str):
-        _check_option("indices", indices, ["lower", "upper", "all"], "if a string")
+        _check_option("indices", indices, ["lower", "upper", "all"], " as a string")
 
     # Handle both MNE Epochs and array inputs
     picks = None

--- a/mne_connectivity/wsmi.py
+++ b/mne_connectivity/wsmi.py
@@ -637,7 +637,7 @@ def wsmi(
         metadata=metadata,
     )
     if average:
-        result_connectivity = Connectivity(data=np.nanmean(con, axis=0), **con_kwargs)
+        result_connectivity = Connectivity(data=np.mean(con, axis=0), **con_kwargs)
     else:
         result_connectivity = EpochConnectivity(data=con, **con_kwargs)
 


### PR DESCRIPTION
Fixes #372

Possible indices kinds will be:
- tuples of arrays for custom seed-target combinations
- `'all'` for all-to-all connectivity (as current); `None` alias will be removed
- `'upper'` and `'lower'` for upper- and lower-triangular parts (excluding diagonal); replaces current `'symmetric`

For connectivity-computing functions accepting the `indices` parameter, valid inputs are:
- tuples of array-likes, always.
- `'all'`, always.
- `'lower'` and `'upper'`, when missing values for a dense connectivity matrix can be inferred based on the existing values (currently nowhere this isn't true).

For multivariate methods, indices will always need to be specified as tuples.

In connectivity containers, where `get_data()` is called with `'dense'` output and `indices` is  `'upper'` or `'lower'`, we will attempt to fill the missing values. If this is not possible (`method` is unknown, or it is known and the transformation is not possible), behaviour is determined by the `missing` parameter. Default is to raise an error, but can be set to a float to fill missing values without trying to transform anything.
When `indices` is `'all'`, no transformation is needed (just reshaping).
When `'indices'` is a tuple, no transformation is needed if the indices correspond to all-to-all connectivity. Otherwise, `missing` should be specified as a float (i.e., won't try any fancy logic to know what should be filled in, at least for now).